### PR TITLE
check_procs: Add delay after forking in test

### DIFF
--- a/plugins/t/check_procs.t
+++ b/plugins/t/check_procs.t
@@ -26,7 +26,7 @@ $result = NPTest->testCmd( "./check_procs -w 100000 -c 100000 -s Z" );
 is( $result->return_code, 0, "Checking less than 100000 zombie processes" );
 like( $result->output, '/^PROCS OK: [0-9]+ process(es)? with /', "Output correct" );
 
-if(fork() == 0) { exec("sleep 7"); } # fork a test process
+if(fork() == 0) { exec("sleep 7"); } else { sleep(1) } # fork a test process in child and give child time to fork in parent
 $result = NPTest->testCmd( "./check_procs -a 'sleep 7'" );
 is( $result->return_code, 0, "Parent process is ignored" );
 like( $result->output, '/^PROCS OK: 1 process?/', "Output correct" );


### PR DESCRIPTION
Forking raises a race condition, where the parent might run the
test before the child has had time to fork. If that happens,
an error similar to this is produced:
 Failed test 'Output correct'
 at ./t/check_procs.t line 32.
                 'PROCS OK: 0 processes with args 'sleep 7' | processes=0;;;0;'
   doesn't match '/^PROCS OK: 1 process?/'

Sleeping a bit should avoid the problem. It might be enough to
sleep less than a second, but perl's built-in sleep function only
supports integer seconds.

In our build environment, the build failed 3 of 4 times before
this patch. After the patch it failed 0 of 7 times.

Signed-off-by: Mikael Falkvidd mfalkvidd@op5.com
