### PR TITLE
check_fping: IPv6 support

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1378,6 +1378,17 @@ else
 	AC_MSG_WARN([Get fping from http://www.fping.com in order to make check_fping plugin])
 fi
 
+AC_PATH_PROG(PATH_TO_FPING6,fping6)
+AC_ARG_WITH(fping6_command,
+            ACX_HELP_STRING([--with-fping6-command=PATH],
+                            [Path to fping6 command]), PATH_TO_FPING6=$withval)
+if test -n "$PATH_TO_FPING6"
+then
+	AC_DEFINE_UNQUOTED(PATH_TO_FPING6,"$PATH_TO_FPING6",[path to fping6])
+else
+	AC_MSG_WARN([Get fping6 from http://www.fping.com in order to make check_fping plugin])
+fi
+
 AC_PATH_PROG(PATH_TO_SSH,ssh)
 AC_ARG_WITH(ssh_command,
             ACX_HELP_STRING([--with-ssh-command=PATH],


### PR DESCRIPTION
Add command line options -4 and -6 (--use-ipv4 and
--use-ipv6) to check_fping. IPv4 is used by default,
maintaining backwards compatibility with older
check_fping versions. IPv6 support requires the
fping6 program.

The implementation is really just an imitation of
check_ping IPv6 support: Plugin command line option
-4/-6 designates whether to run fping/fping6.

Please note that especially the changes to
configure.in might be all wrong - I don't know
what's the proper autoconf way, patching
configure.in just seemed to work for me.
