### PR TITLE
check_apt now correctly exits when apt-get return != 0

### DIFF
--- a/plugins/check_apt.c
+++ b/plugins/check_apt.c
@@ -112,8 +112,8 @@ int main (int argc, char **argv) {
 		result = max_state(result, STATE_CRITICAL);
 	} else if(packages_available > 0){
 		result = max_state(result, STATE_WARNING);
-	} else {
-		result = max_state(result, STATE_OK);
+	} else if(result > STATE_UNKNOWN){
+		result = STATE_UNKNOWN;
 	}
 
 	printf(_("APT %s: %d packages available for %s (%d critical updates). %s%s%s%s\n"),


### PR DESCRIPTION
Hi,
This commit fixes an issue with check_apt where check_apt doesn't exit
with the appropriate return code when apt-get returned a non-zero value.

It was already discussed in Pull Request #45 and should be fine now.
So if there aren't any objections left, please apply it, thanks!

br,
Richard
