### PR TITLE
Bugfix: don't close connection if received bytes are less than buffer size

### DIFF
--- a/plugins/check_tcp.c
+++ b/plugins/check_tcp.c
@@ -277,8 +277,8 @@ main (int argc, char **argv)
 			memcpy(&status[len], buffer, i);
 			len += i;
 
-			/* stop reading if user-forced or data-starved */
-			if(i < sizeof(buffer) || (maxbytes && len >= maxbytes))
+			/* stop reading if user-forced */
+			if( (maxbytes && len >= maxbytes))
 				break;
 
 			if (maxbytes && len >= maxbytes)


### PR DESCRIPTION
Closing the connection because the bytes received are less than the buffer size assumes that all the bytes will be received in one go. This is not always true!

That behaviour is buggy, as discused with Holger Weiß.
