### PR TITLE
check_ping: ignore "WARNING: failed to install socket filter" messages

### DIFF
--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -487,6 +487,7 @@ run_ping (const char *cmd, const char *addr)
 	while (fgets (buf, MAX_INPUT_BUFFER - 1, child_stderr)) {
 		if (
 			! strstr(buf,"WARNING - no SO_TIMESTAMP support, falling back to SIOCGSTAMP")
+			&& ! strstr(buf,"WARNING: failed to install socket filter: Protocol not available")
 			&& ! strstr(buf,"Warning: time of day goes back")
 
 		) {


### PR DESCRIPTION
ignore "WARNING: failed to install socket filter: Protocol not available" message from check_ping

originated from pld-linux:
https://github.com/pld-linux/monitoring-plugins/commits/auto/th/monitoring-plugins-2.1.2-1/nagios-plugins-check_ping-socket-filter-warning.patch
