### PR TITLE
check_ide_smart: remove unused function

### DIFF
--- a/plugins/check_ide_smart.c
+++ b/plugins/check_ide_smart.c
@@ -166,7 +166,6 @@ enum SmartCommand
 
 char *get_offline_text (int);
 int smart_read_values (int, values_t *);
-int values_not_passed (values_t *, thresholds_t *);
 int nagios (values_t *, thresholds_t *);
 void print_value (value_t *, threshold_t *);
 void print_values (values_t *, thresholds_t *);
@@ -335,31 +334,6 @@ smart_read_values (int fd, values_t * values)
 	(void)memcpy(values, inbuf, 512);
 #endif /* __NetBSD__ */
 	return 0;
-}
-
-
-
-int
-values_not_passed (values_t * p, thresholds_t * t) 
-{
-	value_t * value = p->values;
-	threshold_t * threshold = t->thresholds;
-	int failed = 0;
-	int passed = 0;
-	int i;
-	for (i = 0; i < NR_ATTRIBUTES; i++) {
-		if (value->id && threshold->id && value->id == threshold->id) {
-			if (value->value < threshold->threshold) {
-				++failed;
-			}
-			else {
-				++passed;
-			}
-		}
-		++value;
-		++threshold;
-	}
-	return (passed ? -failed : 2);
 }
 
 


### PR DESCRIPTION
Remove function unused since commit b5cc292.

Signed-off-by: Sebastian Herbszt <herbszt@gmx.de>