### PR TITLE
* check_snmp.c: switched DEFAULT_TIMEOUT to DEFAULT_SOCKET_TIMEOUT (prov...

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -292,8 +292,8 @@ main (int argc, char **argv)
       get_stats (path, &fsp);
 
       if (verbose >= 3) {
-        printf ("For %s, used_pct=%g free_pct=%g used_units=%g free_units=%g total_units=%g used_inodes_pct=%g free_inodes_pct=%g fsp.fsu_blocksize=%llu mult=%llu\n",
-          me->me_mountdir, path->dused_pct, path->dfree_pct, path->dused_units, path->dfree_units, path->dtotal_units, path->dused_inodes_percent, path->dfree_inodes_percent, fsp.fsu_blocksize, mult);
+        printf ("For %s, used_pct=%g free_pct=%g used_units=%g free_units=%g total_units=%g used_inodes_pct=%g free_inodes_pct=%g fsp.fsu_blocksize=%ju mult=%ju\n",
+          me->me_mountdir, path->dused_pct, path->dfree_pct, path->dused_units, path->dfree_units, path->dtotal_units, path->dused_inodes_percent, path->dfree_inodes_percent, (uintmax_t)fsp.fsu_blocksize, (uintmax_t)mult);
       }
 
       /* Threshold comparisons */
@@ -1043,9 +1043,9 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
         get_fs_usage (p_list->best_match->me_mountdir, p_list->best_match->me_devname, &tmpfsp);
         get_path_stats(p_list, &tmpfsp); 
         if (verbose >= 3)
-          printf("Group %s: adding %llu blocks sized %llu, (%s) used_units=%g free_units=%g total_units=%g fsu_blocksize=%llu mult=%llu\n",
-                 p_list->group, tmpfsp.fsu_bavail, tmpfsp.fsu_blocksize, p_list->best_match->me_mountdir, p_list->dused_units, p_list->dfree_units,
-                 p_list->dtotal_units, mult);
+          printf("Group %s: adding %ju blocks sized %ju, (%s) used_units=%g free_units=%g total_units=%g fsu_blocksize=%ju mult=%ju\n",
+                 p_list->group, (uintmax_t)tmpfsp.fsu_bavail, (uintmax_t)tmpfsp.fsu_blocksize, p_list->best_match->me_mountdir, p_list->dused_units, 
+                 p_list->dfree_units, p_list->dtotal_units, (uintmax_t)tmpfsp.fsu_blocksize, (uintmax_t)mult);
 
         /* prevent counting the first FS of a group twice since its parameter_list entry 
          * is used to carry the information of all file systems of the entire group */
@@ -1064,9 +1064,8 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
         first = 0;
       }
       if (verbose >= 3) 
-        printf("Group %s now has: used_units=%g free_units=%g total_units=%g fsu_blocksize=%llu mult=%llu\n",
-               p->group, tmpfsp.fsu_bavail, tmpfsp.fsu_blocksize, p->best_match->me_mountdir, p->dused_units,
-               p->dfree_units, p->dtotal_units, mult);
+        printf("Group %s now has: used_units=%g free_units=%g total_units=%g fsu_blocksize=%ju mult=%ju\n",
+               p->group, p->dused_units, p->dfree_units, p->dtotal_units, (uintmax_t)tmpfsp.fsu_blocksize, (uintmax_t)mult);
     }
     /* modify devname and mountdir for output */
     p->best_match->me_mountdir = p->best_match->me_devname = p->group;

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -41,7 +41,6 @@ const char *email = "devel@monitoring-plugins.org";
 #define DEFAULT_PORT "161"
 #define DEFAULT_MIBLIST "ALL"
 #define DEFAULT_PROTOCOL "1"
-#define DEFAULT_TIMEOUT 1
 #define DEFAULT_RETRIES 5
 #define DEFAULT_AUTH_PROTOCOL "MD5"
 #define DEFAULT_PRIV_PROTOCOL "DES"
@@ -227,7 +226,7 @@ main (int argc, char **argv)
 	outbuff = strdup ("");
 	delimiter = strdup (" = ");
 	output_delim = strdup (DEFAULT_OUTPUT_DELIMITER);
-	timeout_interval = DEFAULT_TIMEOUT;
+	timeout_interval = DEFAULT_SOCKET_TIMEOUT;
 	retries = DEFAULT_RETRIES;
 
 	np_init( (char *) progname, argc, argv );


### PR DESCRIPTION
As noted in issue #1318 there's an inconsistency between help function (uses constanct DEFAULT_SOCKET_TIMEOUT from utils.h) and actual code (uses DEFAULT_TIMEOUT constant)

So i removed DEFAULT_TIMEOUT and added DEFAULT_SOCKET_TIMEOUT to timeout_interval
