### PR TITLE
check_procs: Fix for unclosed filehandle in pst3 on Solaris

### DIFF
--- a/plugins-root/pst3.c
+++ b/plugins-root/pst3.c
@@ -139,8 +139,10 @@ try_again:
     if((ps_fd = open(ps_name, O_RDONLY)) == -1)
       continue;
 
-    if((as_fd = open(as_name, O_RDONLY)) == -1)
+    if((as_fd = open(as_name, O_RDONLY)) == -1) {
+      close(ps_fd);
       continue;
+    }
 
     if(read(ps_fd, &psinfo, sizeof(psinfo)) != sizeof(psinfo)) {
       int err = errno;


### PR DESCRIPTION
On Solaris, check_procs uses pst3 instead of /bin/ps (see
http://monitoring-plugins.org/doc/faq/ps-on-solaris.html for background). There's
a small bug in pst3 which causes it to NOT report some processes that are at
the end of the process table, at least on very busy systems (we noticed this
on a CoolThreads T5240 with load averages up to 90).

The bug is that a filehandle is not properly closed.

Thanks to jwinkle01 for finding and patching the bug.

(Closes #1203)