### PR TITLE
Fixes for check_apt handling of -i/-e/-c regexps and SECURITY_RE, plus tests

### DIFF
--- a/plugins/t/check_apt.t
+++ b/plugins/t/check_apt.t
@@ -1,0 +1,90 @@
+#!/usr/bin/perl -w -I ..
+#
+# Test check_apt using input files.
+# Contributed by Alex Bradley, October 2012
+#
+
+use strict;
+use Test::More;
+use NPTest;
+
+sub make_result_regexp {
+    my ($warning, $critical) = @_;
+    my $status;
+    if ($warning == 0 && $critical == 0) {
+	$status = "OK";
+    } elsif ($critical == 0) {
+	$status = "WARNING";
+    } else {
+	$status = "CRITICAL";
+    }
+    return sprintf('/^APT %s: %d packages available for upgrade \(%d critical updates\).\s*$/',
+	$status, $warning, $critical);
+}
+
+if (-x "./check_apt") {
+	plan tests => 28;
+} else {
+	plan skip_all => "No check_apt compiled";
+}
+
+my $result;
+
+my $testfile_command = "./check_apt %s --input-file=t/check_apt_input/%s";
+
+$result = NPTest->testCmd( sprintf($testfile_command, "", "debian1") );
+is( $result->return_code, 0, "No upgrades" );
+like( $result->output, make_result_regexp(0, 0), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "", "debian2") );
+is( $result->return_code, 1, "Debian apt output, warning" );
+like( $result->output, make_result_regexp(13, 0), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "", "debian3") );
+is( $result->return_code, 2, "Debian apt output, some critical" );
+like( $result->output, make_result_regexp(19, 4), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "-c '^[^\\(]*\\(.* (Debian-Security:|Ubuntu:[^/]*/[^-]*-security)'", "debian3") );
+is( $result->return_code, 2, "Debian apt output - should have same result when default security regexp specified via -c" );
+like( $result->output, make_result_regexp(19, 4), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "-i libc6", "debian3") );
+is( $result->return_code, 1, "Debian apt output, filter for libc6" );
+like( $result->output, make_result_regexp(3, 0), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "-i libc6 -i xen", "debian3") );
+is( $result->return_code, 2, "Debian apt output, filter for libc6 and xen" );
+like( $result->output, make_result_regexp(9, 4), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "-i libc6 -i xen -i linux", "debian3") );
+is( $result->return_code, 2, "Debian apt output, filter for libc6, xen, linux" );
+like( $result->output, make_result_regexp(12, 4), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "-e libc6", "debian3") );
+is( $result->return_code, 2, "Debian apt output, filter out libc6" );
+like( $result->output, make_result_regexp(16, 4), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "-e libc6 -e xen", "debian3") );
+is( $result->return_code, 1, "Debian apt output, filter out libc6 and xen" );
+like( $result->output, make_result_regexp(10, 0), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "-e libc6 -e xen -e linux", "debian3") );
+is( $result->return_code, 1, "Debian apt output, filter out libc6, xen, linux" );
+like( $result->output, make_result_regexp(7, 0), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "-c Debian-Security -c linux", "debian3") );
+is( $result->return_code, 2, "Debian apt output, critical on Debian-Security or linux" );
+like( $result->output, make_result_regexp(19, 9), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "-i lib -i linux -e gc1c -c linux-image", "debian3") );
+is( $result->return_code, 2, "Debian apt output, include lib and linux, exclude gc1c, critical on linux-image" );
+like( $result->output, make_result_regexp(10, 2), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "", "ubuntu1") );
+is( $result->return_code, 1, "Ubuntu apt output, warning" );
+like( $result->output, make_result_regexp(5, 0), "Output correct" );
+
+$result = NPTest->testCmd( sprintf($testfile_command, "", "ubuntu2") );
+is( $result->return_code, 2, "Ubuntu apt output, some critical" );
+like( $result->output, make_result_regexp(25, 14), "Output correct" );
+

--- a/plugins/t/check_apt_input/debian1
+++ b/plugins/t/check_apt_input/debian1
@@ -1,0 +1,4 @@
+NOTE: This is only a simulation!
+      apt-get needs root privileges for real execution.
+      Keep also in mind that locking is deactivated,
+      so don't depend on the relevance to the real current situation!

