### PR TITLE
Fix a broken threshold example in plugin-developer guidelines

### DIFF
--- a/doc/developer-guidelines.sgml
+++ b/doc/developer-guidelines.sgml
@@ -303,7 +303,7 @@
 					</row>
 					<row>
 						<entry>check_stuff -w~:0 -c10</entry>
-						<entry>Critical if "stuff" is above 10; Warn if "stuff" is above zero</entry>
+						<entry>Critical if "stuff" is above 10; Warn if "stuff" is above zero (will be critical if "stuff" is less than 0)</entry>
 					</row>
 					<row>
 						<entry>check_stuff -c5:6</entry>


### PR DESCRIPTION
The last example in the table contradicted the previous example. Surely
it's purpose was to showcase the @ behaviour to invert threshold, but the
@ sign was missing.

I also clarified the description to the second last example so it is in same
style as the others.
