### PR TITLE
check_ssh: patches from op5

### DIFF
--- a/plugins/check_ssh.c
+++ b/plugins/check_ssh.c
@@ -278,11 +278,35 @@ ssh_connect (char *haddr, int hport, char *remote_version, char *remote_protocol
 		printf("SSH CRITICAL - No version control string received");
 		exit(STATE_CRITICAL);
 	}
+	/*
+	 * "When the connection has been established, both sides MUST send an
+	 * identification string.  This identification string MUST be
+	 *
+	 * SSH-protoversion-softwareversion SP comments CR LF"
+	 *		- RFC 4253:4.2
+	 */
 	strip (version_control_string);
 	if (verbose)
 		printf ("%s\n", version_control_string);
 	ssh_proto = version_control_string + 4;
-	ssh_server = ssh_proto + strspn (ssh_proto, "-0123456789.");
+
+	/*
+	 * We assume the protoversion is of the form Major.Minor, although
+	 * this is not _strictly_ required. See
+	 *
+	 * "Both the 'protoversion' and 'softwareversion' strings MUST consist of
+	 * printable US-ASCII characters, with the exception of whitespace
+	 * characters and the minus sign (-)"
+	 *		- RFC 4253:4.2
+	 * and,
+	 *
+	 * "As stated earlier, the 'protoversion' specified for this protocol is
+	 * "2.0".  Earlier versions of this protocol have not been formally
+	 * documented, but it is widely known that they use 'protoversion' of
+	 * "1.x" (e.g., "1.5" or "1.3")."
+	 *		- RFC 4253:5
+	 */
+	ssh_server = ssh_proto + strspn (ssh_proto, "0123456789.") + 1; /* (+1 for the '-' separating protoversion from softwareversion) */
 
 	/* If there's a space in the version string, whatever's after the space is a comment
 	 * (which is NOT part of the server name/version)*/

