### PR TITLE
check_file_age: add option to provide perf data

### DIFF
--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -92,7 +92,7 @@ unless (-e $opt_f) {
 $st = File::stat::stat($opt_f);
 $age = time - $st->mtime;
 $size = $st->size;
-$perfdata = "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};min=0";
+$perfdata = "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0";
 
 
 $result = 'OK';

--- a/plugins-scripts/t/check_file_age.t
+++ b/plugins-scripts/t/check_file_age.t
@@ -12,7 +12,7 @@ my $successOutput = '/^FILE_AGE OK: /';
 my $warningOutput = '/^FILE_AGE WARNING: /';
 my $criticalOutput = '/^FILE_AGE CRITICAL: /';
 my $unknownOutput = '/^FILE_AGE UNKNOWN: /';
-my $performanceOutput = '/ \| age=[0-9]+s;[0-9]+;[0-9]+ size=[0-9]+B;[0-9]+;[0-9]+;min=0$/';
+my $performanceOutput = '/ \| age=[0-9]+s;[0-9]+;[0-9]+ size=[0-9]+B;[0-9]+;[0-9]+;0$/';
 
 my $result;
 my $temp_file = "/tmp/check_file_age.tmp";


### PR DESCRIPTION
with this change you can add the option -p or --performance-data,
to add the performance data to the plugin output:
    age=2414351s;size=0B
