### PR TITLE
use 'or' instead of '||' as operator

### DIFF
--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -611,19 +611,19 @@ sub process_arguments(){
 		{
 			$mailq = 'qmail';
 		}
-		elsif (-d '/var/lib/postfix' || -d '/var/local/lib/postfix'
-		       || -e '/usr/sbin/postfix' || -e '/usr/local/sbin/postfix')
+		elsif (-d '/var/lib/postfix' or -d '/var/local/lib/postfix'
+		       or -e '/usr/sbin/postfix' or -e '/usr/local/sbin/postfix')
 		{
 			$mailq = 'postfix';
 		}
-		elsif (-d '/usr/lib/exim4' || -d '/usr/local/lib/exim4'
-		       || -e '/usr/sbin/exim' || -e '/usr/local/sbin/exim')
+		elsif (-d '/usr/lib/exim4' or -d '/usr/local/lib/exim4'
+		       or -e '/usr/sbin/exim' or -e '/usr/local/sbin/exim')
 		{
 			$mailq = 'exim';
 		}
-		elsif (-d '/usr/lib/nullmailer' || -d '/usr/local/lib/nullmailer'
-		       || -e '/usr/sbin/nullmailer-send'
-		       || -e '/usr/local/sbin/nullmailer-send')
+		elsif (-d '/usr/lib/nullmailer' or -d '/usr/local/lib/nullmailer'
+		       or -e '/usr/sbin/nullmailer-send'
+		       or -e '/usr/local/sbin/nullmailer-send')
 		{
 			$mailq = 'nullmailer';
 		}


### PR DESCRIPTION
this fixes a stupid FTBFS with mawk which thinks our file contains regex:

```
NP_VERSION=1.5.110.g2d494 mawk -f ./subst check_mailq.pl > check_mailq
mawk: run time error: regular expression compile failed (missing operand)
/var/lib/postfix' || -d '/var/local/lib/postfix
    FILENAME="check_mailq.pl" FNR=614 NR=614
make[2]: *** [check_mailq] Error 2
```
