### PR TITLE
check_mssql.pl: switched alarm timeout

### DIFF
--- a/plugins-scripts/check_mssql.pl
+++ b/plugins-scripts/check_mssql.pl
@@ -54,7 +54,7 @@ $SIG{'ALRM'} = sub {
      print ("SQL UNKNOWN: ERROR connection $server (alarm timeout)\n");
      exit $ERRORS{"UNKNOWN"};
 };
-alarm($TIMEOUT);
+alarm($timeout);
 
 unless ($dbh = DBI->connect("dbi:Sybase:server=".uc($server), "$username", "$password")) {
 	printf "SQL CRITICAL: Can't connect to mssql server $DBI::errstr\n";


### PR DESCRIPTION
alarm timeout now uses -t option, closes #991

If not set, default TIMEOUT from utils.pm will be used

```
$timeout = $TIMEOUT unless (defined($timeout))
```
