### PR TITLE
Add missing function declaration for sperfdata

### DIFF
--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -118,6 +118,16 @@ char *fperfdata (const char *,
  int,
  double);
 
+char *sperfdata (const char *,
+ double,
+ const char *,
+ char *,
+ char *,
+ int,
+ double,
+ int,
+ double);
+
 /* The idea here is that, although not every plugin will use all of these, 
    most will or should.  Therefore, for consistency, these very common 
    options should have only these meanings throughout the overall suite */


### PR DESCRIPTION
This fixes a bug in check_ldap that causes a segmentation fault when used with the -C or -W options.  With compiler warnings this would be identified as:

```
check_ldap.c:260:4: warning: implicit declaration of function ‘sperfdata’ [-Wimplicit-function-declaration]
    sperfdata ("entries", (double)num_entries, "",
    ^
```
