### PR TITLE
check_fping: autodetect ipv6 addresses

### DIFF
--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -105,7 +105,7 @@ main (int argc, char **argv)
     xasprintf(&option_string, "%s-I %s ", option_string, sourceif);
 
 #ifdef PATH_TO_FPING6
-  if (address_family == AF_INET6)
+  if (address_family != AF_INET && is_inet6_addr(server))
     fping_prog = strdup(PATH_TO_FPING6);
   else
     fping_prog = strdup(PATH_TO_FPING);


### PR DESCRIPTION
Stole the logic in check_ping that allows it to autodetect whether an
address is ipv6 or not. Now the user does not have to specify -6 when
using check_fping with ipv6 addresses.