### PR TITLE
Update check_http.c

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1022,6 +1022,10 @@ check_http (void)
       microsec_firstbyte = deltime (tv_temp);
       elapsed_time_firstbyte = (double)microsec_firstbyte / 1.0e6;
     }
+    while (pos = memchr(buffer, '\0', i)) {
+      /* replace nul character with a blank */
+      *pos = ' ';
+    }
     buffer[i] = '\0';
     xasprintf (&full_page_new, "%s%s", full_page, buffer);
     free (full_page);


### PR DESCRIPTION
If a web page contains a nul character, check_http reads the complete page but --string does not search beyond this character.
