### PR TITLE
check_snmp: Add multiply-by and divide-by options

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -1201,6 +1201,11 @@ print_help (void)
 	printf ("    %s\n", _("Converts rate per second. For example, set to 60 to convert to per minute"));
 	printf (" %s\n", "--offset=OFFSET");
 	printf ("    %s\n", _("Add/substract the specified OFFSET to numeric sensor data"));
+	printf (" %s\n", "--multiply-by");
+	printf ("    %s\n", _("Multiply the result by this amount."));
+	printf (" %s\n", "--divide-by");
+	printf ("    %s\n", _("Divide the result by this amount."));
+
 
 	/* Tests Against Strings */
 	printf (" %s\n", "-s, --string=STRING");


### PR DESCRIPTION
Allows simple scaling on numeric results.

~~Useful~~ Necessary when a wrapper script is prohibitive and device outputs scaled results.  Or when you get bits and need bytes (or vice versa).
