### PR TITLE
check_smtp.c: modified SSL check for use with -e

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -231,7 +231,7 @@ main (int argc, char **argv)
 		  send(sd, SMTP_STARTTLS, strlen(SMTP_STARTTLS), 0);
 
 		  recvlines(buffer, MAX_INPUT_BUFFER); /* wait for it */
-		  if (!strstr (buffer, server_expect)) {
+		  if (!strstr (buffer, SMTP_EXPECT)) {
 		    printf (_("Server does not support STARTTLS\n"));
 		    smtp_quit();
 		    return STATE_UNKNOWN;


### PR DESCRIPTION
currently STARTTLS check does not work with -e if there's text like '220 hostname ESMTP*'. This is caused by SMTP answer from host. 

Postfix answer: 220 2.0.0 Ready to start TLS
Exchange 2010: 220 2.0.0 SMTP server ready

This fix checks against 220 and closes #1093