### PR TITLE
Fixed SF.net bug #3571331, check_http converts semicolon to newline in -k

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -43,7 +43,6 @@ const char *email = "nagiosplug-devel@lists.sourceforge.net";
 #include "base64.h"
 #include <ctype.h>
 
-#define INPUT_DELIMITER ";"
 #define STICKY_NONE 0
 #define STICKY_HOST 1
 #define STICKY_PORT 2
@@ -854,8 +853,7 @@ check_http (void)
   /* optionally send any other header tag */
   if (http_opt_headers_count) {
     for (i = 0; i < http_opt_headers_count ; i++) {
-      for ((pos = strtok(http_opt_headers[i], INPUT_DELIMITER)); pos; (pos = strtok(NULL, INPUT_DELIMITER)))
-        xasprintf (&buf, "%s%s\r\n", buf, pos);
+      xasprintf (&buf, "%s%s\r\n", buf, http_opt_headers[i]);
     }
     /* This cannot be free'd here because a redirection will then try to access this and segfault */
     /* Covered in a testcase in tests/check_http.t */


### PR DESCRIPTION
This commit fixes sourceforge.net bug id 3571331.
The semicolon was defined as input delimiter for multiple values in the -k arguments.
Due to the fact the semicolon is a valid character for HTTP header fields this input delimiter function was removed.
It is still possible to pass multiple header fields via multiple -k (like described in helptext).
