### PR TITLE
Use GMT timezone in SSL certs

### DIFF
--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -264,10 +264,10 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 		(tm->data[10 + offset] - '0') * 10 + (tm->data[11 + offset] - '0');
 	stamp.tm_isdst = -1;
 
-	time_left = difftime(timegm(&stamp), time(NULL));
+	tm_t = timegm(&stamp);
+	time_left = difftime(tm_t, time(NULL));
 	days_left = time_left / 86400;
-	tm_t = mktime (&stamp);
-	strftime(timestamp, 50, "%c", localtime(&tm_t));
+	strftime(timestamp, 50, "%F %R %z/%Z", localtime(&tm_t));
 
 	if (days_left > 0 && days_left <= days_till_exp_warn) {
 		printf (_("%s - Certificate '%s' expires in %d day(s) (%s).\n"), (days_left>days_till_exp_crit)?"WARNING":"CRITICAL", cn, days_left, timestamp);

--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -197,6 +197,7 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 	X509_NAME *subj=NULL;
 	char timestamp[50] = "";
 	char cn[MAX_CN_LENGTH]= "";
+	char *tz;
 	
 	int cnlen =-1;
 	int status=STATE_UNKNOWN;
@@ -267,7 +268,15 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 	tm_t = timegm(&stamp);
 	time_left = difftime(tm_t, time(NULL));
 	days_left = time_left / 86400;
-	strftime(timestamp, 50, "%F %R %z/%Z", localtime(&tm_t));
+	tz = getenv("TZ");
+	setenv("TZ", "GMT", 1);
+	tzset();
+	strftime(timestamp, 50, "%c %z", localtime(&tm_t));
+	if (tz)
+		setenv("TZ", tz, 1);
+	else
+		unsetenv("TZ");
+	tzset();
 
 	if (days_left > 0 && days_left <= days_till_exp_warn) {
 		printf (_("%s - Certificate '%s' expires in %d day(s) (%s).\n"), (days_left>days_till_exp_crit)?"WARNING":"CRITICAL", cn, days_left, timestamp);

--- a/plugins/tests/check_http.t
+++ b/plugins/tests/check_http.t
@@ -186,21 +186,21 @@ SKIP: {
 
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 14" );
 	is( $result->return_code, 0, "$command -p $port_https -S -C 14" );
-	is( $result->output, 'OK - Certificate \'Ton Voon\' will expire on Sun Mar  3 21:41:28 2019.', "output ok" );
+	is( $result->output, 'OK - Certificate \'Ton Voon\' will expire on Sun Mar  3 21:41:28 2019 +0000.', "output ok" );
 
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 14000" );
 	is( $result->return_code, 1, "$command -p $port_https -S -C 14000" );
-	like( $result->output, '/WARNING - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019\)./', "output ok" );
+	like( $result->output, '/WARNING - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019 \+0000\)./', "output ok" );
 
 	# Expired cert tests
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 13960,14000" );
 	is( $result->return_code, 2, "$command -p $port_https -S -C 13960,14000" );
-	like( $result->output, '/CRITICAL - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019\)./', "output ok" );
+	like( $result->output, '/CRITICAL - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019 \+0000\)./', "output ok" );
 
 	$result = NPTest->testCmd( "$command -p $port_https_expired -S -C 7" );
 	is( $result->return_code, 2, "$command -p $port_https_expired -S -C 7" );
 	is( $result->output,
-		'CRITICAL - Certificate \'Ton Voon\' expired on Thu Mar  5 00:13:16 2009.',
+		'CRITICAL - Certificate \'Ton Voon\' expired on Thu Mar  5 00:13:16 2009 +0000.',
 		"output ok" );
 
 }

--- a/plugins/tests/check_http.t
+++ b/plugins/tests/check_http.t
@@ -186,21 +186,21 @@ SKIP: {
 
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 14" );
 	is( $result->return_code, 0, "$command -p $port_https -S -C 14" );
-	is( $result->output, 'OK - Certificate \'Ton Voon\' will expire on Sun Mar  3 21:41:28 2019.', "output ok" );
+	is( $result->output, 'OK - Certificate \'Ton Voon\' will expire on 2019-03-03 21:41 +0000/UTC.', "output ok" );
 
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 14000" );
 	is( $result->return_code, 1, "$command -p $port_https -S -C 14000" );
-	like( $result->output, '/WARNING - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019\)./', "output ok" );
+	like( $result->output, '/WARNING - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(2019-03-03 21:41 +0000/UTC\)./', "output ok" );
 
 	# Expired cert tests
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 13960,14000" );
 	is( $result->return_code, 2, "$command -p $port_https -S -C 13960,14000" );
-	like( $result->output, '/CRITICAL - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019\)./', "output ok" );
+	like( $result->output, '/CRITICAL - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(2019-03-03 21:41 +0000/UTC\)./', "output ok" );
 
 	$result = NPTest->testCmd( "$command -p $port_https_expired -S -C 7" );
 	is( $result->return_code, 2, "$command -p $port_https_expired -S -C 7" );
 	is( $result->output,
-		'CRITICAL - Certificate \'Ton Voon\' expired on Thu Mar  5 00:13:16 2009.',
+		'CRITICAL - Certificate \'Ton Voon\' expired on 2009-03-05 00:13 +0000/UTC.',
 		"output ok" );
 
 }

--- a/plugins/tests/check_http.t
+++ b/plugins/tests/check_http.t
@@ -186,21 +186,21 @@ SKIP: {
 
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 14" );
 	is( $result->return_code, 0, "$command -p $port_https -S -C 14" );
-	is( $result->output, 'OK - Certificate \'Ton Voon\' will expire on 2019-03-03 21:41 +0000/UTC.', "output ok" );
+	is( $result->output, 'OK - Certificate \'Ton Voon\' will expire on Sun Mar  3 21:41:28 2019.', "output ok" );
 
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 14000" );
 	is( $result->return_code, 1, "$command -p $port_https -S -C 14000" );
-	like( $result->output, '/WARNING - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(2019-03-03 21:41 +0000/UTC\)./', "output ok" );
+	like( $result->output, '/WARNING - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019\)./', "output ok" );
 
 	# Expired cert tests
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 13960,14000" );
 	is( $result->return_code, 2, "$command -p $port_https -S -C 13960,14000" );
-	like( $result->output, '/CRITICAL - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(2019-03-03 21:41 +0000/UTC\)./', "output ok" );
+	like( $result->output, '/CRITICAL - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019\)./', "output ok" );
 
 	$result = NPTest->testCmd( "$command -p $port_https_expired -S -C 7" );
 	is( $result->return_code, 2, "$command -p $port_https_expired -S -C 7" );
 	is( $result->output,
-		'CRITICAL - Certificate \'Ton Voon\' expired on 2009-03-05 00:13 +0000/UTC.',
+		'CRITICAL - Certificate \'Ton Voon\' expired on Thu Mar  5 00:13:16 2009.',
 		"output ok" );
 
 }


### PR DESCRIPTION
SSL certs are required to use times in GMT per
https://www.ietf.org/rfc/rfc5280.txt but the mktime() here assumes the
current timezone.

Fix the time_t conversion to be done assuming GMT with timegm() and
only do it once rather than twice.

Display the expiry date and time with ISO format years and give an
offset from GMT and a timezone to be very clear about exactly what time
is being displayed. Time given is correct and now in the machine’s
timezone.

Fix tests to match.
