### PR TITLE
Bug fix for ncpus if hyperthreading turned off in linux

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1270,11 +1270,19 @@ fi
 
 AC_MSG_CHECKING([for number of cpus])
 AC_TRY_COMPILE([#include <unistd.h>],
-	[sysconf(_SC_NPROCESSORS_CONF) > 0;],
-	AC_DEFINE(HAVE_SYSCONF__SC_NPROCESSORS_CONF,1,[Define if sysconf returns number of cpus])
-	AC_MSG_RESULT([sysconf(_SC_NPROCESSORS_CONF)]),
+	[sysconf(_SC_NPROCESSORS_ONLN) > 0;],
+	AC_DEFINE(HAVE_SYSCONF__SC_NPROCESSORS_ONLN,1,[Define if sysconf returns number of cpus])
+	AC_MSG_RESULT([sysconf(_SC_NPROCESSORS_ONLN)]),
 	AC_MSG_RESULT([cannot calculate])
 	)
+
+AC_TRY_COMPILE([#include <unistd.h>],
+        [sysconf(_SC_NPROCESSORS_CONF) > 0;],
+        AC_DEFINE(HAVE_SYSCONF__SC_NPROCESSORS_CONF,1,[Define if sysconf returns number of cpus])
+        AC_MSG_RESULT([sysconf(_SC_NPROCESSORS_CONF)]),
+        AC_MSG_RESULT([cannot calculate])
+        )
+
 
 AC_PATH_PROG(PATH_TO_UPTIME,uptime)
 AC_ARG_WITH(uptime_command,

--- a/plugins/common.h
+++ b/plugins/common.h
@@ -82,10 +82,14 @@
    getting that data
    Will return -1 if cannot get data
 */
-#ifdef HAVE_SYSCONF__SC_NPROCESSORS_CONF 
-#define GET_NUMBER_OF_CPUS() sysconf(_SC_NPROCESSORS_CONF)
+#ifdef HAVE_SYSCONF__SC_NPROCESSORS_ONLN
+#define GET_NUMBER_OF_CPUS() sysconf(_SC_NPROCESSORS_ONLN)
 #else
-#define GET_NUMBER_OF_CPUS() -1
+# ifdef HAVE_SYSCONF__SC_NPROCESSORS_CONF
+#  define GET_NUMBER_OF_CPUS() sysconf(_SC_NPROCESSORS_CONF)
+# else
+#  define GET_NUMBER_OF_CPUS() -1
+# endif
 #endif
 
 #ifdef TIME_WITH_SYS_TIME


### PR DESCRIPTION
This changes fixes the bug outlined in 

http://sourceforge.net/tracker/?func=detail&aid=3611599&group_id=29880&atid=397597

Basically, ncpus is wrong linux if the machine has hyperthreading turned off after startup.
