### PR TITLE
fix bogus use lib

### DIFF
--- a/plugins-scripts/check_ntp.pl
+++ b/plugins-scripts/check_ntp.pl
@@ -61,7 +61,8 @@ use POSIX;
 use strict;
 use Getopt::Long;
 use vars qw($opt_V $opt_h $opt_H $opt_t $opt_w $opt_c $opt_O $opt_j $opt_k $verbose $PROGNAME $def_jitter $ipv4 $ipv6);
-use lib utils.pm;
+use FindBin;
+use lib "$FindBin::Bin";
 use utils qw($TIMEOUT %ERRORS &print_revision &support);
 
 $PROGNAME="check_ntp";


### PR DESCRIPTION
besides that it's wrong, it's detected easily with `perl -c` lint:

```
$ perl -c check_ntp.pl 
Bareword "utils" not allowed while "strict subs" in use at check_ntp.pl line 64.
Bareword "pm" not allowed while "strict subs" in use at check_ntp.pl line 64.
BEGIN not safe after errors--compilation aborted at check_ntp.pl line 65.
```