### PR TITLE
check_http: Move time_ssl to end of extended perfdata output

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1197,10 +1197,10 @@ check_http (void)
            perfd_time (elapsed_time),
            perfd_size (page_len),
            perfd_time_connect (elapsed_time_connect),
-           use_ssl == TRUE ? perfd_time_ssl (elapsed_time_ssl) : "",
            perfd_time_headers (elapsed_time_headers),
            perfd_time_firstbyte (elapsed_time_firstbyte),
-           perfd_time_transfer (elapsed_time_transfer));
+           perfd_time_transfer (elapsed_time_transfer),
+           use_ssl == TRUE ? perfd_time_ssl (elapsed_time_ssl) : "");
   else
     xasprintf (&msg,
            _("%s - %d bytes in %.3f second response time %s|%s %s"),


### PR DESCRIPTION
When using pnp4nagios as your graphing engine and you don't have the MULTI option turned where each source of information is placed into it's own independent RRD file it is difficult to add a new datasource into the middle of a pre-existing RRD file. Having the data added at the end on the other hand isn't nearly as bad. I'd imagine with other graphing platforms like graphite this isn't really an issue.

This is really an attempt to fix some short comings with how my current setup is configured now but I'm hoping it may help others who are in a similar situation.
