### PR TITLE
lib/utils_base.c: if asprintf fails, string is undefined

### DIFF
--- a/lib/utils_base.c
+++ b/lib/utils_base.c
@@ -477,7 +477,7 @@ void np_enable_state(char *keyname, int expected_data_version) {
 	this_state->state_data=NULL;
 
 	/* Calculate filename */
-	ret = asprintf(&temp_filename, "%s/%lu/%s/%s",
+	ret = xasprintf(&temp_filename, "%s/%lu/%s/%s",
 	    _np_state_calculate_location_prefix(), (unsigned long)geteuid(),
 	    this_monitoring_plugin->plugin_name, this_state->name);
 	if (ret < 0)
@@ -619,7 +619,7 @@ void np_state_write_string(time_t data_time, char *data_string) {
 	
 	/* If file doesn't currently exist, create directories */
 	if(access(this_monitoring_plugin->state->_filename,F_OK)!=0) {
-		result = asprintf(&directories, "%s", this_monitoring_plugin->state->_filename);
+		result = xasprintf(&directories, "%s", this_monitoring_plugin->state->_filename);
 		if(result < 0)
 			die(STATE_UNKNOWN, _("Cannot allocate memory: %s"),
 			    strerror(errno));
@@ -638,7 +638,7 @@ void np_state_write_string(time_t data_time, char *data_string) {
 		np_free(directories);
 	}
 
-	result = asprintf(&temp_file,"%s.XXXXXX",this_monitoring_plugin->state->_filename);
+	result = xasprintf(&temp_file,"%s.XXXXXX",this_monitoring_plugin->state->_filename);
 	if(result < 0)
 		die(STATE_UNKNOWN, _("Cannot allocate memory: %s"),
 		    strerror(errno));


### PR DESCRIPTION
if asprintf fails, string content becomes invalid. we need
to check if it ran OK by checking the returned value.

in case of fail, asprintf returns -1, otherwise the number
of writen bytes is returned.

also, on ubuntu 13.10 i've receiving a lot of warnings:

"warning: ignoring return value of ‘asprintf’"

this patches fixes some of them
## Signed-off-by: Ricardo Maraschini ricardo.maraschini@gmail.com

Closes #1227
