### PR TITLE
Fix check_mysql.c client options from file

### DIFF
--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -476,12 +476,6 @@ validate_arguments (void)
 	if (db_user == NULL)
 		db_user = strdup("");
 
-	if (opt_file == NULL)
-		opt_file = strdup("");
-
-	if (opt_group == NULL)
-		opt_group = strdup("");
-
 	if (db_host == NULL)
 		db_host = strdup("");
 


### PR DESCRIPTION
If you don't specify a group or a file to read data from the plugin tries to read from several files that don't exist and no groups.

Here is an strace before this change:

stat("/etc/mysql/.cnf", 0x7fff7c4e6620) = -1 ENOENT (No such file or directory)
stat("/etc/.cnf", 0x7fff7c4e6620)       = -1 ENOENT (No such file or directory)
stat("/root/..cnf", 0x7fff7c4e6620)     = -1 ENOENT (No such file or directory)

Here is an strace after:

stat("/etc/mysql/my.cnf", 0x7fffea2dea40) = -1 ENOENT (No such file or directory)
stat("/etc/my.cnf", {st_mode=S_IFREG|0644, st_size=1331, ...}) = 0
open("/etc/my.cnf", O_RDONLY)           = 3

Even if you did specify a config file to read from bu no group was specified it is likely no group was used instead of using the default "client" group. All of this seems to be unintended behavior. 