--- a/plugins/t/check_apt_input/debian2
+++ b/plugins/t/check_apt_input/debian2
@@ -1,0 +1,37 @@
+NOTE: This is only a simulation!
+      apt-get needs root privileges for real execution.
+      Keep also in mind that locking is deactivated,
+      so don't depend on the relevance to the real current situation!
+Reading package lists... Done
+Building dependency tree       
+Reading state information... Done
+The following packages will be upgraded:
+  base-files debian-archive-keyring dpkg firmware-linux-free libc-bin libc-dev-bin libc6 libc6-dev linux-base
+  linux-image-2.6.32-5-xen-amd64 linux-libc-dev locales lockfile-progs
+13 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+Inst base-files [6.0squeeze5] (6.0squeeze6 Debian:6.0.6/stable [amd64])
+Conf base-files (6.0squeeze6 Debian:6.0.6/stable [amd64])
+Inst dpkg [1.15.8.12] (1.15.8.13 Debian:6.0.6/stable [amd64])
+Conf dpkg (1.15.8.13 Debian:6.0.6/stable [amd64])
+Inst linux-base [2.6.32-45] (2.6.32-46 Debian:6.0.6/stable [all])
+Inst linux-image-2.6.32-5-xen-amd64 [2.6.32-45] (2.6.32-46 Debian:6.0.6/stable [amd64])
+Inst debian-archive-keyring [2010.08.28] (2010.08.28+squeeze1 Debian:6.0.6/stable [all])
+Conf debian-archive-keyring (2010.08.28+squeeze1 Debian:6.0.6/stable [all])
+Inst libc6-dev [2.11.3-3] (2.11.3-4 Debian:6.0.6/stable [amd64]) []
+Inst libc-dev-bin [2.11.3-3] (2.11.3-4 Debian:6.0.6/stable [amd64]) []
+Inst linux-libc-dev [2.6.32-45] (2.6.32-46 Debian:6.0.6/stable [amd64]) []
+Inst libc-bin [2.11.3-3] (2.11.3-4 Debian:6.0.6/stable [amd64]) [libc6:amd64 ]
+Conf libc-bin (2.11.3-4 Debian:6.0.6/stable [amd64]) [libc6:amd64 ]
+Inst libc6 [2.11.3-3] (2.11.3-4 Debian:6.0.6/stable [amd64])
+Conf libc6 (2.11.3-4 Debian:6.0.6/stable [amd64])
+Inst locales [2.11.3-3] (2.11.3-4 Debian:6.0.6/stable [all])
+Inst firmware-linux-free [2.6.32-45] (2.6.32-46 Debian:6.0.6/stable [all])
+Inst lockfile-progs [0.1.15] (0.1.15+squeeze1 Debian:6.0.6/stable [amd64])
+Conf linux-base (2.6.32-46 Debian:6.0.6/stable [all])
+Conf linux-image-2.6.32-5-xen-amd64 (2.6.32-46 Debian:6.0.6/stable [amd64])
+Conf libc-dev-bin (2.11.3-4 Debian:6.0.6/stable [amd64])
+Conf linux-libc-dev (2.6.32-46 Debian:6.0.6/stable [amd64])
+Conf libc6-dev (2.11.3-4 Debian:6.0.6/stable [amd64])
+Conf locales (2.11.3-4 Debian:6.0.6/stable [all])
+Conf firmware-linux-free (2.6.32-46 Debian:6.0.6/stable [all])
+Conf lockfile-progs (0.1.15+squeeze1 Debian:6.0.6/stable [amd64])

