### PR TITLE
check_http: added timeout to perfdata as max val

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1453,32 +1453,32 @@ char *perfd_time (double elapsed_time)
   return fperfdata ("time", elapsed_time, "s",
             thlds->warning?TRUE:FALSE, thlds->warning?thlds->warning->end:0,
             thlds->critical?TRUE:FALSE, thlds->critical?thlds->critical->end:0,
-                   TRUE, 0, FALSE, 0);
+                   TRUE, 0, TRUE, socket_timeout);
 }
 
 char *perfd_time_connect (double elapsed_time_connect)
 {
-  return fperfdata ("time_connect", elapsed_time_connect, "s", FALSE, 0, FALSE, 0, FALSE, 0, FALSE, 0);
+  return fperfdata ("time_connect", elapsed_time_connect, "s", FALSE, 0, FALSE, 0, FALSE, 0, TRUE, socket_timeout);
 }
 
 char *perfd_time_ssl (double elapsed_time_ssl)
 {
-  return fperfdata ("time_ssl", elapsed_time_ssl, "s", FALSE, 0, FALSE, 0, FALSE, 0, FALSE, 0);
+  return fperfdata ("time_ssl", elapsed_time_ssl, "s", FALSE, 0, FALSE, 0, FALSE, 0, TRUE, socket_timeout);
 }
 
 char *perfd_time_headers (double elapsed_time_headers)
 {
-  return fperfdata ("time_headers", elapsed_time_headers, "s", FALSE, 0, FALSE, 0, FALSE, 0, FALSE, 0);
+  return fperfdata ("time_headers", elapsed_time_headers, "s", FALSE, 0, FALSE, 0, FALSE, 0, TRUE, socket_timeout);
 }
 
 char *perfd_time_firstbyte (double elapsed_time_firstbyte)
 {
-  return fperfdata ("time_firstbyte", elapsed_time_firstbyte, "s", FALSE, 0, FALSE, 0, FALSE, 0, FALSE, 0);
+  return fperfdata ("time_firstbyte", elapsed_time_firstbyte, "s", FALSE, 0, FALSE, 0, FALSE, 0, TRUE, socket_timeout);
 }
 
 char *perfd_time_transfer (double elapsed_time_transfer)
 {
-  return fperfdata ("time_transfer", elapsed_time_transfer, "s", FALSE, 0, FALSE, 0, FALSE, 0, FALSE, 0);
+  return fperfdata ("time_transfer", elapsed_time_transfer, "s", FALSE, 0, FALSE, 0, FALSE, 0, TRUE, socket_timeout);
 }
 
 char *perfd_size (int page_len)


### PR DESCRIPTION
Added socket_timeout to time\* perfdata values, see issue #1350

**Then**

```
# extended perfdata
./check_http -H 127.0.0.1 -t 30 -E
HTTP OK: HTTP/1.1 200 OK - 380 bytes in 1,334 second response time |time=1,334256s;;;0,000000 size=380B;;;0 time_connect=0,000235s;;;  time_headers=0,000029s;;; time_firstbyte=1,333924s;;; time_transfer=1,333947s;;;

./check_http -H 127.0.0.1 -t 30
HTTP OK: HTTP/1.1 200 OK - 380 bytes in 0,001 second response time |time=0,000551s;;;0,000000 size=380B;;;0
```

**Now**

```
# extended perfdata
./check_http -H 127.0.0.1 -t 30 -E
HTTP OK: HTTP/1.1 200 OK - 380 bytes in 0,006 second response time |time=0,005946s;;;0,000000;30,000000 size=380B;;;0 time_connect=0,000059s;;;;30,000000  time_headers=0,000035s;;;;30,000000 time_firstbyte=0,005737s;;;;30,000000 time_transfer=0,005806s;;;;30,000000

./check_http -H 127.0.0.1 -t 30
HTTP OK: HTTP/1.1 200 OK - 380 bytes in 0,000 second response time |time=0,000499s;;;0,000000;30,000000 size=380B;;;0
```
