### PR TITLE
check_apt: also check for HWE EOL status

### DIFF
--- a/plugins/check_apt.c
+++ b/plugins/check_apt.c
@@ -33,9 +33,7 @@ const char *progname = "check_apt";
 const char *copyright = "2006-2008";
 const char *email = "devel@monitoring-plugins.org";
 
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include "common.h"
 #include "runcmd.h"


### PR DESCRIPTION
In Ubuntu, LTS point releases ship with hardware enablement kernels and
X.org stacks backported from the latest corresponding non-LTS release by
default, so that users can continue to install and use the LTS release
on newer hardware.

These enablement packages have a shorter support lifetime than the LTS
release itself. The supported mechanism to continue with newer hardware
on LTS releases for the full LTS support lifetime period is to upgrade
to a newer hardware enablement package. This process must be manual,
however, since we do not want to risk regressing installations. We have
concluded that bumping the kernel and X.org versions is a major enough
change that it is not suitable for an automatic update.

Thus we must notify users of this need to update in any way we can, so
that they can take action.

We thought that the existing check_apt test is one appropriate place to
alert users that an update is available.

The underlying logic for the change to this plugin is:
1. Follow the existing behaviour to determine the number of updates and
   critical updates available.
2. If /usr/bin/hwe-support-status does not exist, do nothing different.
   This covers the case where users have not yet received the update that
   makes it available, or are using a distribution that does not provide
   HWE packs (eg. Debian currently).
3. Given that /usr/bin/hwe-support-status does exist, run it with
   --quiet. If an update is required, it will exit with a non-zero status.
4. If an update is required, bump the number of "critical updates"
   detected.
5. Report this as normal.
6. I expect a user who wants more information to run "check_apt -v". In
   this case, /usr/bin/hwe-support-status is run with --verbose and its
   output is printed. This prints a human-readable EOL notification
   message with more information. On Ubuntu, this links to a wiki page
   which we can update with any frequently asked questions.

Though the need for this patch comes from Ubuntu, I've written it in a
way that Debian could use the same mechanism in future. There are no
Ubuntu-specific parts in this patch itself.

More information:

https://launchpad.net/bugs/1244438
https://wiki.ubuntu.com/HweStackEolNotifications
https://wiki.ubuntu.com/1204_HWE_EOL
https://wiki.ubuntu.com/Kernel/LTSEnablementStack
https://blueprints.launchpad.net/ubuntu/+spec/core-1403-hwe-stack-eol-notifications
