### PR TITLE
check_http:Adds a new option to enforce TLSv1.2+

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -344,8 +344,8 @@ process_arguments (int argc, char **argv)
       use_ssl = TRUE;
       if (c=='S' && optarg != NULL) {
         ssl_version = atoi(optarg);
-        if (ssl_version < 1 || ssl_version > 3)
-            usage4 (_("Invalid option - Valid values for SSL Version are 1 (TLSv1), 2 (SSLv2) or 3 (SSLv3)"));
+        if (ssl_version < 1 || ssl_version > 4)
+            usage4 (_("Invalid option - Valid values for SSL Version are 1 (TLSv1.0), 2 (SSLv2), 3 (SSLv3) or 4 (TLSv1.2+)"));
       }
       if (specify_port == FALSE)
         server_port = HTTPS_PORT;
@@ -1468,8 +1468,8 @@ print_help (void)
 
 #ifdef HAVE_SSL
   printf (" %s\n", "-S, --ssl=VERSION");
-  printf ("    %s\n", _("Connect via SSL. Port defaults to 443. VERSION is optional, and prevents"));
-  printf ("    %s\n", _("auto-negotiation (1 = TLSv1, 2 = SSLv2, 3 = SSLv3)."));
+  printf ("    %s\n", _("Connect via SSL. Port defaults to 443. VERSION is optional, and forces a"));
+  printf ("    %s\n", _("particular version (1 = TLSv1.0, 2 = SSLv2, 3 = SSLv3, 4 = TLSv1.2+)."));
   printf (" %s\n", "--sni");
   printf ("    %s\n", _("Enable SSL/TLS hostname extension support (SNI)"));
   printf (" %s\n", "-C, --certificate=INTEGER[,INTEGER]");

--- a/po/de.po
+++ b/po/de.po
@@ -1160,8 +1160,8 @@ msgstr "Ungültiger Zertifikatsablauftermin"
 
 #: plugins/check_http.c:348
 msgid ""
-"Invalid option - Valid values for SSL Version are 1 (TLSv1), 2 (SSLv2) or 3 "
-"(SSLv3)"
+"Invalid option - Valid values for SSL Version are 1 (TLSv1.0), 2 (SSLv2), 3 (SSLv3) "
+"or 4 (TLSv1.2+)"
 msgstr ""
 
 #: plugins/check_http.c:354 plugins/check_tcp.c:599
@@ -1420,11 +1420,11 @@ msgstr ""
 
 #: plugins/check_http.c:1469
 msgid ""
-"Connect via SSL. Port defaults to 443. VERSION is optional, and prevents"
+"Connect via SSL. Port defaults to 443. VERSION is optional, and forces a"
 msgstr ""
 
 #: plugins/check_http.c:1470
-msgid "auto-negotiation (1 = TLSv1, 2 = SSLv2, 3 = SSLv3)."
+msgid "particular version (1 = TLSv1.0, 2 = SSLv2, 3 = SSLv3, 4 = TLSv1.2+)."
 msgstr ""
 
 #: plugins/check_http.c:1472

--- a/po/fr.po
+++ b/po/fr.po
@@ -1198,8 +1198,8 @@ msgstr "Période d'expiration du certificat invalide"
 
 #: plugins/check_http.c:348
 msgid ""
-"Invalid option - Valid values for SSL Version are 1 (TLSv1), 2 (SSLv2) or 3 "
-"(SSLv3)"
+"Invalid option - Valid values for SSL Version are 1 (TLSv1.0), 2 (SSLv2), 3 (SSLv3) "
+"or 4 (TLSv1.2+)"
 msgstr ""
 
 #: plugins/check_http.c:354 plugins/check_tcp.c:599
@@ -1460,11 +1460,11 @@ msgstr "Numéro du port (défaut: "
 
 #: plugins/check_http.c:1469
 msgid ""
-"Connect via SSL. Port defaults to 443. VERSION is optional, and prevents"
+"Connect via SSL. Port defaults to 443. VERSION is optional, and forces a"
 msgstr ""
 
 #: plugins/check_http.c:1470
-msgid "auto-negotiation (1 = TLSv1, 2 = SSLv2, 3 = SSLv3)."
+msgid "particular version (1 = TLSv1.0, 2 = SSLv2, 3 = SSLv3, 4 = TLSv1.2+)."
 msgstr ""
 
 #: plugins/check_http.c:1472

--- a/po/monitoring-plugins.pot
+++ b/po/monitoring-plugins.pot
@@ -1121,8 +1121,8 @@ msgstr ""
 
 #: plugins/check_http.c:348
 msgid ""
-"Invalid option - Valid values for SSL Version are 1 (TLSv1), 2 (SSLv2) or 3 "
-"(SSLv3)"
+"Invalid option - Valid values for SSL Version are 1 (TLSv1.0), 2 (SSLv2), 3 (SSLv3) "
+"or 4 (TLSv1.2+)"
 msgstr ""
 
 #: plugins/check_http.c:354 plugins/check_tcp.c:599
@@ -1372,11 +1372,11 @@ msgstr ""
 
 #: plugins/check_http.c:1469
 msgid ""
-"Connect via SSL. Port defaults to 443. VERSION is optional, and prevents"
+"Connect via SSL. Port defaults to 443. VERSION is optional, and forces a"
 msgstr ""
 
 #: plugins/check_http.c:1470
-msgid "auto-negotiation (1 = TLSv1, 2 = SSLv2, 3 = SSLv3)."
+msgid "particular version (1 = TLSv1.0, 2 = SSLv2, 3 = SSLv3, 4 = TLSv1.2+)."
 msgstr ""
 
 #: plugins/check_http.c:1472


### PR DESCRIPTION
(allowing it to autodetect and connect to future protocol versions)

Closes #1338