### PR TITLE
check_snmp: Added warning and critical thresholds to the performance data

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -573,6 +573,10 @@ main (int argc, char **argv)
 			}
 
 			if (critical_thresholds) {
+
+				if(! warning_thresholds) {
+					strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
+				}
                                 strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
                                 strncat(perfstr, critical_thresholds, sizeof(perfstr)-strlen(perfstr)-1);
                         }


### PR DESCRIPTION
Dear monitoring-plugins developer team,

Thank you very much on your great work on the plugins. Attached I've added a small patch to check_snmp to include the warning and critical thresholds in the performance data to allow better graphing of the monitored values.
