### PR TITLE
check_dns: Accept CIDR

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 This file documents the major additions and syntax changes between releases.
 
 2.3 [...]
+	ENHANCEMENTS
+	check_dns: allow 'expected address' (-a) to be specified in CIDR notation
+	  (IPv4 only).
+
 	FIXES
 	Fix regression where check_dhcp was rereading response in a tight loop
 

--- a/THANKS.in
+++ b/THANKS.in
@@ -355,3 +355,4 @@ Michael Melcher
 Sven Geggus
 Thomas Kurschel
 Yannick Charton
+Nicolai Søborg

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -42,6 +42,8 @@ const char *email = "devel@monitoring-plugins.org";
 int process_arguments (int, char **);
 int validate_arguments (void);
 int error_scan (char *);
+int ip_match_cidr(const char *, const char *);
+unsigned long ip2long(const char *);
 void print_help (void);
 void print_usage (void);
 
@@ -226,9 +228,14 @@ main (int argc, char **argv)
   if (result == STATE_OK && expected_address_cnt > 0) {
     result = STATE_CRITICAL;
     temp_buffer = "";
+
     for (i=0; i<expected_address_cnt; i++) {
-      /* check if we get a match and prepare an error string */
-      if (strcmp(address, expected_address[i]) == 0) result = STATE_OK;
+      /* check if we get a match on 'raw' ip or cidr */
+      if ( strcmp(address, expected_address[i]) == 0
+           || ip_match_cidr(address, expected_address[i]) )
+        result = STATE_OK;
+
+      /* prepare an error string */
       xasprintf(&temp_buffer, "%s%s; ", temp_buffer, expected_address[i]);
     }
     if (result == STATE_CRITICAL) {
@@ -289,7 +296,32 @@ main (int argc, char **argv)
   return result;
 }
 
+int
+ip_match_cidr(const char *addr, const char *cidr_ro)
+{
+  char *subnet, *mask_c, *cidr = strdup(cidr_ro);
+  int mask;
+  subnet = strtok(cidr, "/");
+  mask_c = strtok(NULL, "\0");
+  if (!subnet || !mask_c)
+    return FALSE;
+  mask = atoi(mask_c);
 
+  /* https://www.cryptobells.com/verifying-ips-in-a-subnet-in-php/ */
+  return ( ip2long(addr) & ~ ( ( 1 << ( 32 - mask ) ) - 1 ) ) == ( ip2long(subnet) >> (32 - mask) ) << (32 - mask);
+}
+
+unsigned long
+ip2long(const char* src) {
+  unsigned long ip[4];
+  /* http://computer-programming-forum.com/47-c-language/1376ffb92a12c471.htm */
+  return (sscanf(src, "%3lu.%3lu.%3lu.%3lu",
+                     &ip[0], &ip[1], &ip[2], &ip[3]) == 4 &&
+              ip[0] < 256 && ip[1] < 256 &&
+              ip[2] < 256 && ip[3] < 256)
+          ? ip[0] << 24 | ip[1] << 16 | ip[2] << 8 | ip[3]
+          : 0; 
+}
 
 int
 error_scan (char *input_buffer)
@@ -494,9 +526,9 @@ print_help (void)
   printf ("    %s\n", _("The name or address you want to query"));
   printf (" -s, --server=HOST\n");
   printf ("    %s\n", _("Optional DNS server you want to use for the lookup"));
-  printf (" -a, --expected-address=IP-ADDRESS|HOST\n");
-  printf ("    %s\n", _("Optional IP-ADDRESS you expect the DNS server to return. HOST must end with"));
-  printf ("    %s\n", _("a dot (.). This option can be repeated multiple times (Returns OK if any"));
+  printf (" -a, --expected-address=IP-ADDRESS|CIDR|HOST\n");
+  printf ("    %s\n", _("Optional IP-ADDRESS/CIDR you expect the DNS server to return. HOST must end"));
+  printf ("    %s\n", _("with a dot (.). This option can be repeated multiple times (Returns OK if any"));
   printf ("    %s\n", _("value match). If multiple addresses are returned at once, you have to match"));
   printf ("    %s\n", _("the whole string of addresses separated with commas (sorted alphabetically)."));
   printf (" -A, --expect-authority\n");

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -308,7 +308,7 @@ ip_match_cidr(const char *addr, const char *cidr_ro)
   mask = atoi(mask_c);
 
   /* https://www.cryptobells.com/verifying-ips-in-a-subnet-in-php/ */
-  return ( ip2long(addr) & ~ ( ( 1 << ( 32 - mask ) ) - 1 ) ) == ( ip2long(subnet) >> (32 - mask) ) << (32 - mask);
+  return (ip2long(addr) & ~((1 << (32 - mask)) - 1)) == (ip2long(subnet) >> (32 - mask)) << (32 - mask);
 }
 
 unsigned long

