### PR TITLE
check_procs: Make cgroups aware.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -746,6 +746,26 @@ dnl 	ac_cv_ps_format=["%*s %d %d %d %d %*d %*d %d %d%*[ 0123456789abcdef]%[OSRZT
 dnl 	ac_cv_ps_cols=8
 dnl 	AC_MSG_RESULT([$ac_cv_ps_command])
 
+dnl Lets test if cgroups are supported, on systems with ps axwo command:
+elif ps axwo 'stat comm vsz rss user uid pid ppid args cgroup:256' 2>/dev/null | \
+	egrep -i ["^ *STAT +[UCOMAND]+ +VSZ +RSS +USER +UID +PID +PPID +COMMAND +CGROUP"] > /dev/null
+then
+	ac_cv_ps_varlist="[procstat,&procuid,&procpid,&procppid,&procvsz,&procrss,&procpcpu,proc_cgroup_hierarchy,procprog,&pos]"
+	ac_cv_ps_command="$PATH_TO_PS axwo 'stat uid pid ppid vsz rss pcpu cgroup:256 comm args'"
+	ac_cv_ps_format="%s %d %d %d %d %d %f %s %s %n"
+	ac_cv_ps_cols=10
+	AC_MSG_RESULT([$ac_cv_ps_command])
+
+dnl cgroups with ps -axwo command:
+elif ps -axwo 'stat comm vsz rss user uid pid ppid args cgroup:256' 2>/dev/null | \
+	egrep -i ["^ *STAT +[UCOMAND]+ +VSZ +RSS +USER +UID +PID +PPID +COMMAND +CGROUP"] > /dev/null
+then
+	ac_cv_ps_varlist="[procstat,&procuid,&procpid,&procppid,&procvsz,&procrss,&procpcpu,proc_cgroup_hierarchy,procprog,&pos]"
+	ac_cv_ps_command="$PATH_TO_PS -axwo 'stat uid pid ppid vsz rss pcpu cgroup:256 comm args'"
+	ac_cv_ps_format="%s %d %d %d %d %d %f %s %s %n"
+	ac_cv_ps_cols=10
+	AC_MSG_RESULT([$ac_cv_ps_command])
+
 dnl Some gnu/linux systems (debian for one) don't like -axwo and need axwo.
 dnl so test for this first...
 elif ps axwo 'stat comm vsz rss user uid pid ppid args' 2>/dev/null | \

--- a/plugins/check_nagios.c
+++ b/plugins/check_nagios.c
@@ -66,6 +66,7 @@ main (int argc, char **argv)
 	int procppid = 0;
 	int procvsz = 0;
 	int procrss = 0;
+	char *proc_cgroup_hierarchy;
 	float procpcpu = 0;
 	char procstat[8];
 #ifdef PS_USES_PROCETIME


### PR DESCRIPTION
This patch enables check_proc to monitor processes in PID name-
spaced environments.

Normally, all processes are visible from host - the ones running
directly on host and the ones in containers. This results in
check_procs reporting false-positives or false negatives depending
on whether he sees to many of given processes on to little.

These changes introduce one filter to check_proc - cgroup hierarchy.
Specified on the command line, it allows user to define which cgroup
hierarchy we are interested in and check_proc is ignoring all other.

As mentioned [here](https://github.com/nagios-plugins/nagios-plugins/pull/56#issuecomment-56846776) and [here](https://github.com/nagios-plugins/nagios-plugins/pull/56#issuecomment-67006931), using this option on non cgroup aware systems, the result maybe unexpected. This should be fixed (before aplying).
