### PR TITLE
check_snmp: Introduce support for SNMPv3 context

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -104,6 +104,8 @@ int errcode, excode;
 
 char *server_address = NULL;
 char *community = NULL;
+char **contextargs = NULL;
+char *context = NULL;
 char **authpriv = NULL;
 char *proto = NULL;
 char *seclevel = NULL;
@@ -128,6 +130,7 @@ size_t nunits = 0;
 size_t unitv_size = OID_COUNT_STEP;
 int numoids = 0;
 int numauthpriv = 0;
+int numcontext = 0;
 int verbose = 0;
 int usesnmpgetnext = FALSE;
 char *warning_thresholds = NULL;
@@ -297,8 +300,8 @@ main (int argc, char **argv)
 		snmpcmd = strdup (PATH_TO_SNMPGET);
 	}
 
-	/* 10 arguments to pass before authpriv options + 1 for host and numoids. Add one for terminating NULL */
-	command_line = calloc (10 + numauthpriv + 1 + numoids + 1, sizeof (char *));
+	/* 10 arguments to pass before context and authpriv options + 1 for host and numoids. Add one for terminating NULL */
+	command_line = calloc (10 + numcontext + numauthpriv + 1 + numoids + 1, sizeof (char *));
 	command_line[0] = snmpcmd;
 	command_line[1] = strdup ("-Le");
 	command_line[2] = strdup ("-t");
@@ -310,23 +313,27 @@ main (int argc, char **argv)
 	command_line[8] = "-v";
 	command_line[9] = strdup (proto);
 
+	for (i = 0; i < numcontext; i++) {
+		command_line[10 + i] = contextargs[i];
+	}
+	
 	for (i = 0; i < numauthpriv; i++) {
-		command_line[10 + i] = authpriv[i];
+		command_line[10 + numcontext + i] = authpriv[i];
 	}
 
-	xasprintf (&command_line[10 + numauthpriv], "%s:%s", server_address, port);
+	xasprintf (&command_line[10 + numcontext + numauthpriv], "%s:%s", server_address, port);
 
 	/* This is just for display purposes, so it can remain a string */
-	xasprintf(&cl_hidden_auth, "%s -Le -t %d -r %d -m %s -v %s %s %s:%s",
-		snmpcmd, timeout_interval, retries, strlen(miblist) ? miblist : "''", proto, "[authpriv]",
+	xasprintf(&cl_hidden_auth, "%s -Le -t %d -r %d -m %s -v %s %s %s %s:%s",
+		snmpcmd, timeout_interval, retries, strlen(miblist) ? miblist : "''", proto, "[context]", "[authpriv]",
 		server_address, port);
 
 	for (i = 0; i < numoids; i++) {
-		command_line[10 + numauthpriv + 1 + i] = oids[i];
+		command_line[10 + numcontext + numauthpriv + 1 + i] = oids[i];
 		xasprintf(&cl_hidden_auth, "%s %s", cl_hidden_auth, oids[i]);	
 	}
 
-	command_line[10 + numauthpriv + 1 + numoids] = NULL;
+	command_line[10 + numcontext + numauthpriv + 1 + numoids] = NULL;
 
 	if (verbose)
 		printf ("%s\n", cl_hidden_auth);
@@ -646,6 +653,7 @@ process_arguments (int argc, char **argv)
 		{"retries", required_argument, 0, 'e'},
 		{"miblist", required_argument, 0, 'm'},
 		{"protocol", required_argument, 0, 'P'},
+		{"context", required_argument, 0, 'N'},
 		{"seclevel", required_argument, 0, 'L'},
 		{"secname", required_argument, 0, 'U'},
 		{"authproto", required_argument, 0, 'a'},
@@ -675,7 +683,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	while (1) {
-		c = getopt_long (argc, argv, "nhvVOt:c:w:H:C:o:e:E:d:D:s:t:R:r:l:u:p:m:P:L:U:a:x:A:X:",
+		c = getopt_long (argc, argv, "nhvVOt:c:w:H:C:o:e:E:d:D:s:t:R:r:l:u:p:m:P:N:L:U:a:x:A:X:",
 									 longopts, &option);
 
 		if (c == -1 || c == EOF)
@@ -712,6 +720,9 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'P':	/* SNMP protocol version */
 			proto = optarg;
+			break;
+		case 'N':	/* SNMPv3 context */
+			context = optarg;
 			break;
 		case 'L':	/* security level */
 			seclevel = optarg;
@@ -960,6 +971,13 @@ validate_arguments ()
 		authpriv[1] = strdup (community);
 	}
 	else if ( strcmp (proto, "3") == 0 ) {		/* snmpv3 args */
+		if (!(context == NULL)) {
+			numcontext = 2;
+			contextargs = calloc (numcontext, sizeof (char *));
+			contextargs[0] = strdup ("-n");
+			contextargs[1] = strdup (context);
+		}
+		
 		if (seclevel == NULL)
 			xasprintf(&seclevel, "noAuthNoPriv");
 
@@ -1101,6 +1119,8 @@ print_help (void)
 	printf ("    %s\n", _("Use SNMP GETNEXT instead of SNMP GET"));
 	printf (" %s\n", "-P, --protocol=[1|2c|3]");
 	printf ("    %s\n", _("SNMP protocol version"));
+	printf (" %s\n", "-N, --context=CONTEXT");
+	printf ("    %s\n", _("SNMPv3 context"));
 	printf (" %s\n", "-L, --seclevel=[noAuthNoPriv|authNoPriv|authPriv]");
 	printf ("    %s\n", _("SNMPv3 securityLevel"));
 	printf (" %s\n", "-a, --authproto=[MD5|SHA]");
@@ -1208,6 +1228,6 @@ print_usage (void)
 	printf ("%s -H <ip_address> -o <OID> [-w warn_range] [-c crit_range]\n",progname);
 	printf ("[-C community] [-s string] [-r regex] [-R regexi] [-t timeout] [-e retries]\n");
 	printf ("[-l label] [-u units] [-p port-number] [-d delimiter] [-D output-delimiter]\n");
-	printf ("[-m miblist] [-P snmp version] [-L seclevel] [-U secname] [-a authproto]\n");
-	printf ("[-A authpasswd] [-x privproto] [-X privpasswd]\n");
+	printf ("[-m miblist] [-P snmp version] [-N context] [-L seclevel] [-U secname]\n");
+	printf ("[-a authproto] [-A authpasswd] [-x privproto] [-X privpasswd]\n");
 }


### PR DESCRIPTION
snmpget already supports using SNMPv3 contexts using the option "-n".
Thus all we need to do is introduce a new argument to check_snmp and
pass the argument on to snmpget using snmpget's option "-n".
Since "-n" is already in use for check_snmp for a different purpose,
we use "-N" instead.
