### PR TITLE
fix outdated Free Software Foundation address

### DIFF
--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -18,7 +18,7 @@
 #
 # you should have received a copy of the GNU General Public License
 # along with this program if not, write to the Free Software Foundation,
-# Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 
 use strict;
 use English;

--- a/plugins-scripts/check_ifoperstatus.pl
+++ b/plugins-scripts/check_ifoperstatus.pl
@@ -19,7 +19,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+# USA 
 #
 #
 # Report bugs to:  help@monitoring-plugins.org

--- a/plugins-scripts/check_ifstatus.pl
+++ b/plugins-scripts/check_ifstatus.pl
@@ -22,7 +22,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 #
 #
 # Report bugs to: ck@zet.net, help@monitoring-plugins.org

--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -20,8 +20,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-#
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+# USA 
 #
 ############################################################################
 


### PR DESCRIPTION
Fix the obsolete Free Software Foundation address. 
See http://www.fsf.org/about/contact/ for the current address.
