### PR TITLE
[check_radius.c] prevent segfault on rc_avpair_add.

### DIFF
--- a/plugins/check_radius.c
+++ b/plugins/check_radius.c
@@ -171,6 +171,14 @@ main (int argc, char **argv)
 			my_rc_read_dictionary (my_rc_conf_str (str)))
 		die (STATE_UNKNOWN, _("Config file error\n"));
 
+	/* Initialize Value Pair to prevent segfault on rc_avpair_add.
+	 * debugging on radiuslib-ng show that the mem isn't allocated,
+	 * and some random memory is in the USER-PASSWORD pair.
+	 * So, after initialization, the password is filled with the correct values
+	 */
+	data.send_pairs = NULL;
+	data.receive_pairs = NULL;
+
 	service = PW_AUTHENTICATE_ONLY;
 
 	memset (&data, 0, sizeof(data));


### PR DESCRIPTION
patch from debian (#nagios-plugins_1.4.11-2.diff.gz)

originated from pld linux
https://github.com/pld-linux/monitoring-plugins/blob/auto/th/monitoring-plugins-2.1.2-1/nagios-plugins-check_radius_segfault.patch