### PR TITLE
check_icmp: use packet reception time to compute rtt

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1,39 +1,39 @@
 /*****************************************************************************
-*
+* 
 * Monitoring check_icmp plugin
-*
+* 
 * License: GPL
 * Copyright (c) 2005-2008 Monitoring Plugins Development Team
 * Original Author : Andreas Ericsson <ae@op5.se>
-*
+* 
 * Description:
-*
+* 
 * This file contains the check_icmp plugin
-*
+* 
 * Relevant RFC's: 792 (ICMP), 791 (IP)
-*
+* 
 * This program was modeled somewhat after the check_icmp program,
 * which was in turn a hack of fping (www.fping.org) but has been
 * completely rewritten since to generate higher precision rta values,
 * and support several different modes as well as setting ttl to control.
 * redundant routes. The only remainders of fping is currently a few
 * function names.
-*
-*
+* 
+* 
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-*
+* 
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-*
+* 
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*
-*
+* 
+* 
 *****************************************************************************/
 
 /* progname may change */


### PR DESCRIPTION
Currently, check_icmp uses processing time to compute rtt. This can lead to invalid values when the machine is heavily loaded. The patch I propose uses the SO_TIMESTAMP feature of setsockopt to use the kernel reception time instead.
