### PR TITLE
check_dig: expected answer is now incasesensitive

### DIFF
--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -125,7 +125,7 @@ main (int argc, char **argv)
         if (verbose)
           printf ("%s\n", chld_out.line[i]);
 
-        if (strstr (chld_out.line[i], (expected_address == NULL ? query_address : expected_address)) != NULL) {
+        if (strcasestr (chld_out.line[i], (expected_address == NULL ? query_address : expected_address)) != NULL) {
           msg = chld_out.line[i];
           result = STATE_OK;
 


### PR DESCRIPTION
  check_dig was casesensitive if an expected answer is given.
  Switching strstr with strcasestr fixes this issue

  While testing i noticed a bug where expected is not an exact match
  New issue for that is opened #1385

  This fix closes #1233