### PR TITLE
Bugfix: Detect array recovery percentages < 10% in check_linux_raid.pl

### DIFF
--- a/contrib/check_linux_raid.pl
+++ b/contrib/check_linux_raid.pl
@@ -61,7 +61,7 @@ while(defined $nextdev){
 		if (defined $device) {
 			if (/(\[[_U]+\])/) {
 				$status{$device} = $1;
-			} elsif (/recovery = (.*?)\s/) {  
+			} elsif (/recovery =\s+(.*?)\s/) {
 				$recovery{$device} = $1;
 				($finish{$device}) = /finish=(.*?min)/;
 				$device=undef;


### PR DESCRIPTION
This patch fixes the regular expression for the array recovery
completion percentage to detect the percentage when there is more than
one space between between "recovery =" and the percentage. (When
the percentage is less than 10%, /proc/mdstat shows it left-padded
with an extra space: "recovery =  7.6%".)
