### PR TITLE
Fix generate change log

### DIFF
--- a/tools/generate-change-log
+++ b/tools/generate-change-log
@@ -19,6 +19,7 @@ use Text::Wrap;
 
 # The lines will have a length of no more than $columns - 1.
 $Text::Wrap::columns = 81;
+$Text::Wrap::huge    = 'overflow';
 
 if (system('git rev-parse --git-dir >/dev/null 2>&1') != 0) {
 	print "Not a Git repository, so I won't update the ChangeLog.\n";


### PR DESCRIPTION
workaround for broken Text::Wrap:
"This shouldn't happen at /usr/share/perl/5.18/Text/Wrap.pm line 84."
changing huge to overflow make generating changelogs work again at
the price of not having changelog strictly cut of at 80 columns
anymore. Words longer than 80 characters will now printed in one
line. This mainly affects old sf.net urls.
