### PR TITLE
Die on SSL initialization errors

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -881,7 +881,7 @@ check_http (void)
     gettimeofday (&tv_temp, NULL);
     result = np_net_ssl_init_with_hostname_version_and_cert(sd, (use_sni ? host_name : NULL), ssl_version, client_cert, client_privkey);
     if (result != STATE_OK)
-      return result;
+      die (STATE_CRITICAL, NULL);
     microsec_ssl = deltime (tv_temp);
     elapsed_time_ssl = (double)microsec_ssl / 1.0e6;
     if (check_cert == TRUE) {


### PR DESCRIPTION
Fixes issue where if an SSL initialization error occurs on a redirect using -f follow the plugin still returns an OK state.

It is okay to return the CRITICAL state back to main() but redir() does not account for any returned results and you end up with messages similar to the following and the plugin exiting in an OK state:

CRITICAL - Cannot make SSL connection. HTTP OK: HTTP/1.1 301 Moved Permanently

This was seen on the latest 1.4.16 release of the plugins. Interestingly trying to replicate the same issue on the 1.4.12 release of the plugins and the result is as follows with the check exiting in a CRITICAL state:

CRITICAL - Cannot make SSL connection. HTTP CRITICAL - Error on receive
