### PR TITLE
check_dns: add AAAA,MX,TXT,SRV,CNAME

### DIFF
--- a/THANKS.in
+++ b/THANKS.in
@@ -302,3 +302,4 @@ Sebastian Schmidt
 Simon Kainz
 Steve Weinreich
 Tim Laszlo
+David Horn


### PR DESCRIPTION
Just turning attached patch of github issue #894 into a push request.

"Added optional support for the major DNS record types (AAAA, MX, TXT, SRV, CNAME, A, ANY). Specifically, allow for a new optional --querytype parameter, and a new optional --accept-cname parameter. Help text has been updated to reflect the changes as well. Patch is against SVN trunk of check_dns.c from April 7,2009.

This change should be completely backwards compatible with existing check_dns usage and syntax. New features are off by default."
