### PR TITLE
check_dig: Add support for drill tool to

### DIFF
--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -290,7 +290,10 @@ process_arguments (int argc, char **argv)
       dns_server = argv[c];
     }
     else {
-      dns_server = strdup ("127.0.0.1");
+      if (strcmp(query_transport,"-6") == 0)
+        dns_server = strdup("::1");
+      else
+        dns_server = strdup ("127.0.0.1");
     }
   }
 


### PR DESCRIPTION
FreeBSD starting with version 10 is shipped with ldns instead of bind as resolver. Consequently the dig tool in base is replaced by drill. While dig can still be installed as a third party application, it would be nice to make do with the tools available in the system already.
This patch rearranges the command line used to invoke dig slightly so that it can be used with both dig and drill (tested with dig 9.8.3-P1 and 9.9.4 as well as drill 1.6.16). It would be really neat if the configure script could be changed to automatically pick up drill when dig is not available (or the other way around), but my autotools-foo is not good enough for that.
This part of the patch is an extended version of the locally maintained patch currently deployed in the FreeBSD ports tree by Dmitry Sivachenko.

Unrelated, to this, the default DNS server, if not specified, now takes into account the -4 and -6 switches (i.e. if -6 is given ::1 is used instead of 127.0.0.1).
