### PR TITLE
Fix PATH_TO_QMAIL_QSTAT in configure

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1456,9 +1456,12 @@ else
 fi
 
 AC_PATH_PROG(PATH_TO_QMAIL_QSTAT,qmail-qstat)
-if test -x "$PATH_TO_QMAIL_QSTAT"
+AC_ARG_WITH(qmail_qstat_command,
+            ACX_HELP_STRING([--with-qmail-qstat-command=PATH],
+                            [sets path to qmail-qstat]), PATH_TO_QMAIL_QSTAT=$withval)
+if test -n "$PATH_TO_QMAIL_QSTAT"
 then
-	AC_DEFINE_UNQUOTED(PATH_TO_MAILQ,"$PATH_TO_QMAIL_QSTAT",[path to qmail-qstat])
+	AC_DEFINE_UNQUOTED(PATH_TO_QMAIL_QSTAT,"$PATH_TO_QMAIL_QSTAT",[path to qmail-qstat])
 else
 	AC_MSG_WARN([Could not find qmail-qstat or eqivalent])
 fi


### PR DESCRIPTION
When configuring PATH_TO_QMAIL_QSTAT the PATH_TO_MAILQ would get applied instead after tests had passed. Also made --with-qmail-qstat-command a configuration option.
