### PR TITLE
Handle negative values properly with check_snmp

### DIFF
--- a/lib/utils_base.h
+++ b/lib/utils_base.h
@@ -62,7 +62,7 @@ int check_range(double, range *);
 int get_status(double, thresholds *);
 
 /* All possible characters in a threshold range */
-#define NP_THRESHOLDS_CHARS "0123456789.:@~"
+#define NP_THRESHOLDS_CHARS "-0123456789.:@~"
 
 char *np_escaped_string (const char *);
 

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -459,7 +459,7 @@ main (int argc, char **argv)
 		/* Process this block for numeric comparisons */
 		/* Make some special values,like Timeticks numeric only if a threshold is defined */
 		if (thlds[i]->warning || thlds[i]->critical || calculate_rate) {
-			ptr = strpbrk (show, "0123456789");
+			ptr = strpbrk (show, "-0123456789");
 			if (ptr == NULL)
 				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
 			while (i >= response_size) {


### PR DESCRIPTION
check_snmp becomes capable of evaluating negative values properly, but it might be returning CRITICALs where it used to return OK and was ignored, if a negative value turns out to actually be a valid value.

If negative values are actually valid, this can be worked around, by adding "~:" to the warning/critical threshold : 100 -> ~:100
