### PR TITLE
check_snmp: Handle SNMPv3 noAuthNoPriv properly

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -963,11 +963,16 @@ validate_arguments ()
 		if (seclevel == NULL)
 			xasprintf(&seclevel, "noAuthNoPriv");
 
+		if (secname == NULL)
+			die(STATE_UNKNOWN, _("Required parameter: %s\n"), "secname");
+
 		if (strcmp(seclevel, "noAuthNoPriv") == 0) {
-			numauthpriv = 2;
+			numauthpriv = 4;
 			authpriv = calloc (numauthpriv, sizeof (char *));
 			authpriv[0] = strdup ("-l");
 			authpriv[1] = strdup ("noAuthNoPriv");
+			authpriv[2] = strdup ("-u");
+			authpriv[3] = strdup (secname);
 		} else {
 			if (! ( (strcmp(seclevel, "authNoPriv")==0) || (strcmp(seclevel, "authPriv")==0) ) ) {
 				usage2 (_("Invalid seclevel"), seclevel);
@@ -975,9 +980,6 @@ validate_arguments ()
 
 			if (authproto == NULL )
 				xasprintf(&authproto, DEFAULT_AUTH_PROTOCOL);
-
-			if (secname == NULL)
-				die(STATE_UNKNOWN, _("Required parameter: %s\n"), "secname");
 
 			if (authpasswd == NULL)
 				die(STATE_UNKNOWN, _("Required parameter: %s\n"), "authpasswd");


### PR DESCRIPTION
The SNMPv3 noAuthNoPriv security level, somewhat unintuitively, requires
a security name to be passed along together with the request. Check_snmp
previously did not do this, causing snmpget to throw an error:

"External command error: No log handling enabled - turning on stderr
logging
snmpget: No securityName specified"

This patch fixes the issue by always providing the security name when
noAuthNoPriv is specified.

See also:
https:://bugs.op5.com/view.php?id=8385.

Signed-off-by: Anton Lofgren alofgren@op5.com