--- a/plugins/t/check_apt_input/debian3
+++ b/plugins/t/check_apt_input/debian3
@@ -1,0 +1,42 @@
+NOTE: This is only a simulation!
+      apt-get needs root privileges for real execution.
+      Keep also in mind that locking is deactivated,
+      so don't depend on the relevance to the real current situation!
+Inst base-files [6.0squeeze5] (6.0squeeze6 Debian:6.0.6/stable [amd64])
+Conf base-files (6.0squeeze6 Debian:6.0.6/stable [amd64])
+Inst dpkg [1.15.8.12] (1.15.8.13 Debian:6.0.6/stable [amd64])
+Conf dpkg (1.15.8.13 Debian:6.0.6/stable [amd64])
+Inst linux-base [2.6.32-45] (2.6.32-46 Debian:6.0.6/stable [all])
+Inst linux-image-2.6.32-5-amd64 [2.6.32-45] (2.6.32-46 Debian:6.0.6/stable [amd64])
+Inst xen-hypervisor-4.0-amd64 [4.0.1-5.3] (4.0.1-5.4 Debian:6.0.6/stable, Debian-Security:6.0/stable [amd64])
+Inst xen-linux-system-2.6.32-5-xen-amd64 [2.6.32-45] (2.6.32-46 Debian:6.0.6/stable [amd64]) []
+Inst linux-image-2.6.32-5-xen-amd64 [2.6.32-45] (2.6.32-46 Debian:6.0.6/stable [amd64])
+Inst debian-archive-keyring [2010.08.28] (2010.08.28+squeeze1 Debian:6.0.6/stable [all])
+Conf debian-archive-keyring (2010.08.28+squeeze1 Debian:6.0.6/stable [all])
+Inst libc6-i386 [2.11.3-3] (2.11.3-4 Debian:6.0.6/stable [amd64]) []
+Inst libc-bin [2.11.3-3] (2.11.3-4 Debian:6.0.6/stable [amd64]) [libc6:amd64 ]
+Conf libc-bin (2.11.3-4 Debian:6.0.6/stable [amd64]) [libc6:amd64 ]
+Inst libc6 [2.11.3-3] (2.11.3-4 Debian:6.0.6/stable [amd64])
+Conf libc6 (2.11.3-4 Debian:6.0.6/stable [amd64])
+Inst libgc1c2 [1:6.8-1.2] (1:6.8-2 Debian:6.0.6/stable [amd64])
+Inst locales [2.11.3-3] (2.11.3-4 Debian:6.0.6/stable [all])
+Inst firmware-linux-free [2.6.32-45] (2.6.32-46 Debian:6.0.6/stable [all])
+Inst libxenstore3.0 [4.0.1-5.3] (4.0.1-5.4 Debian:6.0.6/stable, Debian-Security:6.0/stable [amd64])
+Inst lockfile-progs [0.1.15] (0.1.15+squeeze1 Debian:6.0.6/stable [amd64])
+Inst xen-utils-4.0 [4.0.1-5.3] (4.0.1-5.4 Debian:6.0.6/stable, Debian-Security:6.0/stable [amd64])
+Inst xenstore-utils [4.0.1-5.3] (4.0.1-5.4 Debian:6.0.6/stable, Debian-Security:6.0/stable [amd64])
+Inst libconfig-inifiles-perl [2.52-1] (2.52-1+squeeze1 Debian:6.0.6/stable [all])
+Conf linux-base (2.6.32-46 Debian:6.0.6/stable [all])
+Conf linux-image-2.6.32-5-amd64 (2.6.32-46 Debian:6.0.6/stable [amd64])
+Conf xen-hypervisor-4.0-amd64 (4.0.1-5.4 Debian:6.0.6/stable, Debian-Security:6.0/stable [amd64])
+Conf linux-image-2.6.32-5-xen-amd64 (2.6.32-46 Debian:6.0.6/stable [amd64])
+Conf xen-linux-system-2.6.32-5-xen-amd64 (2.6.32-46 Debian:6.0.6/stable [amd64])
+Conf libc6-i386 (2.11.3-4 Debian:6.0.6/stable [amd64])
+Conf libgc1c2 (1:6.8-2 Debian:6.0.6/stable [amd64])
+Conf locales (2.11.3-4 Debian:6.0.6/stable [all])
+Conf firmware-linux-free (2.6.32-46 Debian:6.0.6/stable [all])
+Conf libxenstore3.0 (4.0.1-5.4 Debian:6.0.6/stable, Debian-Security:6.0/stable [amd64])
+Conf lockfile-progs (0.1.15+squeeze1 Debian:6.0.6/stable [amd64])
+Conf xen-utils-4.0 (4.0.1-5.4 Debian:6.0.6/stable, Debian-Security:6.0/stable [amd64])
+Conf xenstore-utils (4.0.1-5.4 Debian:6.0.6/stable, Debian-Security:6.0/stable [amd64])
+Conf libconfig-inifiles-perl (2.52-1+squeeze1 Debian:6.0.6/stable [all])

