### PR TITLE
Add commandline -T switch to check_time and check_ntp_time

### DIFF
--- a/THANKS.in
+++ b/THANKS.in
@@ -307,3 +307,4 @@ Stéphane Bortzmeyer
 Luca Corti
 Jethro Carr
 Evgeni Golov
+Casper Langemeijer

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -458,7 +458,7 @@ int process_arguments(int argc, char **argv){
 		{"warning", required_argument, 0, 'w'},
 		{"critical", required_argument, 0, 'c'},
 		{"timeout", required_argument, 0, 't'},
-		{"timeout-warning", no_argument, 0, 'T'},
+		{"timeout-result", required_argument, 0, 'T'},
 		{"hostname", required_argument, 0, 'H'},
 		{"port", required_argument, 0, 'p'},
 		{0, 0, 0, 0}
@@ -469,7 +469,7 @@ int process_arguments(int argc, char **argv){
 		usage ("\n");
 
 	while (1) {
-		c = getopt_long (argc, argv, "Vhv46qw:c:t:H:p:T", longopts, &option);
+		c = getopt_long (argc, argv, "Vhv46qw:c:t:H:p:T:", longopts, &option);
 		if (c == -1 || c == EOF || c == 1)
 			break;
 
@@ -505,8 +505,9 @@ int process_arguments(int argc, char **argv){
 		case 't':
 			socket_timeout=atoi(optarg);
 			break;
-		case 'T':									/* Timeout will lead to a warning, not critical status */
-			socket_timeout_state = STATE_WARNING;
+		case 'T':     /* Result to return on timeouts */
+			if ((socket_timeout_state = mp_translate_state(optarg)) == ERROR)
+				usage4 (_("Timeout result must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer (0-3)."));
 			break;
 		case '4':
 			address_family = AF_INET;
@@ -621,8 +622,8 @@ void print_help(void){
 	printf (" %s\n", "-c, --critical=THRESHOLD");
 	printf ("    %s\n", _("Offset to result in critical status (seconds)"));
 	printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
-	printf (" %s\n", "-T, --timeout-warning");
-	printf ("   %s\n", _("Connection timeout will result in warning status instead of critical"));
+	printf (" %s\n", "-T, --timeout-result=STATUS");
+	printf ("   %s\n", _("Connection timeout will result in STATUS instead of critical"));
 	printf (UT_VERBOSE);
 
 	printf("\n");
@@ -648,6 +649,6 @@ void
 print_usage(void)
 {
 	printf ("%s\n", _("Usage:"));
-	printf(" %s -H <host> [-4|-6] [-w <warn>] [-c <crit>] [-v verbose] [-t timeout] [-T]\n", progname);
+	printf(" %s -H <host> [-4|-6] [-w <warn>] [-c <crit>] [-v verbose] [-t timeout] [-T STATUS]\n", progname);
 }
 

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -458,6 +458,7 @@ int process_arguments(int argc, char **argv){
 		{"warning", required_argument, 0, 'w'},
 		{"critical", required_argument, 0, 'c'},
 		{"timeout", required_argument, 0, 't'},
+		{"timeout-warning", no_argument, 0, 'T'},
 		{"hostname", required_argument, 0, 'H'},
 		{"port", required_argument, 0, 'p'},
 		{0, 0, 0, 0}
@@ -468,7 +469,7 @@ int process_arguments(int argc, char **argv){
 		usage ("\n");
 
 	while (1) {
-		c = getopt_long (argc, argv, "Vhv46qw:c:t:H:p:", longopts, &option);
+		c = getopt_long (argc, argv, "Vhv46qw:c:t:H:p:T", longopts, &option);
 		if (c == -1 || c == EOF || c == 1)
 			break;
 
@@ -503,6 +504,9 @@ int process_arguments(int argc, char **argv){
 			break;
 		case 't':
 			socket_timeout=atoi(optarg);
+			break;
+		case 'T':									/* Timeout will lead to a warning, not critical status */
+			socket_timeout_state = STATE_WARNING;
 			break;
 		case '4':
 			address_family = AF_INET;
@@ -617,6 +621,8 @@ void print_help(void){
 	printf (" %s\n", "-c, --critical=THRESHOLD");
 	printf ("    %s\n", _("Offset to result in critical status (seconds)"));
 	printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
+	printf (" %s\n", "-T, --timeout-warning");
+	printf ("   %s\n", _("Connection timeout will result in warning status instead of critical"));
 	printf (UT_VERBOSE);
 
 	printf("\n");
@@ -642,6 +648,6 @@ void
 print_usage(void)
 {
 	printf ("%s\n", _("Usage:"));
-	printf(" %s -H <host> [-4|-6] [-w <warn>] [-c <crit>] [-v verbose]\n", progname);
+	printf(" %s -H <host> [-4|-6] [-w <warn>] [-c <crit>] [-v verbose] [-t timeout] [-T]\n", progname);
 }
 

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -418,7 +418,7 @@ double offset_request(const char *host, int *status){
 	}
 
 	if (one_read == 0) {
-		die(STATE_CRITICAL, "NTP CRITICAL: No response from NTP server\n");
+		die(socket_timeout_state, _("NTP %s: No response from NTP server\n"), state_text (socket_timeout_state));
 	}
 
 	/* now, pick the best server from the list */

--- a/plugins/check_time.c
+++ b/plugins/check_time.c
@@ -198,7 +198,7 @@ process_arguments (int argc, char **argv)
 		{"port", required_argument, 0, 'p'},
 		{"udp", no_argument, 0, 'u'},
 		{"timeout", required_argument, 0, 't'},
-		{"timeout-warning", no_argument, 0, 'T'},
+		{"timeout-result", required_argument, 0, 'T'},
 		{"version", no_argument, 0, 'V'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
@@ -221,7 +221,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	while (1) {
-		c = getopt_long (argc, argv, "hVH:w:c:W:C:p:t:uT", longopts,
+		c = getopt_long (argc, argv, "hVH:w:c:W:C:p:t:uT:", longopts,
 									 &option);
 
 		if (c == -1 || c == EOF)
@@ -304,8 +304,9 @@ process_arguments (int argc, char **argv)
 			else
 				socket_timeout = atoi (optarg);
 			break;
-		case 'T':									/* Timeout will lead to a warning, not critical status */
-			socket_timeout_state = STATE_WARNING;
+		case 'T':     /* Result to return on timeouts */
+			if ((socket_timeout_state = mp_translate_state(optarg)) == ERROR)
+				usage4 (_("Timeout result must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer (0-3)."));
 			break;
 		case 'u':									/* udp */
 			use_udp = TRUE;
@@ -363,9 +364,8 @@ print_help (void)
   printf ("   %s\n", _("Response time (sec.) necessary to result in critical status"));
 
 	printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
-
-  printf (" %s\n", "-T, --timeout-warning");
-  printf ("   %s\n", _("Connection timeout will result in warning status instead of critical"));
+  printf (" %s\n", "-T, --timeout-result=STATUS");
+  printf ("   %s\n", _("Connection timeout will result in STATUS instead of critical"));
 
 	printf (UT_SUPPORT);
 }
@@ -377,5 +377,5 @@ print_usage (void)
 {
   printf ("%s\n", _("Usage:"));
 	printf ("%s -H <host_address> [-p port] [-u] [-w variance] [-c variance]\n",progname);
-  printf (" [-W connect_time] [-C connect_time] [-t timeout] [-T]\n");
+  printf (" [-W connect_time] [-C connect_time] [-t timeout] [-T STATUS]\n");
 }

--- a/plugins/check_time.c
+++ b/plugins/check_time.c
@@ -198,6 +198,7 @@ process_arguments (int argc, char **argv)
 		{"port", required_argument, 0, 'p'},
 		{"udp", no_argument, 0, 'u'},
 		{"timeout", required_argument, 0, 't'},
+		{"timeout-warning", no_argument, 0, 'T'},
 		{"version", no_argument, 0, 'V'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
@@ -220,7 +221,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	while (1) {
-		c = getopt_long (argc, argv, "hVH:w:c:W:C:p:t:u", longopts,
+		c = getopt_long (argc, argv, "hVH:w:c:W:C:p:t:uT", longopts,
 									 &option);
 
 		if (c == -1 || c == EOF)
@@ -303,6 +304,9 @@ process_arguments (int argc, char **argv)
 			else
 				socket_timeout = atoi (optarg);
 			break;
+		case 'T':									/* Timeout will lead to a warning, not critical status */
+			socket_timeout_state = STATE_WARNING;
+			break;
 		case 'u':									/* udp */
 			use_udp = TRUE;
 		}
@@ -360,6 +364,9 @@ print_help (void)
 
 	printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
 
+  printf (" %s\n", "-T, --timeout-warning");
+  printf ("   %s\n", _("Connection timeout will result in warning status instead of critical"));
+
 	printf (UT_SUPPORT);
 }
 
@@ -370,5 +377,5 @@ print_usage (void)
 {
   printf ("%s\n", _("Usage:"));
 	printf ("%s -H <host_address> [-p port] [-u] [-w variance] [-c variance]\n",progname);
-  printf (" [-W connect_time] [-C connect_time] [-t timeout]\n");
+  printf (" [-W connect_time] [-C connect_time] [-t timeout] [-T]\n");
 }

--- a/plugins/t/check_ntp.t
+++ b/plugins/t/check_ntp.t
@@ -10,8 +10,9 @@ use NPTest;
 
 my @PLUGINS1 = ('check_ntp', 'check_ntp_peer', 'check_ntp_time');
 my @PLUGINS2 = ('check_ntp_peer');
+my @PLUGINS3 = ('check_ntp_time');
 
-plan tests => (12 * scalar(@PLUGINS1)) + (6 * scalar(@PLUGINS2));
+plan tests => (12 * scalar(@PLUGINS1)) + (6 * scalar(@PLUGINS2)) + (2 * scalar(@PLUGINS3));
 
 my $res;
 
@@ -108,3 +109,20 @@ foreach my $plugin (@PLUGINS2) {
 		like( $res->output, $ntp_critmatch2, "$plugin: Output match CRITICAL with jitter, stratum, and truechimers" );
 	}
 }
+
+foreach my $plugin (@PLUGINS3) {
+
+	# -T parameter checks
+	$res = NPTest->testCmd(
+		"./$plugin -H $host_nonresponsive -t 1 -T UNKNOWN"
+		);
+	cmp_ok( $res->return_code, '==', 3, "$plugin: timeout with result status UNKNOWN check" );
+	
+	$res = NPTest->testCmd(
+		"./$plugin -H $host_nonresponsive -t 1 -T WARNING"
+		);
+	cmp_ok( $res->return_code, '==', 1, "$plugin: timeout with result status UNKNOWN check" );
+	
+
+}
+

--- a/plugins/t/check_time.t
+++ b/plugins/t/check_time.t
@@ -9,7 +9,7 @@ use Test;
 use NPTest;
 
 use vars qw($tests);
-BEGIN {$tests = 8; plan tests => $tests}
+BEGIN {$tests = 10; plan tests => $tests}
 
 my $host_udp_time      = getTestParameter( "host_udp_time",      "NP_HOST_UDP_TIME",      "localhost",
 					   "A host providing the UDP Time Service" );
@@ -36,6 +36,10 @@ $t += checkCmd( "./check_time    $host_udp_time -wt 59 -ct 59 -cd 999999 -wd 999
 # failure mode
 $t += checkCmd( "./check_time -H $host_nonresponsive -t 1", 2 );
 $t += checkCmd( "./check_time -H $hostname_invalid   -t 1", 3 );
+
+# -T parameter checks
+$t += checkCmd( "./check_time -H $host_nonresponsive   -t 1 -T UNKNOWN", 3 );
+$t += checkCmd( "./check_time -H $host_nonresponsive   -t 1 -T WARNING", 1 );
 
 exit(0) if defined($Test::Harness::VERSION);
 exit($tests - $t);


### PR DESCRIPTION
Connection timeout will result in warning status instead of critical

I want to compare my servers to a time server not in my control. When for an unknown reason the time server is not responding for me that is not actionable.