### PR TITLE
Trivial source code whitespace formatting fixes to standard.

### DIFF
--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -138,7 +138,7 @@ main (int argc, char **argv)
 		if (pl == UNKNOWN_PACKET_LOSS || rta < 0.0) {
 			printf ("%s\n", cmd);
 			die (STATE_UNKNOWN,
-			           _("CRITICAL - Could not interpret output from ping command\n"));
+				_("CRITICAL - Could not interpret output from ping command\n"));
 		}
 
 		if (pl >= cpl || rta >= crta || rta < 0)
@@ -547,7 +547,7 @@ error_scan (char buf[MAX_INPUT_BUFFER], const char *addr)
 		if (warn_text == NULL)
 			warn_text = strdup (_(WARN_DUPLICATES));
 		else if (! strstr (warn_text, _(WARN_DUPLICATES)) &&
-		         xasprintf (&warn_text, "%s %s", warn_text, _(WARN_DUPLICATES)) == -1)
+				xasprintf (&warn_text, "%s %s", warn_text, _(WARN_DUPLICATES)) == -1)
 			die (STATE_UNKNOWN, _("Unable to realloc warn_text\n"));
 		return (STATE_WARNING);
 	}
@@ -567,7 +567,7 @@ print_help (void)
 
 	printf (_("Use ping to check connection statistics for a remote host."));
 
-  printf ("\n\n");
+	printf ("\n\n");
 
 	print_usage ();
 
@@ -577,29 +577,29 @@ print_help (void)
 	printf (UT_IPv46);
 
 	printf (" %s\n", "-H, --hostname=HOST");
-  printf ("    %s\n", _("host to ping"));
-  printf (" %s\n", "-w, --warning=THRESHOLD");
-  printf ("    %s\n", _("warning threshold pair"));
-  printf (" %s\n", "-c, --critical=THRESHOLD");
-  printf ("    %s\n", _("critical threshold pair"));
-  printf (" %s\n", "-p, --packets=INTEGER");
-  printf ("    %s ", _("number of ICMP ECHO packets to send"));
-  printf (_("(Default: %d)\n"), DEFAULT_MAX_PACKETS);
-  printf (" %s\n", "-L, --link");
-  printf ("    %s\n", _("show HTML in the plugin output (obsoleted by urlize)"));
+	printf ("    %s\n", _("host to ping"));
+	printf (" %s\n", "-w, --warning=THRESHOLD");
+	printf ("    %s\n", _("warning threshold pair"));
+	printf (" %s\n", "-c, --critical=THRESHOLD");
+	printf ("    %s\n", _("critical threshold pair"));
+	printf (" %s\n", "-p, --packets=INTEGER");
+	printf ("    %s ", _("number of ICMP ECHO packets to send"));
+	printf (_("(Default: %d)\n"), DEFAULT_MAX_PACKETS);
+	printf (" %s\n", "-L, --link");
+	printf ("    %s\n", _("show HTML in the plugin output (obsoleted by urlize)"));
 
 	printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
 
-  printf ("\n");
+	printf ("\n");
 	printf ("%s\n", _("THRESHOLD is <rta>,<pl>% where <rta> is the round trip average travel"));
-  printf ("%s\n", _("time (ms) which triggers a WARNING or CRITICAL state, and <pl> is the"));
-  printf ("%s\n", _("percentage of packet loss to trigger an alarm state."));
+	printf ("%s\n", _("time (ms) which triggers a WARNING or CRITICAL state, and <pl> is the"));
+	printf ("%s\n", _("percentage of packet loss to trigger an alarm state."));
 
-  printf ("\n");
+	printf ("\n");
 	printf ("%s\n", _("This plugin uses the ping command to probe the specified host for packet loss"));
-  printf ("%s\n", _("(percentage) and round trip average (milliseconds). It can produce HTML output"));
-  printf ("%s\n", _("linking to a traceroute CGI contributed by Ian Cass. The CGI can be found in"));
-  printf ("%s\n", _("the contrib area of the downloads section at http://www.nagios.org/"));
+	printf ("%s\n", _("(percentage) and round trip average (milliseconds). It can produce HTML output"));
+	printf ("%s\n", _("linking to a traceroute CGI contributed by Ian Cass. The CGI can be found in"));
+	printf ("%s\n", _("the contrib area of the downloads section at http://www.nagios.org/"));
 
 	printf (UT_SUPPORT);
 }
@@ -607,7 +607,7 @@ print_help (void)
 void
 print_usage (void)
 {
-  printf ("%s\n", _("Usage:"));
+	printf ("%s\n", _("Usage:"));
 	printf ("%s -H <host_address> -w <wrta>,<wpl>%% -c <crta>,<cpl>%%\n", progname);
-  printf (" [-p packets] [-t timeout] [-4|-6]\n");
+	printf (" [-p packets] [-t timeout] [-4|-6]\n");
 }


### PR DESCRIPTION
Trivial source code formatting only: Use tabs consistently for source code indentation (whitespace), as per https://github.com/monitoring-plugins/monitoring-plugins/blob/master/CODING .
