### PR TITLE
Remove the suggestion to run check_apt with --verbose since it doesn't d...

### DIFF
--- a/plugins/check_apt.c
+++ b/plugins/check_apt.c
@@ -124,7 +124,7 @@ int main (int argc, char **argv) {
 	       (stderr_warning)?" warnings detected":"",
 	       (stderr_warning && exec_warning)?",":"",
 	       (exec_warning)?" errors detected":"",
-	       (stderr_warning||exec_warning)?". run with -v for information.":"",
+	       (stderr_warning||exec_warning)?".":"",
 	        packages_available,
 		   sec_count
 	       );


### PR DESCRIPTION
...o anything

I'm tempted to remove --verbose as a flag for `check_apt` altogether since it doesn't do anything, but this at least removes the user-facing bits.
