### PR TITLE
use exit code 3 for version and help

### DIFF
--- a/doc/developer-guidelines.sgml
+++ b/doc/developer-guidelines.sgml
@@ -194,13 +194,15 @@
 					<row>
 						<entry align="center"><para>3</para></entry>
 						<entry valign="middle"><para>Unknown</para></entry>
-						<entry><para>Invalid command line arguments were supplied to the 
+						<entry><para>Invalid command line arguments were supplied to the
 						plugin or low-level failures internal to the plugin (such as unable to fork,
 						or open a tcp socket) that prevent it from performing the specified
 						operation. Higher-level errors (such as name resolution errors,
 						socket timeouts, etc) are outside of the control of plugins and should
 						generally NOT be reported as UNKNOWN states.
-						</para></entry>
+						</para>
+						<para>The --help or --version output should also result in Unknown state.</para>
+						</entry>
 					</row>
 				</tbody>
 			</tgroup>
@@ -610,6 +612,9 @@
 		<para>The option -v or --verbose should be present in all plugins.
 		The user should be allowed to specify -v multiple times to increase
 		the verbosity level, as described in <xref linkend="verboselevels">.</para>
+
+		The exit code for version information or help should be UNKNOWN
+		(3).</para>
     </section>
 
     <section>

--- a/plugins-root/check_dhcp.c
+++ b/plugins-root/check_dhcp.c
@@ -1163,11 +1163,11 @@ int call_getopt(int argc, char **argv){
 
 		case 'V': /* version */
 			print_revision(progname, NP_VERSION);
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 
 		case 'h': /* help */
 			print_help();
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 
 		case 'v': /* verbose */
 			verbose=1;

--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -526,10 +526,10 @@ main(int argc, char **argv)
 				break;
 			case 'V': /* version */
 				print_revision (progname, NP_VERSION);
-				exit (STATE_OK);
+				exit (STATE_UNKNOWN);
 			case 'h': /* help */
 				print_help ();
-				exit (STATE_OK);
+				exit (STATE_UNKNOWN);
 			}
 		}
 	}

