### PR TITLE
check_procs: Use /proc/pid/exe, when available, instead of getpid() for filtering out self

### DIFF
--- a/plugins/check_procs.c
+++ b/plugins/check_procs.c
@@ -238,7 +238,7 @@ main (int argc, char **argv)
 				(!usepid && ((ret = stat_exe(procpid, &statbuf) != -1) && statbuf.st_dev == mydev && statbuf.st_ino == myino) ||
 				 (ret == -1 && errno == ENOENT))) {
 				if (verbose >= 3)
-					 printf("not considering - is myself\n");
+					 printf("not considering - is myself or gone\n");
 				continue;
 			}
 


### PR DESCRIPTION
Make check_procs filter out itself in the process list by comparing the
file pointed to by /proc/pid/exe. On platforms where this is not
available or when check_procs is passed the -T flag, the old behaviour
(check whether PID equals getpid()) is retained.

This fixes some false alarms when e.g. Nagios has, for whatever reasons,
some backlog of checks to run and check_procs with -a is called more
than once in a short time, matching its sister process.

(was https://github.com/nagios-plugins/nagios-plugins/pull/25)
