### PR TITLE
check_dig: use +retry instead of +tries

### DIFF
--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -48,7 +48,7 @@ void print_usage (void);
 
 #define UNDEFINED 0
 #define DEFAULT_PORT 53
-#define DEFAULT_TRIES 3
+#define DEFAULT_TRIES 2
 
 char *query_address = NULL;
 char *record_type = "A";
@@ -94,7 +94,7 @@ main (int argc, char **argv)
   timeout_interval_dig = timeout_interval / number_tries + number_tries;
 
   /* get the command to run */
-  xasprintf (&command_line, "%s %s %s -p %d @%s %s %s +tries=%d +time=%d",
+  xasprintf (&command_line, "%s %s %s -p %d @%s %s %s +retry=%d +time=%d",
             PATH_TO_DIG, dig_args, query_transport, server_port, dns_server, query_address, record_type, number_tries, timeout_interval_dig);
 
   alarm (timeout_interval);


### PR DESCRIPTION
After upgrading from an Ubuntu/15.10 to 16.04 installation, I noticed that
check_dig is always returning a WARNING:

$ /usr/lib/nagios/plugins/check_dig -l localhost -v
/usr/bin/dig   -p 53 @127.0.0.1 localhost A +tries=3 +time=6
Looking for: 'localhost'
DNS WARNING - 0.008 seconds response time (dig returned an error status)|time=0.008274s;;;0.000000

The older Ubuntu installation got its check_dig from the
nagios-plugins-standard package[0] which did not include the +tries
option. The current Ubuntu version provides its check_dig from the
monitoring-plugins-standard package[1], which _does_ use the +tries
option that was introduced with df53473[2].

On my system, it so happens that /usr/bin/dig is provided not by the
(BIND) dnsutils package but by knot-dnsutils[3] from the Knot DNS project.
The Knot dig(1) command doesn't support the +tries option[4] but does
support +retry (which is also supported[5] by the BIND dig(1) command).

One way to fix that would be for me to install the BIND dnsutils package. But I did not
want to do that: it's so much larger in size and pulls in much more dependencies
than the knot-dnsutils package.

The patch below changes check_dig to use +retry instead of +tries. Both
options are similar, but not the same:

 +retry - Sets the number of times to retry UDP queries to server to T
          instead of the default, 2. Unlike +tries, this does not include
          the initial query

As number_tries seems to be hard coded to 3, I've lowered DEFAULT_TRIES to
2 so check_dig should behave as before (with +tries=3).

Thanks,
Christian.

[0] http://packages.ubuntu.com/wily/nagios-plugins-standard
[1] http://packages.ubuntu.com/xenial/monitoring-plugins-standard
[2] https://github.com/monitoring-plugins/monitoring-plugins/commit/df53473
[3] http://packages.ubuntu.com/xenial/knot-dnsutils
[4] https://www.knot-dns.cz/docs/2.x/html/man_kdig.html#notes
[5] https://ftp.isc.org/isc/bind9/cur/9.10/doc/arm/man.dig.html

Signed-off-by: Christian Kujau <lists@nerdbynature.de>