--- a/plugins-scripts/check_breeze.pl
+++ b/plugins-scripts/check_breeze.pl
@@ -28,10 +28,10 @@ GetOptions
 
 if ($opt_V) {
 	print_revision($PROGNAME,'@NP_VERSION@');
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
-if ($opt_h) {print_help(); exit $ERRORS{'OK'};}
+if ($opt_h) {print_help(); exit $ERRORS{'UNKNOWN'};}
 
 ($opt_H) || usage("Host name/address not specified\n");
 my $host = $1 if ($opt_H =~ /([-.A-Za-z0-9]+)/);

--- a/plugins-scripts/check_disk_smb.pl
+++ b/plugins-scripts/check_disk_smb.pl
@@ -54,10 +54,10 @@ GetOptions
 
 if ($opt_V) {
 	print_revision($PROGNAME,'@NP_VERSION@'); #'
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
-if ($opt_h) {print_help(); exit $ERRORS{'OK'};}
+if ($opt_h) {print_help(); exit $ERRORS{'UNKNOWN'};}
 
 my $smbclient = $utils::PATH_TO_SMBCLIENT;
 $smbclient    || usage("check requires smbclient, smbclient not set\n");

--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -60,12 +60,12 @@ GetOptions(
 
 if ($opt_V) {
 	print_revision($PROGNAME, '@NP_VERSION@');
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
 if ($opt_h) {
 	print_help();
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
 $opt_f = shift unless ($opt_f);

--- a/plugins-scripts/check_flexlm.pl
+++ b/plugins-scripts/check_flexlm.pl
@@ -58,7 +58,7 @@ GetOptions
 
 if ($opt_V) {
 	print_revision($PROGNAME,'@NP_VERSION@');
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
 unless (defined $opt_t) {
@@ -66,7 +66,7 @@ unless (defined $opt_t) {
 }
 
 
-if ($opt_h) {print_help(); exit $ERRORS{'OK'};}
+if ($opt_h) {print_help(); exit $ERRORS{'UNKNOWN'};}
 
 unless (defined $opt_F) {
 	print "Missing license.dat file\n";

--- a/plugins-scripts/check_ifoperstatus.pl
+++ b/plugins-scripts/check_ifoperstatus.pl
@@ -367,17 +367,17 @@ sub process_arguments() {
 
 	if ($status == 0){
 		print_help();
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
 	if ($opt_V) {
 		print_revision($PROGNAME,'@NP_VERSION@');
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
 	if ($opt_h) {
 		print_help();
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
 	if (! utils::is_hostname($hostname)){

--- a/plugins-scripts/check_ifstatus.pl
+++ b/plugins-scripts/check_ifstatus.pl
@@ -119,7 +119,7 @@ $status = process_arguments();
 if ($status != 0)
 {
 	print_help() ;
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
 
@@ -313,17 +313,17 @@ sub process_arguments() {
 		
 	if ($status == 0){
 		print_help();
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
 	if ($opt_V) {
 		print_revision($PROGNAME,'@NP_VERSION@');
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
 	if ($opt_h) {
 		print_help();
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
 	unless (defined $timeout) {

--- a/plugins-scripts/check_ircd.pl
+++ b/plugins-scripts/check_ircd.pl
@@ -181,10 +181,10 @@ MAIN:
 
 	if ($opt_V) {
 		print_revision($PROGNAME,'@NP_VERSION@');
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
-	if ($opt_h) {print_help(); exit $ERRORS{'OK'};}
+	if ($opt_h) {print_help(); exit $ERRORS{'UNKNOWN'};}
 
 	($opt_H) || ($opt_H = shift @ARGV) || usage("Host name/address not specified\n");
 	my $remotehost = $1 if ($opt_H =~ /([-.A-Za-z0-9]+)/);

--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -573,12 +573,12 @@ sub process_arguments(){
 
 	if ($opt_V) {
 		print_revision($PROGNAME,'@NP_VERSION@');
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
 	if ($opt_h) {
 		print_help();
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
 	if (defined $opt_v ){

--- a/plugins-scripts/check_mssql.pl
+++ b/plugins-scripts/check_mssql.pl
@@ -130,7 +130,7 @@ sub process_arguments {
 
 	if (defined $opt_V) {
 		print_revision($PROGNAME,'@NP_VERSION@');
-		exit $ERRORS{'OK'};
+		exit $ERRORS{'UNKNOWN'};
 	}
 
 	syntax("Help:") if ($help);

--- a/plugins-scripts/check_netdns.pl
+++ b/plugins-scripts/check_netdns.pl
@@ -45,10 +45,10 @@ GetOptions("V" => $opt_V,         "version" => $opt_V,
 					 "H=s" => $opt_H,       "hostname=s" => $opt_H);
                            
 # -h means display verbose help screen
-if($opt_h){ print_help(); exit 0; }
+if($opt_h){ print_help(); exit 3; }
 
 # -V means display version number
-if ($opt_V) { print_version(); exit 0; }
+if ($opt_V) { print_version(); exit 3; }
 
 # -H means host name
 $opt_H = shift unless ($opt_H);
@@ -70,7 +70,7 @@ if ($opt_s) {
 		$server = $1;
 	} else {
 		print "$opt_s is not a valid host name";
-		exit -1;
+		exit 3;
 	}
 }
 

--- a/plugins-scripts/check_ntp.pl
+++ b/plugins-scripts/check_ntp.pl
@@ -98,12 +98,12 @@ GetOptions
 
 if ($opt_V) {
 	print_revision($PROGNAME,'@NP_VERSION@');
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
 if ($opt_h) {
 	print_help();
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
 # jitter test params specified

--- a/plugins-scripts/check_rpc.pl
+++ b/plugins-scripts/check_rpc.pl
@@ -63,12 +63,12 @@ GetOptions(
 );
 
 # -h means display verbose help screen
-if ($opt_h) { print_help(); exit $ERRORS{'OK'}; }
+if ($opt_h) { print_help(); exit $ERRORS{'UNKNOWN'}; }
 
 # -V means display version number
 if ($opt_V) {
 	print_revision($PROGNAME,'@NP_VERSION@');
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
 # Hash containing all RPC program names and numbers

--- a/plugins-scripts/check_wave.pl
+++ b/plugins-scripts/check_wave.pl
@@ -31,12 +31,12 @@ GetOptions
 
 if ($opt_V) {
 	print_revision($PROGNAME,'@NP_VERSION@'); #'
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
 if ($opt_h) {
 	print_help();
-	exit $ERRORS{'OK'};
+	exit $ERRORS{'UNKNOWN'};
 }
 
 $opt_H = shift unless ($opt_H);

--- a/plugins-scripts/t/check_rpc.t
+++ b/plugins-scripts/t/check_rpc.t
@@ -15,7 +15,7 @@ my $successOutput = '/^check_rpc/';
 
 my $t;
 
-$t += checkCmd( "./check_rpc -V",   0, $successOutput );
+$t += checkCmd( "./check_rpc -V",   3, $successOutput );
 
 exit(0) if defined($Test::Harness::VERSION);
 exit($tests - $t);

--- a/plugins/check_apt.c
+++ b/plugins/check_apt.c
@@ -160,10 +160,10 @@ int process_arguments (int argc, char **argv) {
 		switch(c) {
 		case 'h':
 			print_help();
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 		case 'V':
 			print_revision(progname, NP_VERSION);
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 		case 'v':
 			verbose++;
 			break;

--- a/plugins/check_by_ssh.c
+++ b/plugins/check_by_ssh.c
@@ -209,10 +209,10 @@ process_arguments (int argc, char **argv)
 		switch (c) {
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'v':									/* help */
 			verbose = TRUE;
 			break;

--- a/plugins/check_cluster.c
+++ b/plugins/check_cluster.c
@@ -200,7 +200,7 @@ int process_arguments(int argc, char **argv){
 
 		case 'V': /* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 			break;
 
 		case 'H': /* help */

--- a/plugins/check_dbi.c
+++ b/plugins/check_dbi.c
@@ -368,10 +368,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':     /* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':     /* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 
 		case 'c':     /* critical range */
 			critical_range = optarg;

--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -223,10 +223,10 @@ process_arguments (int argc, char **argv)
     switch (c) {
     case 'h':                 /* help */
       print_help ();
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case 'V':                 /* version */
       print_revision (progname, NP_VERSION);
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case 'H':                 /* hostname */
       host_or_die(optarg);
       dns_server = optarg;

--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -766,10 +766,10 @@ process_arguments (int argc, char **argv)
       break;
     case 'V':                 /* version */
       print_revision (progname, NP_VERSION);
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case 'h':                 /* help */
       print_help ();
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case '?':                 /* help */
       usage (_("Unknown argument"));
     }

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -395,10 +395,10 @@ process_arguments (int argc, char **argv)
     switch (c) {
     case 'h': /* help */
       print_help ();
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case 'V': /* version */
       print_revision (progname, NP_VERSION);
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case 'v': /* version */
       verbose = TRUE;
       break;

--- a/plugins/check_dummy.c
+++ b/plugins/check_dummy.c
@@ -52,11 +52,11 @@ main (int argc, char **argv)
     usage4 (_("Could not parse arguments"));
   else if (strcmp (argv[1], "-V") == 0 || strcmp (argv[1], "--version") == 0) {
     print_revision (progname, NP_VERSION);
-    exit (STATE_OK);
+    exit (STATE_UNKNOWN);
   }
   else if (strcmp (argv[1], "-h") == 0 || strcmp (argv[1], "--help") == 0) {
     print_help ();
-    exit (STATE_OK);
+    exit (STATE_UNKNOWN);
   }
   else if (!is_integer (argv[1]))
     usage4 (_("Arguments to check_dummy must be an integer"));

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -314,10 +314,10 @@ process_arguments (int argc, char **argv)
       usage5 ();
     case 'h':                 /* help */
       print_help ();
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case 'V':                 /* version */
       print_revision (progname, NP_VERSION);
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case 'v':                 /* verbose mode */
       verbose = TRUE;
       break;

--- a/plugins/check_game.c
+++ b/plugins/check_game.c
@@ -196,10 +196,10 @@ process_arguments (int argc, char **argv)
     switch (c) {
     case 'h': /* help */
       print_help ();
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case 'V': /* version */
       print_revision (progname, NP_VERSION);
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
     case 'v': /* version */
       verbose = TRUE;
       break;

--- a/plugins/check_hpjd.c
+++ b/plugins/check_hpjd.c
@@ -350,10 +350,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case '?':									/* help */
 			usage5 ();
 		}

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -267,11 +267,11 @@ process_arguments (int argc, char **argv)
       break;
     case 'h': /* help */
       print_help ();
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
       break;
     case 'V': /* version */
       print_revision (progname, NP_VERSION);
-      exit (STATE_OK);
+      exit (STATE_UNKNOWN);
       break;
     case 't': /* timeout period */
       if (!is_intnonneg (optarg))

--- a/plugins/check_ide_smart.c
+++ b/plugins/check_ide_smart.c
@@ -234,10 +234,10 @@ main (int argc, char *argv[])
 			break;
 		case 'h':
 			print_help ();
-			return STATE_OK;
+			return STATE_UNKNOWN;
 		case 'V':
 			print_revision (progname, NP_VERSION);
-			return STATE_OK;
+			return STATE_UNKNOWN;
 		default:
 			usage5 ();
 		}
@@ -249,7 +249,7 @@ main (int argc, char *argv[])
 
 	if (!device) {
 		print_help ();
-		return STATE_OK;
+		return STATE_UNKNOWN;
 	}
 
 	fd = open (device, OPEN_MODE);

--- a/plugins/check_ldap.c
+++ b/plugins/check_ldap.c
@@ -325,10 +325,10 @@ process_arguments (int argc, char **argv)
 		switch (c) {
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 't':									/* timeout period */
 			if (!is_intnonneg (optarg))
 				usage2 (_("Timeout interval must be a positive integer"), optarg);

--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -251,10 +251,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case '?':									/* help */
 			usage5 ();
 		}

--- a/plugins/check_mrtg.c
+++ b/plugins/check_mrtg.c
@@ -234,10 +234,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case '?':									/* help */
 			usage5 ();
 		}

--- a/plugins/check_mrtgtraf.c
+++ b/plugins/check_mrtgtraf.c
@@ -270,10 +270,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case '?':									/* help */
 			usage5 ();
 		}

--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -444,10 +444,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'v':
 			verbose++;
 			break;

--- a/plugins/check_mysql_query.c
+++ b/plugins/check_mysql_query.c
@@ -250,10 +250,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'q':
 			xasprintf(&sql_query, "%s", optarg);
 			break;

--- a/plugins/check_nagios.c
+++ b/plugins/check_nagios.c
@@ -235,10 +235,10 @@ process_arguments (int argc, char **argv)
 		switch (c) {
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'F':									/* status log */
 			status_log = optarg;
 			break;

--- a/plugins/check_nt.c
+++ b/plugins/check_nt.c
@@ -553,10 +553,10 @@ int process_arguments(int argc, char **argv){
 			usage5 ();
 			case 'h': /* help */
 				print_help();
-				exit(STATE_OK);
+				exit(STATE_UNKNOWN);
 			case 'V': /* version */
 				print_revision(progname, NP_VERSION);
-				exit(STATE_OK);
+				exit(STATE_UNKNOWN);
 			case 'H': /* hostname */
 				server_address = optarg;
 				break;

--- a/plugins/check_ntp.c
+++ b/plugins/check_ntp.c
@@ -691,11 +691,11 @@ int process_arguments(int argc, char **argv){
 		switch (c) {
 		case 'h':
 			print_help();
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 			break;
 		case 'V':
 			print_revision(progname, NP_VERSION);
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 			break;
 		case 'v':
 			verbose++;

--- a/plugins/check_ntp_peer.c
+++ b/plugins/check_ntp_peer.c
@@ -448,11 +448,11 @@ int process_arguments(int argc, char **argv){
 		switch (c) {
 		case 'h':
 			print_help();
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 			break;
 		case 'V':
 			print_revision(progname, NP_VERSION);
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 			break;
 		case 'v':
 			verbose++;

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -477,11 +477,11 @@ int process_arguments(int argc, char **argv){
 		switch (c) {
 		case 'h':
 			print_help();
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 			break;
 		case 'V':
 			print_revision(progname, NP_VERSION);
-			exit(STATE_OK);
+			exit(STATE_UNKNOWN);
 			break;
 		case 'v':
 			verbose++;

--- a/plugins/check_nwstat.c
+++ b/plugins/check_nwstat.c
@@ -1354,10 +1354,10 @@ int process_arguments(int argc, char **argv) {
 			usage5 ();
 			case 'h': /* help */
 				print_help();
-				exit(STATE_OK);
+				exit(STATE_UNKNOWN);
 			case 'V': /* version */
 				print_revision(progname, NP_VERSION);
-				exit(STATE_OK);
+				exit(STATE_UNKNOWN);
 			case 'H': /* hostname */
 				server_address=optarg;
 				break;

--- a/plugins/check_overcr.c
+++ b/plugins/check_overcr.c
@@ -340,10 +340,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'H':									/* hostname */
 			server_address = optarg;
 			break;

--- a/plugins/check_pgsql.c
+++ b/plugins/check_pgsql.c
@@ -302,10 +302,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':     /* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':     /* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 't':     /* timeout period */
 			if (!is_integer (optarg))
 				usage2 (_("Timeout interval must be a positive integer"), optarg);

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -224,11 +224,11 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':	/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 			break;
 		case 'V':	/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 			break;
 		case 't':	/* timeout period */
 			timeout_interval = atoi (optarg);

--- a/plugins/check_procs.c
+++ b/plugins/check_procs.c
@@ -428,10 +428,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 't':									/* timeout period */
 			if (!is_integer (optarg))
 				usage2 (_("Timeout interval must be a positive integer"), optarg);

--- a/plugins/check_radius.c
+++ b/plugins/check_radius.c
@@ -259,10 +259,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':									/* help */
 			print_help ();
-			exit (OK);
+			exit (STATE_UNKNOWN);
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (OK);
+			exit (STATE_UNKNOWN);
 		case 'v':									/* verbose mode */
 			verbose = TRUE;
 			break;

--- a/plugins/check_real.c
+++ b/plugins/check_real.c
@@ -359,10 +359,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case '?':									/* usage */
 			usage5 ();
 		}

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -623,10 +623,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case '?':									/* help */
 			usage5 ();
 		}

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -709,10 +709,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':	/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':	/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'v': /* verbose */
 			verbose++;
 			break;

--- a/plugins/check_ssh.c
+++ b/plugins/check_ssh.c
@@ -128,10 +128,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'v':									/* verbose */
 			verbose = TRUE;
 			break;

--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -470,10 +470,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case '?':									/* error */
 			usage5 ();
 		}

--- a/plugins/check_tcp.c
+++ b/plugins/check_tcp.c
@@ -463,10 +463,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':                 /* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':                 /* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'v':                 /* verbose mode */
 			flags |= FLAG_VERBOSE;
 			match_flags |= NP_MATCH_VERBOSE;

--- a/plugins/check_time.c
+++ b/plugins/check_time.c
@@ -231,10 +231,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'H':									/* hostname */
 			if (is_host (optarg) == FALSE)
 				usage2 (_("Invalid hostname/address"), optarg);

--- a/plugins/check_ups.c
+++ b/plugins/check_ups.c
@@ -558,10 +558,10 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		}
 	}
 

--- a/plugins/check_users.c
+++ b/plugins/check_users.c
@@ -210,10 +210,10 @@ process_arguments (int argc, char **argv)
 			usage5 ();
 		case 'h':									/* help */
 			print_help ();
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'V':									/* version */
 			print_revision (progname, NP_VERSION);
-			exit (STATE_OK);
+			exit (STATE_UNKNOWN);
 		case 'c':									/* critical */
 			if (!is_intnonneg (optarg))
 				usage4 (_("Critical threshold must be a positive integer"));


### PR DESCRIPTION
Plugins which use OK state for help or version information may run
unnoticed in that modes without doing any check. So its good
style to let version and help exit with Unknown state.

Signed-off-by: Sven Nierlein <sven@nierlein.de>