### PR TITLE
check_mailq: add sudo support

### DIFF
--- a/THANKS.in
+++ b/THANKS.in
@@ -302,3 +302,4 @@ Sebastian Schmidt
 Simon Kainz
 Steve Weinreich
 Tim Laszlo
+Christopher Schultz

--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -28,7 +28,7 @@
 use POSIX;
 use strict;
 use Getopt::Long;
-use vars qw($opt_V $opt_h $opt_v $verbose $PROGNAME $opt_w $opt_c $opt_t
+use vars qw($opt_V $opt_h $opt_v $verbose $PROGNAME $opt_w $opt_c $opt_t $opt_s
 					$opt_M $mailq $status $state $msg $msg_q $msg_p $opt_W $opt_C $mailq @lines
 					%srcdomains %dstdomains);
 use lib  utils.pm;
@@ -55,6 +55,13 @@ if ($status){
 	exit $ERRORS{"UNKNOWN"};
 }
 
+my($sudocmd);
+if($opt_s) {
+  $sudocmd="/usr/bin/sudo ";
+} else {
+  $sudocmd="";
+}
+
 $SIG{'ALRM'} = sub {
 	print ("ERROR: timed out waiting for $utils::PATH_TO_MAILQ \n");
 	exit $ERRORS{"WARNING"};
@@ -67,7 +74,7 @@ if ($mailq eq "sendmail") {
 
 	## open mailq 
 	if ( defined $utils::PATH_TO_MAILQ && -x $utils::PATH_TO_MAILQ ) {
-		if (! open (MAILQ, "$utils::PATH_TO_MAILQ | " ) ) {
+		if (! open (MAILQ, "$sudocmd$utils::PATH_TO_MAILQ | " ) ) {
 			print "ERROR: could not open $utils::PATH_TO_MAILQ \n";
 			exit $ERRORS{'UNKNOWN'};
 		}
@@ -296,7 +303,7 @@ elsif ( $mailq eq "postfix" ) {
 
      ## open mailq
         if ( defined $utils::PATH_TO_MAILQ && -x $utils::PATH_TO_MAILQ ) {
-                if (! open (MAILQ, "$utils::PATH_TO_MAILQ | " ) ) {
+                if (! open (MAILQ, "$sudocmd$utils::PATH_TO_MAILQ | " ) ) {
                         print "ERROR: could not open $utils::PATH_TO_MAILQ \n";
                         exit $ERRORS{'UNKNOWN'};
                 }
@@ -460,7 +467,7 @@ elsif ( $mailq eq "qmail" ) {
 elsif ( $mailq eq "exim" ) {
 	## open mailq 
 	if ( defined $utils::PATH_TO_MAILQ && -x $utils::PATH_TO_MAILQ ) {
-		if (! open (MAILQ, "$utils::PATH_TO_MAILQ | " ) ) {
+		if (! open (MAILQ, "$sudocmd$utils::PATH_TO_MAILQ | " ) ) {
 			print "ERROR: could not open $utils::PATH_TO_MAILQ \n";
 			exit $ERRORS{'UNKNOWN'};
 		}
@@ -517,7 +524,8 @@ sub process_arguments(){
 		 "M:s" => \$opt_M, "mailserver:s" => \$opt_M, # mailserver (default	sendmail)
 		 "w=i" => \$opt_w, "warning=i"  => \$opt_w,   # warning if above this number
 		 "c=i" => \$opt_c, "critical=i" => \$opt_c,	  # critical if above this number
-		 "t=i" => \$opt_t, "timeout=i"  => \$opt_t 
+		 "t=i" => \$opt_t, "timeout=i"  => \$opt_t,
+                 "s"   => \$opt_s, "sudo"       => \$opt_s
 		 );
 
 	if ($opt_V) {
@@ -592,6 +600,7 @@ sub print_help () {
 	print "-C (--Critical)  = Min. number of messages for same domain in queue to generate critical alert ( W < C )\n";
 	print "-t (--timeout)   = Plugin timeout in seconds (default = $utils::TIMEOUT)\n";
 	print "-M (--mailserver) = [ sendmail | qmail | postfix | exim ] (default = sendmail)\n";
+	print "-s (--sudo)      = Use sudo to call the mailq command\n";
 	print "-h (--help)\n";
 	print "-V (--version)\n";
 	print "-v (--verbose)   = debugging output\n";


### PR DESCRIPTION
Just turning attached patch of github issue #1099 into a push request
(with some modifications)

"The check_mailq plug-in calls /usr/bin/mailq which, in my environments, requires root access. This is easily accomplished by giving nagios sudo access to /usr/bin/mailq but check_mailq needs to call sudo in order to use those privileges.

I have made a small patch that accomplishes this goal with an additional parameter (-s or --sudo). The user still needs to edit /etc/sudoers to give the nagios user permissions to execute /usr/bin/mailq without a password.

I attached my patch to my original issue report over at the old Nagios plugins tracker here: http://tracker.nagios.org/view.php?id=368"
