### PR TITLE
check_oracle: --tns bad string matching

### DIFF
--- a/THANKS.in
+++ b/THANKS.in
@@ -302,3 +302,4 @@ Sebastian Schmidt
 Simon Kainz
 Steve Weinreich
 Tim Laszlo
+Frederic Krueger

--- a/plugins-scripts/check_oracle.sh
+++ b/plugins-scripts/check_oracle.sh
@@ -136,7 +136,7 @@ case "$cmd" in
     tnschk=` tnsping $2`
     tnschk2=` echo  $tnschk | grep -c OK`
     if [ ${tnschk2} -eq 1 ] ; then 
-	tnschk3=` echo $tnschk | sed -e 's/.*(//' -e 's/).*//'`
+	tnschk3=${tnschk##*(}; tnschk3=${tnschk3%)*}
 	echo "OK - reply time ${tnschk3} from $2"
 	exit $STATE_OK
     else


### PR DESCRIPTION
check_oracle in the 1.4.15 release doesn't correctly parse the output gotten
from at least Oracle 11 (with german locales). I guess it's probably more.
Also it completely needlessly uses sed where basic bash string parsing actually
does more than suffice (and does not run into possible problems with locales
## like sed ;)).

Just turning attached patch of github issue #1015 into a push request.
(Closes #1015)
