### PR TITLE
check_disk - show all disks if state is ok and option error only is used

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -168,6 +168,7 @@ main (int argc, char **argv)
   int result = STATE_UNKNOWN;
   int disk_result = STATE_UNKNOWN;
   char *output;
+  char *ko_output;
   char *details;
   char *perf;
   char *preamble;
@@ -187,6 +188,7 @@ main (int argc, char **argv)
 
   preamble = strdup (" - free space:");
   output = strdup ("");
+  ko_output = strdup ("");
   details = strdup ("");
   perf = strdup ("");
   stat_buf = malloc(sizeof *stat_buf);
@@ -351,9 +353,6 @@ main (int argc, char **argv)
                           TRUE, 0,
                           TRUE, path->dtotal_units));
 
-      if (disk_result==STATE_OK && erronly && !verbose)
-        continue;
-
       if(disk_result && verbose >= 1) {
 	xasprintf(&flag_header, " %s [", state_text (disk_result));
       } else {
@@ -379,15 +378,27 @@ main (int argc, char **argv)
                 (unsigned long)w_df, (unsigned long)c_df, w_dfp, c_dfp);
       */
 
+      /* OS: #1420 save all not ok paths to different output, but only in case of error only option */
+      if (disk_result!=STATE_OK && erronly) {
+        xasprintf (&ko_output, "%s%s %s %.0f %s (%.0f%%",
+                ko_output, flag_header,
+                (!strcmp(me->me_mountdir, "none") || display_mntp) ? me->me_devname : me->me_mountdir,
+                path->dfree_units,
+                units,
+                path->dfree_pct);
+      }
+
     }
 
+    /* OS: #1420 only show offending paths if error only option is set, but show all paths if everything is ok */
+    output = (erronly && result!=STATE_OK) ? ko_output : output;
   }
 
   if (verbose >= 2)
     xasprintf (&output, "%s%s", output, details);
 
 
-  printf ("DISK %s%s%s|%s\n", state_text (result), (erronly && result==STATE_OK) ? "" : preamble, output, perf);
+  printf ("DISK %s%s%s|%s\n", state_text (result), preamble, output, perf);
   return result;
 }
 


### PR DESCRIPTION
This fix changes output of check_disk in case of --error-only/-e option
is used and state is ok

 - Old output: DISK OK
 - New output: DISK OK - free space: / 159731 MB (83% inode=61%);
   /dev/shm 2926 MB (100% inode=99%); /boot 58 MB (32% inode=99%);

Resolves: #1420