### PR TITLE
check_ping: Parse ICMPv6 "Address unreachable"

### DIFF
--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -517,7 +517,9 @@ error_scan (char buf[MAX_INPUT_BUFFER], const char *addr)
 		strstr (buf, "Destination Net Unreachable")
 		)
 		die (STATE_CRITICAL, _("CRITICAL - Network Unreachable (%s)"), addr);
-	else if (strstr (buf, "Destination Host Unreachable"))
+	else if (strstr (buf, "Destination Host Unreachable") ||
+		strstr (buf, "Address unreachable")
+		)
 		die (STATE_CRITICAL, _("CRITICAL - Host Unreachable (%s)"), addr);
 	else if (strstr (buf, "Destination Port Unreachable"))
 		die (STATE_CRITICAL, _("CRITICAL - Bogus ICMP: Port Unreachable (%s)"), addr);


### PR DESCRIPTION
In ICMPv6 "Host unreachable" has been renamed to "Address unreachable"
(see RFC4443 3.1). Handle ping6 returning "Address unreachable" and map
it to the "Host unreachable" plugin output.

Fixes SF#3518671
