### PR TITLE
drop superfluous libexecdir

### DIFF
--- a/plugins-scripts/check_breeze.pl
+++ b/plugins-scripts/check_breeze.pl
@@ -6,7 +6,6 @@ use Getopt::Long;
 use vars qw($opt_V $opt_h $opt_w $opt_c $opt_H $opt_C $PROGNAME);
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw(%ERRORS &print_revision &support &usage);
 
 $PROGNAME = "check_breeze";

--- a/plugins-scripts/check_disk_smb.pl
+++ b/plugins-scripts/check_disk_smb.pl
@@ -26,7 +26,6 @@ use vars qw($opt_P $opt_V $opt_h $opt_H $opt_s $opt_W $opt_u $opt_p $opt_w $opt_
 use vars qw($PROGNAME);
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw($TIMEOUT %ERRORS &print_revision &support &usage);
 
 sub print_help ();

--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -27,7 +27,6 @@ use File::stat;
 use vars qw($PROGNAME);
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw (%ERRORS &print_revision &support);
 
 sub print_help ();

--- a/plugins-scripts/check_flexlm.pl
+++ b/plugins-scripts/check_flexlm.pl
@@ -37,7 +37,6 @@ use Getopt::Long;
 use vars qw($opt_V $opt_h $opt_F $opt_t $verbose $PROGNAME);
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw(%ERRORS &print_revision &support &usage);
 
 $PROGNAME="check_flexlm";

--- a/plugins-scripts/check_ifoperstatus.pl
+++ b/plugins-scripts/check_ifoperstatus.pl
@@ -37,7 +37,6 @@ use POSIX;
 use strict;
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw($TIMEOUT %ERRORS &print_revision &support);
 
 use Net::SNMP;

--- a/plugins-scripts/check_ifstatus.pl
+++ b/plugins-scripts/check_ifstatus.pl
@@ -35,7 +35,6 @@ use POSIX;
 use strict;
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw($TIMEOUT %ERRORS &print_revision &support);
 
 use Net::SNMP;

--- a/plugins-scripts/check_ircd.pl
+++ b/plugins-scripts/check_ircd.pl
@@ -51,7 +51,6 @@ use vars qw($opt_V $opt_h $opt_t $opt_p $opt_H $opt_w $opt_c $verbose);
 use vars qw($PROGNAME);
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw($TIMEOUT %ERRORS &print_revision &support &usage);
 
 # ----------------------------------------------------[ Function Prototypes ]--

--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -33,7 +33,6 @@ use vars qw($opt_V $opt_h $opt_v $verbose $PROGNAME $opt_w $opt_c $opt_t $opt_s
 					%srcdomains %dstdomains);
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw(%ERRORS &print_revision &support &usage );
 
 my ($sudo);

--- a/plugins-scripts/check_mssql.pl
+++ b/plugins-scripts/check_mssql.pl
@@ -31,7 +31,6 @@ use DBD::Sybase;
 use Getopt::Long;
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw($TIMEOUT %ERRORS &print_revision &support);
 use strict;
 

--- a/plugins-scripts/check_netdns.pl
+++ b/plugins-scripts/check_netdns.pl
@@ -29,8 +29,7 @@ use Getopt::Long;
 use Net::DNS;
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
-use utils ;
+use utils;
 
 my $PROGNAME = "check_netdns";
 

--- a/plugins-scripts/check_rpc.pl
+++ b/plugins-scripts/check_rpc.pl
@@ -22,7 +22,6 @@
 use strict;
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw($TIMEOUT %ERRORS &print_revision &support);
 use vars qw($PROGNAME);
 my ($verbose,@proto,%prognum,$host,$response,$prognum,$port,$cmd,$progver,$state);

--- a/plugins-scripts/check_wave.pl
+++ b/plugins-scripts/check_wave.pl
@@ -5,7 +5,6 @@
 use strict;
 use FindBin;
 use lib "$FindBin::Bin";
-use lib '@libexecdir@';
 use utils qw($TIMEOUT %ERRORS &print_revision &support);
 use vars qw($PROGNAME);
 use Getopt::Long;


### PR DESCRIPTION
utils.pm locate is already convered by FindBin

i tried to identify if this problem:
https://github.com/nagios-plugins/nagios-plugins/pull/109

is present in monitoring-plugins as well. luckily it was not, but the superfluous use lib libexecdir was. this is cleanup of that.