### PR TITLE
check_swap: returns OK, if no swap activated [sf#2823005]

### DIFF
--- a/THANKS.in
+++ b/THANKS.in
@@ -302,3 +302,4 @@ Sebastian Schmidt
 Simon Kainz
 Steve Weinreich
 Tim Laszlo
+Jan Ondrej

--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -124,7 +124,7 @@ main (int argc, char **argv)
 			free_swap_mb += dskfree_mb;
 			if (allswaps) {
 				if (dsktotal_mb == 0)
-					percent=100.0;
+					percent=0.0;
 				else
 					percent = 100 * (((double) dskused_mb) / ((double) dsktotal_mb));
 				result = max_state (result, check_swap (percent, dskfree_mb));


### PR DESCRIPTION
My swap was not activated on boot for unknown reason and nagios does not
report this as a problem. Here is an example:

[root@kecom ~]# rpm -q nagios-plugins
nagios-plugins-1.4.13-11.fc10.i386
[root@kecom ~]# /usr/lib/nagios/plugins/check_swap -w 80% -c 40% -c 1 -w 2
SWAP CRITICAL - 100% free (0 MB out of 0 MB) |swap=0MB;0;0;0;0

If there is no swap and users is trying to test percentage of free swap,
consider 0 MB free swap space as problem, or of free/total raises division
## by zero, then set percentage to 0%, not to 100%.

Just turning attached patch of github issue #896 into a push request.
(Closes #896)
