### PR TITLE
add openssl 1.1 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -493,15 +493,15 @@ if ! test x"$with_openssl" = x"no"; then
 	dnl Check for crypto lib
 	_SAVEDLIBS="$LIBS"
 	LIBS="-L${with_openssl}/lib"
-	AC_CHECK_LIB(crypto,CRYPTO_lock)
-	if test "$ac_cv_lib_crypto_CRYPTO_lock" = "yes"; then
+	AC_CHECK_LIB(crypto,CRYPTO_new_ex_data)
+	if test "$ac_cv_lib_crypto_CRYPTO_new_ex_data" = "yes"; then
 		dnl Check for SSL lib
 		AC_CHECK_LIB(ssl,main, SSLLIBS="-lssl -lcrypto",,-lcrypto)
 	fi
 	LIBS="$_SAVEDLIBS"
 
 	dnl test headers and libs to decide whether check_http should use SSL
-	if test "$ac_cv_lib_crypto_CRYPTO_lock" = "yes"; then
+	if test "$ac_cv_lib_crypto_CRYPTO_new_ex_data" = "yes"; then
 		if test "$ac_cv_lib_ssl_main" = "yes"; then
 			if test "$FOUNDINCLUDE" = "yes"; then
 				FOUNDOPENSSL="yes"

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -941,8 +941,8 @@ check_http (void)
     elapsed_time_ssl = (double)microsec_ssl / 1.0e6;
     if (check_cert == TRUE) {
       result = np_net_ssl_check_cert(days_till_exp_warn, days_till_exp_crit);
-      np_net_ssl_cleanup();
       if (sd) close(sd);
+      np_net_ssl_cleanup();
       return result;
     }
   }
@@ -1086,10 +1086,10 @@ check_http (void)
     die (STATE_CRITICAL, _("HTTP CRITICAL - No data received from host\n"));
 
   /* close the connection */
+  if (sd) close(sd);
 #ifdef HAVE_SSL
   np_net_ssl_cleanup();
 #endif
-  if (sd) close(sd);
 
   /* Save check time */
   microsec = deltime (tv);

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -239,8 +239,8 @@ main (int argc, char **argv)
 		  result = np_net_ssl_init(sd);
 		  if(result != STATE_OK) {
 		    printf (_("CRITICAL - Cannot create SSL context.\n"));
-		    np_net_ssl_cleanup();
 		    close(sd);
+		    np_net_ssl_cleanup();
 		    return STATE_CRITICAL;
 		  } else {
 			ssl_established = 1;
@@ -764,10 +764,12 @@ recvlines(char *buf, size_t bufsize)
 int
 my_close (void)
 {
+	int result;
+	result = close(sd);
 #ifdef HAVE_SSL
-  np_net_ssl_cleanup();
+	np_net_ssl_cleanup();
 #endif
-  return close(sd);
+	return result;
 }
 
 

--- a/plugins/check_tcp.c
+++ b/plugins/check_tcp.c
@@ -247,8 +247,8 @@ main (int argc, char **argv)
 		}
 	}
 	if(result != STATE_OK){
-		np_net_ssl_cleanup();
 		if(sd) close(sd);
+		np_net_ssl_cleanup();
 		return result;
 	}
 #endif /* HAVE_SSL */
@@ -321,10 +321,10 @@ main (int argc, char **argv)
 	if (server_quit != NULL) {
 		my_send(server_quit, strlen(server_quit));
 	}
+	if (sd) close (sd);
 #ifdef HAVE_SSL
 	np_net_ssl_cleanup();
 #endif
-	if (sd) close (sd);
 
 	microsec = deltime (tv);
 	elapsed_time = (double)microsec / 1.0e6;

--- a/plugins/common.h
+++ b/plugins/common.h
@@ -161,6 +161,13 @@
 #  endif
 #endif
 
+/* openssl 1.1 does not set OPENSSL_NO_SSL2 by default but ships without ssl2 */
+#ifdef OPENSSL_VERSION_NUMBER
+#  if OPENSSL_VERSION_NUMBER >= 0x10100000
+#   define OPENSSL_NO_SSL2
+#  endif
+#endif
+
 /*
  *
  * Standard Values


### PR DESCRIPTION
changes:
  - CRYPTO_lock detection replaced in configure.ac. We don't use that
    function anywhere, so just replace it with the suggested one from
    https://wiki.openssl.org/index.php/Library_Initialization#Autoconf
  - OPENSSL_NO_SSL2 is no longer defined while ssl2 is not included.
    Set it ourself using the suggested openssl 1.1 version check from
    https://wiki.openssl.org/index.php/1.1_API_Changes#Backward_compatibility
  - openssl 1.1 sends a sigpipe if the connection is still open when
     calling SSL_shutdown(), so move the close before the shutdown.

Signed-off-by: Sven Nierlein <sven@nierlein.de>