### PR TITLE
check_fping error handling enhanced

### DIFF
--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -74,6 +74,7 @@ main (int argc, char **argv)
 /* normaly should be  int result = STATE_UNKNOWN; */
 
   int status = STATE_UNKNOWN;
+  int result = 0;
   char *fping_prog = NULL;
   char *server = NULL;
   char *command_line = NULL;
@@ -146,9 +147,23 @@ main (int argc, char **argv)
   (void) fclose (child_stderr);
 
   /* close the pipe */
-  if (spclose (child_process))
+  if (result = spclose (child_process))
     /* need to use max_state not max */
     status = max_state (status, STATE_WARNING);
+
+  if (result > 1 ) {
+    status = max_state (status, STATE_UNKNOWN);
+    if (result == 2) {
+      die (STATE_UNKNOWN, _("FPING UNKNOWN - IP address not found\n"));
+    }
+    if (result == 3) {
+      die (STATE_UNKNOWN, _("FPING UNKNOWN - invalid commandline argument\n"));
+    }
+    if (result == 4) {
+      die (STATE_UNKNOWN, _("FPING UNKNOWN - failed system call\n"));
+    }
+
+  }
 
   printf ("FPING %s - %s\n", state_text (status), server_name);
 
@@ -174,6 +189,10 @@ textscan (char *buf)
     die (STATE_CRITICAL, _("FPING CRITICAL - %s is unreachable\n"),
                "host");
 
+  }
+  else if (strstr (buf, "Operation not permitted") || strstr (buf, "No such device") ) {
+    die (STATE_UNKNOWN, _("FPING UNKNOWN - %s parameter error\n"),
+               "host");
   }
   else if (strstr (buf, "is down")) {
     die (STATE_CRITICAL, _("FPING CRITICAL - %s is down\n"), server_name);


### PR DESCRIPTION
generates UNKNOWN on fping parameter error (i.e. wrong interface, missing perms ..)
