### PR TITLE
Support arbitrary number of oids in check_snmp

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -229,13 +229,14 @@ main (int argc, char **argv)
 
 	np_set_args(argc, argv);
 
+	time(&current_time);
+
 	if (process_arguments (argc, argv) == ERROR)
 		usage4 (_("Could not parse arguments"));
 
 	if(calculate_rate) {
 		if (!strcmp(label, "SNMP"))
 			label = strdup("SNMP RATE");
-		time(&current_time);
 		i=0;
 		previous_state = np_state_read();
 		if(previous_state!=NULL) {

--- a/plugins/common.h
+++ b/plugins/common.h
@@ -208,9 +208,9 @@ enum {
 # define bindtextdomain(Domainname, Dirname) /* empty */
 #endif
 
-/* For non-GNU compilers to ignore __attribute__ */
-#ifndef __GNUC__
-# define __attribute__(x) /* do nothing */
+/* For non-GNU/non-clang compilers to ignore __attribute__ */
+#if !defined(__GNUC__) && !defined(__CLANG__)
+# define __attribute__(noreturn) /* do nothing */
 #endif
 
 #endif /* _COMMON_H_ */


### PR DESCRIPTION
check_snmp was restricted to 8 oids. This patch makes all related memory structures grow dynamically, so we can go beyond that limit.
