### PR TITLE
check_procs: add option to ignore plugin parent process

### DIFF
--- a/plugins/check_procs.c
+++ b/plugins/check_procs.c
@@ -123,6 +123,7 @@ main (int argc, char **argv)
 	char *procprog;
 
 	pid_t mypid = 0;
+	pid_t myppid = 0;
 	struct stat statbuf;
 	dev_t mydev = 0;
 	ino_t myino = 0;
@@ -172,6 +173,7 @@ main (int argc, char **argv)
 
 	/* find ourself */
 	mypid = getpid();
+	myppid = getppid();
 	if (usepid || stat_exe(mypid, &statbuf) == -1) {
 		/* usepid might have been set by -T */
 		usepid = 1;
@@ -239,6 +241,12 @@ main (int argc, char **argv)
 				 (ret == -1 && errno == ENOENT))) {
 				if (verbose >= 3)
 					 printf("not considering - is myself or gone\n");
+				continue;
+			}
+			/* Ignore parent*/
+			else if (myppid == procpid) {
+				if (verbose >= 3)
+					 printf("not considering - is parent\n");
 				continue;
 			}
 
@@ -409,7 +417,7 @@ process_arguments (int argc, char **argv)
 			strcpy (argv[c], "-t");
 
 	while (1) {
-		c = getopt_long (argc, argv, "Vvhkt:c:w:p:s:u:C:a:z:r:m:P:T",
+		c = getopt_long (argc, argv, "Vvihkt:c:w:p:s:u:C:a:z:r:m:P:T",
 			longopts, &option);
 
 		if (c == -1 || c == EOF)
@@ -773,5 +781,5 @@ print_usage (void)
   printf ("%s\n", _("Usage:"));
 	printf ("%s -w <range> -c <range> [-m metric] [-s state] [-p ppid]\n", progname);
   printf (" [-u user] [-r rss] [-z vsz] [-P %%cpu] [-a argument-array]\n");
-  printf (" [-C command] [-k] [-t timeout] [-v]\n");
+  printf (" [-C command] [-k] [-i] [-t timeout] [-v]\n");
 }

--- a/plugins/t/check_procs.t
+++ b/plugins/t/check_procs.t
@@ -13,7 +13,7 @@ my $t;
 if (`uname -s` eq "SunOS\n" && ! -x "/usr/local/nagios/libexec/pst3") {
 	plan skip_all => "Ignoring tests on solaris because of pst3";
 } else {
-	plan tests => 12;
+	plan tests => 16;
 }
 
 my $result;
@@ -26,6 +26,13 @@ $result = NPTest->testCmd( "./check_procs -w 100000 -c 100000 -s Z" );
 is( $result->return_code, 0, "Checking less than 100000 zombie processes" );
 like( $result->output, '/^PROCS OK: [0-9]+ process(es)? with /', "Output correct" );
 
+SKIP: {
+	skip "No bash available", 4 unless(system("which bash > /dev/null") == 0);
+	$result = NPTest->testCmd( "bash -c './check_procs -a '/sbin/init'; true'" );
+	is( $result->return_code, 0, "Parent process is ignored" );
+	like( $result->output, '/^PROCS OK: 1 process?/', "Output correct" );
+
+}
 $result = NPTest->testCmd( "./check_procs -w 0 -c 100000" );
 is( $result->return_code, 1, "Checking warning if processes > 0" );
 like( $result->output, '/^PROCS WARNING: [0-9]+ process(es)? | procs=[0-9]+;0;100000;0;$/', "Output correct" );


### PR DESCRIPTION
This fixes an issue that appears when running check_procs over NRPE,
where the default shell is configured to (for example) dash, as is the
case on Debian.

dash (and tcsh, and mksh, and probably others), when invoked with -c forks an additional process
to execute the argument string. Contrast this with bash, which does not
do this, provided that the argument string simply can be exec()'d as-is.

To demonstrate:
$ bash -c pstree
init─┬ ..
    ...
    ├─sshd─-─sshd───pstree

versus
$ dash -c pstree
init─┬ ..
    ...
    ├─sshd─-─sshd───dash───pstree

The consequence of this fork is that the following invokation:
    /opt/plugins/check_procs -a init

will result in this output:

```
PROCS OK: 2 processes with args 'init' | processes=2;;;0;
```

because the check_procs, in addition to finding the actual init process,
finds its parent shell as well.

This example is a bit contrived, but I think it illustrates the
point.

This wouldn't really be a problem, and normally isn't, if it weren't
for the fact that NRPE uses a call to popen() which does exactly the
above (executes '/bin/sh -c ...'), causing inconsistent behaviour
between distributions and much confusion for end users.

The argument may be made that the dash process spawned by NRPE is just a
process like any other, and should therefore be included in the process
count just like any other. However, this is not very intuitive, because
of the previously mentioned inconsistencies.

The argument might also well be made that we're _never_ interested in the
immediate ancestor of the plugin, but it is unknown how many
installations have already made the necessary modifications to their
setups to make up for the fact that the plugin behaves the way it does.

Thus, this patch adds an option --ignore-parent, which could (and
indeed, in my opinion, should) be used, if you want to run check_procs through NRPE,
with the -a option.

See also these bug reports:
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=626913
http://sourceforge.net/p/nagiosplug/bugs/512/
https://github.com/nagios-plugins/nagios-plugins/issues/999
https://bugs.op5.com/view.php?id=4398
