### PR TITLE
Exit on stderr

### DIFF
--- a/lib/utils_cmd.c
+++ b/lib/utils_cmd.c
@@ -116,14 +116,6 @@ cmd_init (void)
 	}
 #endif
 
-	/* if maxfd is unnaturally high, force it to a lower value
-	* ( e.g. on SunOS, when ulimit is set to unlimited: 2147483647 this would cause
-	* a segfault when following calloc is called ...  ) */
-
-	if ( maxfd > 2048 ) {
-		maxfd = 2048;
-	}
-
 	if (!_cmd_pids)
 		_cmd_pids = calloc (maxfd, sizeof (pid_t));
 }


### PR DESCRIPTION
We need the option  to bail out with an error, if there is something on stdout.
E.g. someone is defining: 

```
stty erase ^H
```

without any checks in the users profile (.bashrc or .profile)

Sorry for the GIT hussle
