### PR TITLE
DNS is case insensitive!

### DIFF
--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -127,7 +127,7 @@ main (int argc, char **argv)
     if (verbose)
       puts(chld_out.line[i]);
 
-    if (strstr (chld_out.line[i], ".in-addr.arpa")) {
+    if (strcasestr (chld_out.line[i], ".in-addr.arpa")) {
       if ((temp_buffer = strstr (chld_out.line[i], "name = ")))
         addresses[n_addresses++] = strdup (temp_buffer + 7);
       else {


### PR DESCRIPTION
Thus recent Versions of bind will no longer change .IN-ADDR.ARPA to lowercase
as the uppercase version is also valid.

To have check_dns.c consider this fact change strstr to strcasestr