--- a/plugins/t/NPTest.cache.travis
+++ b/plugins/t/NPTest.cache.travis
@@ -4,7 +4,7 @@
   'NP_DNS_SERVER' => '8.8.8.8',
   'NP_GOOD_NTP_SERVICE' => '',
   'NP_HOSTNAME_INVALID' => 'nosuchhost',
-  'NP_HOSTNAME_VALID' => 'monitoringplugins.org',
+  'NP_HOSTNAME_VALID' => 'monitoring-plugins.org',
   'NP_HOSTNAME_VALID_IP' => '130.133.8.40',
   'NP_HOSTNAME_VALID_CIDR' => '130.133.8.41/30',
   'NP_HOSTNAME_INVALID_CIDR' => '130.133.8.39/30',

--- a/plugins/t/NPTest.cache.travis
+++ b/plugins/t/NPTest.cache.travis
@@ -6,6 +6,8 @@
   'NP_HOSTNAME_INVALID' => 'nosuchhost',
   'NP_HOSTNAME_VALID' => 'monitoringplugins.org',
   'NP_HOSTNAME_VALID_IP' => '130.133.8.40',
+  'NP_HOSTNAME_VALID_CIDR' => '130.133.8.41/30',
+  'NP_HOSTNAME_INVALID_CIDR' => '130.133.8.39/30',
   'NP_HOSTNAME_VALID_REVERSE' => 'orwell.monitoring-plugins.org.',
   'NP_HOST_DHCP_RESPONSIVE' => '',
   'NP_HOST_NONRESPONSIVE' => '10.0.0.1',

--- a/plugins/t/check_dns.t
+++ b/plugins/t/check_dns.t
@@ -17,7 +17,7 @@ my $successOutput = '/DNS OK: [\.0-9]+ seconds? response time/';
 my $hostname_valid = getTestParameter( 
 			"NP_HOSTNAME_VALID",
 			"A valid (known to DNS) hostname",
-			"monitoring-plugins.org"
+			"monitoring-plugins.org",
 			);
 
 my $hostname_valid_ip = getTestParameter(
@@ -34,14 +34,14 @@ my $hostname_valid_cidr = getTestParameter(
 
 my $hostname_invalid_cidr = getTestParameter(
 			"NP_HOSTNAME_INVALID_CIDR",
-			"An valid CIDR range not containing $hostname_valid_ip",
+			"An (valid) CIDR range NOT containing $hostname_valid_ip",
 			"130.133.8.39/30",
 			);
 
 my $hostname_valid_reverse = getTestParameter(
 			"NP_HOSTNAME_VALID_REVERSE",
 			"The hostname of $hostname_valid_ip",
-			"66-118-156-50.static.sagonet.net.",
+			"orwell.monitoring-plugins.org.",
 			);
 
 my $hostname_invalid = getTestParameter( 

--- a/plugins/t/check_dns.t
+++ b/plugins/t/check_dns.t
@@ -10,7 +10,7 @@ use NPTest;
 
 plan skip_all => "check_dns not compiled" unless (-x "check_dns");
 
-plan tests => 16;
+plan tests => 19;
 
 my $successOutput = '/DNS OK: [\.0-9]+ seconds? response time/';
 
@@ -23,7 +23,19 @@ my $hostname_valid = getTestParameter(
 my $hostname_valid_ip = getTestParameter(
 			"NP_HOSTNAME_VALID_IP",
 			"The IP address of the valid hostname $hostname_valid",
-			"66.118.156.50",
+			"130.133.8.40",
+			);
+
+my $hostname_valid_cidr = getTestParameter(
+			"NP_HOSTNAME_VALID_CIDR",
+			"An valid CIDR range containing $hostname_valid_ip",
+			"130.133.8.41/30",
+			);
+
+my $hostname_invalid_cidr = getTestParameter(
+			"NP_HOSTNAME_INVALID_CIDR",
+			"An valid CIDR range not containing $hostname_valid_ip",
+			"130.133.8.39/30",
 			);
 
 my $hostname_valid_reverse = getTestParameter(
@@ -87,3 +99,9 @@ $res = NPTest->testCmd("./check_dns -H $hostname_valid_ip -a $hostname_valid_rev
 cmp_ok( $res->return_code, '==', 0, "Got expected fqdn");
 like  ( $res->output, $successOutput, "Output OK");
 
+$res = NPTest->testCmd("./check_dns -H $hostname_valid -a $hostname_valid_cidr -t 5");
+cmp_ok( $res->return_code, '==', 0, "Got expected address");
+
+$res = NPTest->testCmd("./check_dns -H $hostname_valid -a $hostname_invalid_cidr -t 5");
+cmp_ok( $res->return_code, '==', 2, "Got wrong address");
+like  ( $res->output, "/^DNS CRITICAL.*expected '$hostname_invalid_cidr' but got '$hostname_valid_ip'".'$/', "Output OK");


### PR DESCRIPTION
Improve `check_dns` by allowing the _expected address_ to be specified by CIDR notation (IPv4 only).