### PR TITLE
check_by_ssh: print command output in verbose mode

### DIFF
--- a/plugins/check_by_ssh.c
+++ b/plugins/check_by_ssh.c
@@ -100,6 +100,13 @@ main (int argc, char **argv)
 
 	result = cmd_run_array (commargv, &chld_out, &chld_err, 0);
 
+	if (verbose) {
+		for(i = 0; i < chld_out.lines; i++)
+			printf("stdout: %s\n", chld_out.line[i]);
+		for(i = 0; i < chld_err.lines; i++)
+			printf("stderr: %s\n", chld_err.line[i]);
+	}
+
 	if (skip_stdout == -1) /* --skip-stdout specified without argument */
 		skip_stdout = chld_out.lines;
 	if (skip_stderr == -1) /* --skip-stderr specified without argument */


### PR DESCRIPTION
right now it is not possible to print the command output of ssh. check_by_ssh
only prints the command itself. This patchs adds printing the output too. This
makes it possible to use ssh with verbose logging which helps debuging any
connection, key or other ssh problems.
Note: you must use -E,--skip-stderr=<high number>, otherwise check_by_ssh would
always exit with unknown state.

Example:

  ./check_by_ssh -H localhost -o LogLevel=DEBUG3 -C "sleep 1" -E 999 -v

Signed-off-by: Sven Nierlein sven@nierlein.de