--- a/plugins/t/check_apt_input/ubuntu1
+++ b/plugins/t/check_apt_input/ubuntu1
@@ -1,0 +1,14 @@
+NOTE: This is only a simulation!
+      apt-get needs root privileges for real execution.
+      Also keep in mind that locking is deactivated,
+      so don't depend on the relevance to the real current situation!
+Inst grub-pc [1.99-21ubuntu3.1] (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64]) []
+Inst grub-pc-bin [1.99-21ubuntu3.1] (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64]) []
+Inst grub2-common [1.99-21ubuntu3.1] (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64]) []
+Inst grub-efi-amd64-bin [1.99-21ubuntu3.1] (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64]) []
+Inst grub-common [1.99-21ubuntu3.1] (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64])
+Conf grub-common (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64])
+Conf grub2-common (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64])
+Conf grub-pc-bin (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64])
+Conf grub-pc (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64])
+Conf grub-efi-amd64-bin (1.99-21ubuntu3.4 Ubuntu:12.04/precise-updates [amd64])

--- a/plugins/t/check_apt_input/ubuntu2
+++ b/plugins/t/check_apt_input/ubuntu2
@@ -1,0 +1,54 @@
+NOTE: This is only a simulation!
+      apt-get needs root privileges for real execution.
+      Also keep in mind that locking is deactivated,
+      so don't depend on the relevance to the real current situation!
+Inst libc6-dev [2.15-0ubuntu10] (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64]) []
+Inst libc-dev-bin [2.15-0ubuntu10] (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64]) []
+Inst linux-libc-dev [3.2.0-29.46] (3.2.0-31.50 Ubuntu:12.04/precise-security [amd64]) []
+Inst tzdata [2012e-0ubuntu0.12.04] (2012e-0ubuntu0.12.04.1 Ubuntu:12.04/precise-security [all]) []
+Conf tzdata (2012e-0ubuntu0.12.04.1 Ubuntu:12.04/precise-security [all]) []
+Inst libc-bin [2.15-0ubuntu10] (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64]) [libc6:amd64 ]
+Conf libc-bin (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64]) [libc6:amd64 ]
+Inst libc6 [2.15-0ubuntu10] (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64])
+Conf libc6 (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64])
+Inst libapt-pkg4.12 [0.8.16~exp12ubuntu10.2] (0.8.16~exp12ubuntu10.3 Ubuntu:12.04/precise-updates [amd64])
+Conf libapt-pkg4.12 (0.8.16~exp12ubuntu10.3 Ubuntu:12.04/precise-updates [amd64])
+Inst ubuntu-keyring [2011.11.21] (2011.11.21.1 Ubuntu:12.04/precise-updates [all])
+Conf ubuntu-keyring (2011.11.21.1 Ubuntu:12.04/precise-updates [all])
+Inst gpgv [1.4.11-3ubuntu2] (1.4.11-3ubuntu2.1 Ubuntu:12.04/precise-security [amd64])
+Conf gpgv (1.4.11-3ubuntu2.1 Ubuntu:12.04/precise-security [amd64])
+Inst gnupg [1.4.11-3ubuntu2] (1.4.11-3ubuntu2.1 Ubuntu:12.04/precise-security [amd64])
+Conf gnupg (1.4.11-3ubuntu2.1 Ubuntu:12.04/precise-security [amd64])
+Inst apt [0.8.16~exp12ubuntu10.2] (0.8.16~exp12ubuntu10.3 Ubuntu:12.04/precise-updates [amd64])
+Conf apt (0.8.16~exp12ubuntu10.3 Ubuntu:12.04/precise-updates [amd64])
+Inst libssl1.0.0 [1.0.1-4ubuntu5.3] (1.0.1-4ubuntu5.5 Ubuntu:12.04/precise-updates [amd64])
+Conf libssl1.0.0 (1.0.1-4ubuntu5.5 Ubuntu:12.04/precise-updates [amd64])
+Inst libapt-inst1.4 [0.8.16~exp12ubuntu10.2] (0.8.16~exp12ubuntu10.3 Ubuntu:12.04/precise-updates [amd64])
+Inst resolvconf [1.63ubuntu15] (1.63ubuntu16 Ubuntu:12.04/precise-updates [all])
+Inst libdbus-1-3 [1.4.18-1ubuntu1] (1.4.18-1ubuntu1.1 Ubuntu:12.04/precise-security [amd64])
+Inst libxml2 [2.7.8.dfsg-5.1ubuntu4.1] (2.7.8.dfsg-5.1ubuntu4.2 Ubuntu:12.04/precise-security [amd64])
+Inst multiarch-support [2.15-0ubuntu10] (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64])
+Conf multiarch-support (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64])
+Inst apt-utils [0.8.16~exp12ubuntu10.2] (0.8.16~exp12ubuntu10.3 Ubuntu:12.04/precise-updates [amd64])
+Inst isc-dhcp-client [4.1.ESV-R4-0ubuntu5.2] (4.1.ESV-R4-0ubuntu5.5 Ubuntu:12.04/precise-security [amd64]) []
+Inst isc-dhcp-common [4.1.ESV-R4-0ubuntu5.2] (4.1.ESV-R4-0ubuntu5.5 Ubuntu:12.04/precise-security [amd64])
+Inst dbus [1.4.18-1ubuntu1] (1.4.18-1ubuntu1.1 Ubuntu:12.04/precise-security [amd64])
+Inst linux-firmware [1.79] (1.79.1 Ubuntu:12.04/precise-updates [all])
+Inst xserver-common [2:1.11.4-0ubuntu10.7] (2:1.11.4-0ubuntu10.8 Ubuntu:12.04/precise-updates [all])
+Inst xserver-xorg-core [2:1.11.4-0ubuntu10.7] (2:1.11.4-0ubuntu10.8 Ubuntu:12.04/precise-updates [amd64])
+Inst xserver-xorg-input-synaptics [1.6.2-1ubuntu1~precise1] (1.6.2-1ubuntu1~precise2 Ubuntu:12.04/precise-updates [amd64])
+Conf libc-dev-bin (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64])
+Conf linux-libc-dev (3.2.0-31.50 Ubuntu:12.04/precise-security [amd64])
+Conf libc6-dev (2.15-0ubuntu10.2 Ubuntu:12.04/precise-security [amd64])
+Conf libapt-inst1.4 (0.8.16~exp12ubuntu10.3 Ubuntu:12.04/precise-updates [amd64])
+Conf resolvconf (1.63ubuntu16 Ubuntu:12.04/precise-updates [all])
+Conf libdbus-1-3 (1.4.18-1ubuntu1.1 Ubuntu:12.04/precise-security [amd64])
+Conf libxml2 (2.7.8.dfsg-5.1ubuntu4.2 Ubuntu:12.04/precise-security [amd64])
+Conf apt-utils (0.8.16~exp12ubuntu10.3 Ubuntu:12.04/precise-updates [amd64])
+Conf isc-dhcp-common (4.1.ESV-R4-0ubuntu5.5 Ubuntu:12.04/precise-security [amd64])
+Conf isc-dhcp-client (4.1.ESV-R4-0ubuntu5.5 Ubuntu:12.04/precise-security [amd64])
+Conf dbus (1.4.18-1ubuntu1.1 Ubuntu:12.04/precise-security [amd64])
+Conf linux-firmware (1.79.1 Ubuntu:12.04/precise-updates [all])
+Conf xserver-common (2:1.11.4-0ubuntu10.8 Ubuntu:12.04/precise-updates [all])
+Conf xserver-xorg-core (2:1.11.4-0ubuntu10.8 Ubuntu:12.04/precise-updates [amd64])
+Conf xserver-xorg-input-synaptics (1.6.2-1ubuntu1~precise2 Ubuntu:12.04/precise-updates [amd64])


### PR DESCRIPTION
- Fix for Debian bug #522812 (check_apt -c broken)
- Fix for bug 1904965 from Nagios SourceForge tracker (check_apt: SECURITY_RE is not correct)
- Add hidden `--input-file` option to check_apt, allowing it to take sample apt output as input (modelled on check_procs)
- Test script for check_apt with test cases for my fixes above (modelled on `tests/check_procs.t`)
