### PR TITLE
check_disk: option to ignore root-reserved space

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -135,6 +135,7 @@ int verbose = 0;
 int erronly = FALSE;
 int display_mntp = FALSE;
 int exact_match = FALSE;
+int freespace_ignore_reserved = FALSE;
 char *warn_freespace_units = NULL;
 char *crit_freespace_units = NULL;
 char *warn_freespace_percent = NULL;
@@ -424,6 +425,7 @@ process_arguments (int argc, char **argv)
     {"eregi-partition", required_argument, 0, 'R'},
     {"ereg-path", required_argument, 0, 'r'},
     {"ereg-partition", required_argument, 0, 'r'},
+    {"freespace-ignore-reserved", no_argument, 0, 'f'},
     {"ignore-ereg-path", required_argument, 0, 'i'},
     {"ignore-ereg-partition", required_argument, 0, 'i'},
     {"ignore-eregi-path", required_argument, 0, 'I'},
@@ -452,7 +454,7 @@ process_arguments (int argc, char **argv)
       strcpy (argv[c], "-t");
 
   while (1) {
-    c = getopt_long (argc, argv, "+?VqhveCt:c:w:K:W:u:p:x:X:mklLg:R:r:i:I:MEA", longopts, &option);
+    c = getopt_long (argc, argv, "+?VqhvefCt:c:w:K:W:u:p:x:X:mklLg:R:r:i:I:MEA", longopts, &option);
 
     if (c == -1 || c == EOF)
       break;
@@ -605,6 +607,9 @@ process_arguments (int argc, char **argv)
       if (path_selected)
         die (STATE_UNKNOWN, "DISK %s: %s", _("UNKNOWN"), _("Must set -E before selecting paths\n"));
       exact_match = TRUE;
+      break;
+    case 'f':
+      freespace_ignore_reserved = TRUE;
       break;
     case 'g':
       if (path_selected)
@@ -871,6 +876,8 @@ print_help (void)
   printf ("    %s\n", _("For paths or partitions specified with -p, only check for exact paths"));
   printf (" %s\n", "-e, --errors-only");
   printf ("    %s\n", _("Display only devices/mountpoints with errors"));
+  printf (" %s\n", "-f, --freespace-ignore-reserved");
+  printf ("    %s\n", _("Don't account root-reserved blocks into freespace in perfdata"));
   printf (" %s\n", "-g, --group=NAME");
   printf ("    %s\n", _("Group paths. Thresholds apply to (free-)space of all partitions together"));
   printf (" %s\n", "-k, --kilobytes");
@@ -921,7 +928,7 @@ print_usage (void)
 {
   printf ("%s\n", _("Usage:"));
   printf (" %s -w limit -c limit [-W limit] [-K limit] {-p path | -x device}\n", progname);
-  printf ("[-C] [-E] [-e] [-g group ] [-k] [-l] [-M] [-m] [-R path ] [-r path ]\n");
+  printf ("[-C] [-E] [-e] [-f] [-g group ] [-k] [-l] [-M] [-m] [-R path ] [-r path ]\n");
   printf ("[-t timeout] [-u unit] [-v] [-X type]\n");
 }
 
@@ -994,13 +1001,19 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
 
 void
 get_path_stats (struct parameter_list *p, struct fs_usage *fsp) {
-  p->total = fsp->fsu_blocks;
   /* 2007-12-08 - Workaround for Gnulib reporting insanely high available
   * space on BSD (the actual value should be negative but fsp->fsu_bavail
   * is unsigned) */
   p->available = fsp->fsu_bavail > fsp->fsu_bfree ? 0 : fsp->fsu_bavail;
   p->available_to_root = fsp->fsu_bfree;
-  p->used = p->total - p->available_to_root;
+  p->used = fsp->fsu_blocks - fsp->fsu_bfree;
+  if (freespace_ignore_reserved) {
+    /* option activated : we substract the root-reserved space from the total */
+    p->total = fsp->fsu_blocks - p->available_to_root + p->available;
+  } else {
+    /* default behaviour : take all the blocks into account */
+    p->total = fsp->fsu_blocks;
+  }
   
   p->dused_units = p->used*fsp->fsu_blocksize/mult;
   p->dfree_units = p->available*fsp->fsu_blocksize/mult;


### PR DESCRIPTION
Hello,

I didn't see how to ignore root-reserved space in check_disk so here is a patch adding an runtime option for this.

I took the letter 'f' (freespace-ignore-reserved) but maybe it's not the most intuitive. Feel free to change.

Extract from commit message :

> Before / after:
> 
> ```
> ./check_disk -w 2% -c 1% /home
> ./check_disk -w 2% -c 1% -f /home
> DISK CRITICAL - free space: /home 272 MB (1% inode=83%);| /home=17551MB;18401;18589;0;18777
> DISK CRITICAL - free space: /home 272 MB (1% inode=83%);| /home=17551MB;17466;17644;0;17823
> ```
> 
> Well, it doesn't really give me more space :) but the perfdata are a
> little bit more coherent : free + used = total.
