### PR TITLE
check_mailq.pl: separate submission queue

### DIFF
--- a/THANKS.in
+++ b/THANKS.in
@@ -405,3 +405,4 @@ Robert Bohne
 Wolfgang Nieder
 andrew bezella
 Lorenz Gruenwald
+John Morrissey

--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -149,7 +149,26 @@ if ($mailq eq "sendmail") {
 ##/var/spool/mqueue/qF/df is empty
 ##                Total Requests: 1
 
-	
+# separate submission/transport queues, empty
+## MSP Queue status...
+## /var/spool/mqueue-client is empty
+##                 Total requests: 0
+## MTA Queue status...
+## /var/spool/mqueue is empty
+##                 Total requests: 0
+# separate submission/transport queues: 1
+## MSP Queue status...
+##                 /var/spool/mqueue-client (1 request)
+## -----Q-ID----- --Size-- -----Q-Time----- ------------Sender/Recipient-----------
+## oAJEfhdW014123        5 Fri Nov 19 14:41 jwm
+##                  (Deferred: Connection refused by [127.0.0.1])
+##                                          root
+##                 Total requests: 1
+## MTA Queue status...
+## /var/spool/mqueue is empty
+##                 Total requests: 0
+
+	my $this_msg_q = 0;
 	while (<MAILQ>) {
 	
 		# match email addr on queue listing
@@ -189,13 +208,18 @@ if ($mailq eq "sendmail") {
 	    	#
 		    # single queue: first line
 		    # multi queue: one for each queue. overwrite on multi queue below
-	  	  $msg_q = $1 ;
+		  $this_msg_q = $1 ;
+	  	  $msg_q += $1 ;
 			}
 		} elsif (/^\s+Total\sRequests:\s(\d+)$/i) {
-			print "$utils::PATH_TO_MAILQ = $_ \n" if $verbose ;
-			#
-			# multi queue: last line
-			$msg_q = $1 ;
+			if ($this_msg_q) {
+				$this_msg_q = 0 ;
+			} else {
+				print "$utils::PATH_TO_MAILQ = $_ \n" if $verbose ;
+				#
+				# multi queue: last line
+				$msg_q += $1 ;
+			}
 		}
 	
 	}


### PR DESCRIPTION
check_mailq.pl ignores the separate submission queue used in (modern?) sendmail
implementations.

For the queue output below with one message in the submission queue and no
messages in the transport queue, check_mailq.pl reports zero messages in the
queue because the request count from the last queue always overwrites previous
queues. If the sendmail MTA isn't running or has become wedged, messages will
sit in the submission queue forever.

The attached patch fixes this in a backwards compatible way (i.e., it shouldn't
## break any of the currently supported formats).

Just turning attached patch of github issue #972 into a push request.
(Closes #972)
