### PR TITLE
properly remove MSG_PEEK in check_dhcp.c.

### DIFF
--- a/plugins-root/check_dhcp.c
+++ b/plugins-root/check_dhcp.c
@@ -693,7 +693,7 @@ int receive_dhcp_packet(void *buffer, int buffer_size, int sock, int timeout, st
         else{
 		bzero(&source_address,sizeof(source_address));
 		address_size=sizeof(source_address);
-                recv_result=recvfrom(sock,(char *)buffer,buffer_size,MSG_PEEK,(struct sockaddr *)&source_address,&address_size);
+                recv_result=recvfrom(sock,(char *)buffer,buffer_size,0,(struct sockaddr *)&source_address,&address_size);
 		if(verbose)
 			printf("recv_result: %d\n",recv_result);
 


### PR DESCRIPTION
As per the comment in the logged issue, this fixes #1450.