--- a/plugins/check_ssh.c
+++ b/plugins/check_ssh.c
@@ -215,8 +215,13 @@ ssh_connect (char *haddr, int hport, char *remote_version, char *remote_protocol
 {
 	int sd;
 	int result;
+	int len = 0;
+	ssize_t byte_offset = 0;
+	ssize_t recv_ret = 0;
+	char *version_control_string = NULL;
 	char *output = NULL;
 	char *buffer = NULL;
+	char *tmp= NULL, *saveptr = NULL;
 	char *ssh_proto = NULL;
 	char *ssh_server = NULL;
 	static char *rev_no = VERSION;
@@ -231,51 +236,94 @@ ssh_connect (char *haddr, int hport, char *remote_version, char *remote_protocol
 		return result;
 
 	output = (char *) malloc (BUFF_SZ + 1);
-	memset (output, 0, BUFF_SZ + 1);
-	recv (sd, output, BUFF_SZ, 0);
-	if (strncmp (output, "SSH", 3)) {
-		printf (_("Server answer: %s"), output);
+	memset(output, 0, BUFF_SZ+1);
+	while (!version_control_string && (recv_ret = recv(sd, output+byte_offset, BUFF_SZ - byte_offset, 0)) > 0) {
+		if (strchr(output, '\n')) { /* we've got at least one full line, start parsing*/
+			byte_offset = 0;
+			while (strchr(output+byte_offset, '\n') != NULL) {
+				/*Partition the buffer so that this line is a separate string,
+				 * by replacing the newline with NUL*/
+				output[(strchr(output+byte_offset, '\n')-output)]= '\0';
+				len = strlen(output+byte_offset);
+				if (len >= 4) {
+					/*if the string starts with SSH-, this _should_ be a valid version control string*/
+					if (strncmp (output+byte_offset, "SSH-", 4) == 0) {
+						version_control_string = output+byte_offset;
+						break;
+					}
+				}
+
+				/*the start of the next line (if one exists) will be after the current one (+ NUL)*/
+				byte_offset+=len+1;
+			}
+			if(!version_control_string) {
+				/* move unconsumed data to beginning of buffer, null rest */
+				memmove((void *)output, (void *)output+byte_offset+1, BUFF_SZ - len+1);
+				memset(output+byte_offset+1, 0, BUFF_SZ-byte_offset+1);
+
+				/*start reading from end of current line chunk on next recv*/
+				byte_offset = strlen(output);
+			}
+		}
+		else {
+			byte_offset += recv_ret;
+		}
+	}
+	tmp = NULL;
+	if (recv_ret < 0) {
+		printf("SSH CRITICAL - %s", strerror(errno));
+		exit(STATE_CRITICAL);
+	}
+	if (!version_control_string) {
+		printf("SSH CRITICAL - No version control string received");
+		exit(STATE_CRITICAL);
+	}
+	strip (version_control_string);
+	if (verbose)
+		printf ("%s\n", version_control_string);
+	ssh_proto = version_control_string + 4;
+	ssh_server = ssh_proto + strspn (ssh_proto, "-0123456789.");
+
+	/* If there's a space in the version string, whatever's after the space is a comment
+	 * (which is NOT part of the server name/version)*/
+	tmp = strchr(ssh_server, ' ');
+	if (tmp) {
+		ssh_server[tmp - ssh_server] = '\0';
+	}
+	if (strlen(ssh_proto) == 0 || strlen(ssh_server) == 0) {
+		printf(_("SSH CRITICAL - Invalid protocol version control string %s\n"), version_control_string);
+		exit (STATE_CRITICAL);
+	}
+	ssh_proto[strspn (ssh_proto, "0123456789. ")] = 0;
+
+	xasprintf (&buffer, "SSH-%s-check_ssh_%s\r\n", ssh_proto, rev_no);
+	send (sd, buffer, strlen (buffer), MSG_DONTWAIT);
+	if (verbose)
+		printf ("%s\n", buffer);
+
+	if (remote_version && strcmp(remote_version, ssh_server)) {
+		printf
+			(_("SSH CRITICAL - %s (protocol %s) version mismatch, expected '%s'\n"),
+			 ssh_server, ssh_proto, remote_version);
 		close(sd);
 		exit (STATE_CRITICAL);
 	}
-	else {
-		strip (output);
-		if (verbose)
-			printf ("%s\n", output);
-		ssh_proto = output + 4;
-		ssh_server = ssh_proto + strspn (ssh_proto, "-0123456789. ");
-		ssh_proto[strspn (ssh_proto, "0123456789. ")] = 0;
 
-		xasprintf (&buffer, "SSH-%s-check_ssh_%s\r\n", ssh_proto, rev_no);
-		send (sd, buffer, strlen (buffer), MSG_DONTWAIT);
-		if (verbose)
-			printf ("%s\n", buffer);
-
-		if (remote_version && strcmp(remote_version, ssh_server)) {
-			printf
-				(_("SSH CRITICAL - %s (protocol %s) version mismatch, expected '%s'\n"),
-				 ssh_server, ssh_proto, remote_version);
-			close(sd);
-			exit (STATE_CRITICAL);
-		}
-
-		if (remote_protocol && strcmp(remote_protocol, ssh_proto)) {
-			printf
-				(_("SSH CRITICAL - %s (protocol %s) protocol version mismatch, expected '%s'\n"),
-				 ssh_server, ssh_proto, remote_protocol);
-			close(sd);
-			exit (STATE_CRITICAL);
-		}
-
-		elapsed_time = (double)deltime(tv) / 1.0e6;
-
+	if (remote_protocol && strcmp(remote_protocol, ssh_proto)) {
 		printf
-			(_("SSH OK - %s (protocol %s) | %s\n"),
-			 ssh_server, ssh_proto, fperfdata("time", elapsed_time, "s",
-			 FALSE, 0, FALSE, 0, TRUE, 0, TRUE, (int)socket_timeout));
+			(_("SSH CRITICAL - %s (protocol %s) protocol version mismatch, expected '%s'\n"),
+			 ssh_server, ssh_proto, remote_protocol);
 		close(sd);
-		exit (STATE_OK);
+		exit (STATE_CRITICAL);
 	}
+	elapsed_time = (double)deltime(tv) / 1.0e6;
+
+	printf
+		(_("SSH OK - %s (protocol %s) | %s\n"),
+		 ssh_server, ssh_proto, fperfdata("time", elapsed_time, "s",
+			 FALSE, 0, FALSE, 0, TRUE, 0, TRUE, (int)socket_timeout));
+	close(sd);
+	exit (STATE_OK);
 }
 
 

--- a/plugins/check_ssh.c
+++ b/plugins/check_ssh.c
@@ -106,7 +106,7 @@ process_arguments (int argc, char **argv)
 		{"timeout", required_argument, 0, 't'},
 		{"verbose", no_argument, 0, 'v'},
 		{"remote-version", required_argument, 0, 'r'},
-		{"remote-protcol", required_argument, 0, 'P'},
+		{"remote-protocol", required_argument, 0, 'P'},
 		{0, 0, 0, 0}
 	};
 

--- a/plugins/t/check_ssh.t
+++ b/plugins/t/check_ssh.t
@@ -92,19 +92,16 @@ SKIP {
 	cmp_ok($result->return_code, '==', 0, "Exit with return code 0 (OK)");
 	like($result->output, '/^SSH OK - /', "Status text if command returned none (OK)");
 
-
 	$res = NPTest->testCmd(
 	    "./check_ssh -H $host_nonresponsive -t 2"
 	    );
-	cmp_ok($result->return_code, '==', 2, "Exit with return code 0 (OK)");
+	cmp_ok($result->return_code, '==', 2, "Exit with return code 2 (CRITICAL)");
 	like($result->output, '/^CRITICAL - Socket timeout after 2 seconds/', "Status text if command returned none (OK)");
-
-
 
 	$res = NPTest->testCmd(
 	    "./check_ssh -H $hostname_invalid -t 2"
 	    );
-	cmp_ok($result->return_code, '==', 3, "Exit with return code 0 (OK)");
+	cmp_ok($result->return_code, '==', 3, "Exit with return code 3 (UNKNOWN)");
 	like($result->output, '/^check_ssh: Invalid hostname/', "Status text if command returned none (OK)");
 
 }

--- a/plugins/t/check_ssh.t
+++ b/plugins/t/check_ssh.t
@@ -12,7 +12,6 @@ use NPTest;
 my $ssh_host           = getTestParameter("NP_SSH_HOST",
                                           "A host providing SSH service",
                                           "localhost");
-
 my $host_nonresponsive = getTestParameter("NP_HOST_NONRESPONSIVE",
                                           "The hostname of system not responsive to network requests",
                                           "10.0.0.1" );
@@ -21,29 +20,91 @@ my $hostname_invalid   = getTestParameter("NP_HOSTNAME_INVALID",
                                           "An invalid (not known to DNS) hostname",
                                           "nosuchhost" );
 
-
-plan skip_all => "SSH_HOST must be defined" unless $ssh_host;
-plan tests    => 6;
+my $res;
 
 
-my $result = NPTest->testCmd(
-    "./check_ssh -H $ssh_host"
-    );
-cmp_ok($result->return_code, '==', 0, "Exit with return code 0 (OK)");
-like($result->output, '/^SSH OK - /', "Status text if command returned none (OK)");
+plan tests => 18;
+SKIP: {
+
+	skip "No netcat available", 12 unless (system("which nc > /dev/null") == 0);
+
+	my $nc_flags = "-l 5003 -i 1";
+	#A valid protocol version control string has the form
+	#       SSH-protoversion-softwareversion SP comments CR LF
+	#
+	# where `comments` is optional, protoversion is the SSH protocol version and
+	# softwareversion is an arbitrary string representing the server software version
+	open(NC, "echo 'SSH-2.0-nagiosplug.ssh.0.1' | nc ${nc_flags}|");
+	sleep 1;
+	$res = NPTest->testCmd( "./check_ssh -H localhost -p 5003" );
+	cmp_ok( $res->return_code, '==', 0, "Got SSH protocol version control string");
+	like( $res->output, '/^SSH OK - nagiosplug.ssh.0.1 \(protocol 2.0\)/', "Output OK");
+	close NC;
+
+	open(NC, "echo 'SSH-2.0-nagiosplug.ssh.0.1 this is a comment' | nc ${nc_flags} |");
+	sleep 1;
+	$res = NPTest->testCmd( "./check_ssh -H localhost -p 5003 -r nagiosplug.ssh.0.1" );
+	cmp_ok( $res->return_code, '==', 0, "Got SSH protocol version control string, and parsed comment appropriately");
+	like( $res->output, '/^SSH OK - nagiosplug.ssh.0.1 \(protocol 2.0\)/', "Output OK");
+	close NC;
 
 
-$result = NPTest->testCmd(
-    "./check_ssh -H $host_nonresponsive -t 2"
-    );
-cmp_ok($result->return_code, '==', 2, "Exit with return code 0 (OK)");
-like($result->output, '/^CRITICAL - Socket timeout after 2 seconds/', "Status text if command returned none (OK)");
+	open(NC, "echo 'SSH-' | nc ${nc_flags}|");
+	sleep 1;
+	$res = NPTest->testCmd( "./check_ssh -H localhost -p 5003" );
+	cmp_ok( $res->return_code, '==', 2, "Got invalid SSH protocol version control string");
+	like( $res->output, '/^SSH CRITICAL/', "Output OK");
+	close NC;
+
+	open(NC, "echo '' | nc ${nc_flags}|");
+	sleep 1;
+	$res = NPTest->testCmd( "./check_ssh -H localhost -p 5003" );
+	cmp_ok( $res->return_code, '==', 2, "No version control string received");
+	like( $res->output, '/^SSH CRITICAL - No version control string received/', "Output OK");
+	close NC;
+
+	open(NC, "echo 'Not a version control string' | nc ${nc_flags}|");
+	sleep 1;
+	$res = NPTest->testCmd( "./check_ssh -H localhost -p 5003" );
+	cmp_ok( $res->return_code, '==', 2, "No version control string received");
+	like( $res->output, '/^SSH CRITICAL - No version control string received/', "Output OK");
+	close NC;
+
+
+	#RFC 4253 permits servers to send any number of data lines prior to sending the protocol version control string
+	open(NC, "echo 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n
+		BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\n
+		CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC\n
+		DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD\n
+		Some\nPrepended\nData\nLines\nSSH-2.0-nagiosplug.ssh.0.2' | nc ${nc_flags}|");
+	sleep 1;
+	$res = NPTest->testCmd( "./check_ssh -H localhost -p 5003" );
+	cmp_ok( $res->return_code, '==', 0, "Got delayed SSH protocol version control string");
+	like( $res->output, '/^SSH OK - nagiosplug.ssh.0.2 \(protocol 2.0\)/', "Output OK");
+	close NC;
+}
+
+SKIP {
+	skip "SSH_HOST must be defined", 6 unless $ssh_host;
+	$res = NPTest->testCmd(
+	    "./check_ssh -H $ssh_host"
+	    );
+	cmp_ok($result->return_code, '==', 0, "Exit with return code 0 (OK)");
+	like($result->output, '/^SSH OK - /', "Status text if command returned none (OK)");
+
+
+	$res = NPTest->testCmd(
+	    "./check_ssh -H $host_nonresponsive -t 2"
+	    );
+	cmp_ok($result->return_code, '==', 2, "Exit with return code 0 (OK)");
+	like($result->output, '/^CRITICAL - Socket timeout after 2 seconds/', "Status text if command returned none (OK)");
 
 
 
-$result = NPTest->testCmd(
-    "./check_ssh -H $hostname_invalid -t 2"
-    );
-cmp_ok($result->return_code, '==', 3, "Exit with return code 0 (OK)");
-like($result->output, '/^check_ssh: Invalid hostname/', "Status text if command returned none (OK)");
+	$res = NPTest->testCmd(
+	    "./check_ssh -H $hostname_invalid -t 2"
+	    );
+	cmp_ok($result->return_code, '==', 3, "Exit with return code 0 (OK)");
+	like($result->output, '/^check_ssh: Invalid hostname/', "Status text if command returned none (OK)");
 
+}


### PR DESCRIPTION
Here are a few check_ssh patches that I've written in response to various bug reports we've received at op5. I apparently put off sending them upstream for too long, because I had a couple of merge conflicts. If you're able to run the tests before merging, that'd probably be a good idea, in the case of a mismerge.
