### PR TITLE
Enable check_file_age to test for maximum file size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ install:
   - sudo apt-get install -qq --no-install-recommends slapd ldap-utils
   - sudo apt-get install -qq --no-install-recommends autoconf automake
   - sudo apt-get install -qq --no-install-recommends faketime
+  - sudo apt-get install -qq --no-install-recommends libmonitoring-plugin-perl
   # Trusty related dependencies (not yet provided)
   - test "$(dpkg -l | grep -E "mysql-(client|server)-[0-9].[0-9]" | grep -c ^ii)" -gt 0 || sudo apt-get install -qq --no-install-recommends mariadb-client mariadb-server
 

--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -57,7 +57,7 @@ GetOptions(
 	"C=s" => \$opt_C, "critical-size=s" => \$opt_C);
 
 if ($opt_V) {
-	print_revision($PROGNAME, '2.2.22.g0d73b');
+	print_revision($PROGNAME, '@NP_VERSION@');
 	exit $ERRORS{'UNKNOWN'};
 }
 
@@ -152,9 +152,9 @@ sub print_help () {
 	print "  If any of the warning and critical arguments are in range syntax (not just bare numbers)\n";
 	print "  then all warning and critical arguments will be interpreted as ranges.\n";
 	print "  To use range processing the perl module Monitoring::Plugin must be installed\n";
-	print "  For range syntax see https://nagios-plugins.org/doc/guidelines.html#THRESHOLDFORMAT\n";
+	print "  For range syntax see https://www.monitoring-plugins.org/doc/guidelines.html#THRESHOLDFORMAT\n";
 	print "  It is strongly recommended when using range syntax that all four of -w, -W, -c and -C are specified\n";
-	print "  otherwise it is unlikely that the size test will be doint wat is desired\n";
+	print "  otherwise it is unlikely that the size test will be doing what is desired\n";
 	print "\n";
 	support();
 }

--- a/plugins-scripts/check_file_age.pl
+++ b/plugins-scripts/check_file_age.pl
@@ -43,8 +43,6 @@ $ENV{'ENV'}='';
 
 $opt_w = 240;
 $opt_c = 600;
-$opt_W = 0;
-$opt_C = 0;
 $opt_f = "";
 
 Getopt::Long::Configure('bundling');
@@ -53,13 +51,13 @@ GetOptions(
 	"h"   => \$opt_h, "help"	=> \$opt_h,
 	"i"   => \$opt_i, "ignore-missing"	=> \$opt_i,
 	"f=s" => \$opt_f, "file"	=> \$opt_f,
-	"w=f" => \$opt_w, "warning-age=f" => \$opt_w,
-	"W=f" => \$opt_W, "warning-size=f" => \$opt_W,
-	"c=f" => \$opt_c, "critical-age=f" => \$opt_c,
-	"C=f" => \$opt_C, "critical-size=f" => \$opt_C);
+	"w=s" => \$opt_w, "warning-age=s" => \$opt_w,
+	"W=s" => \$opt_W, "warning-size=s" => \$opt_W,
+	"c=s" => \$opt_c, "critical-age=s" => \$opt_c,
+	"C=s" => \$opt_C, "critical-size=s" => \$opt_C);
 
 if ($opt_V) {
-	print_revision($PROGNAME, '@NP_VERSION@');
+	print_revision($PROGNAME, '2.2.22.g0d73b');
 	exit $ERRORS{'UNKNOWN'};
 }
 
@@ -91,18 +89,47 @@ unless (-e $opt_f) {
 $st = File::stat::stat($opt_f);
 $age = time - $st->mtime;
 $size = $st->size;
-$perfdata = "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0";
-
 
 $result = 'OK';
 
-if (($opt_c and $age > $opt_c) or ($opt_C and $size < $opt_C)) {
-	$result = 'CRITICAL';
+if ($opt_c !~ m/^\d+$/ or ($opt_C and $opt_C !~ m/^\d+$/)
+		or $opt_w !~ m/^\d+$/ or ($opt_W and $opt_W !~ m/^\d+$/)) {
+	# range has been specified so use M::P::R to process
+	require Monitoring::Plugin::Range;
+	# use permissive range defaults for size when none specified
+	$opt_W = "0:" unless ($opt_W);
+	$opt_C = "0:" unless ($opt_C);
+
+	if (Monitoring::Plugin::Range->parse_range_string($opt_c)
+		->check_range($age) == 1) { # 1 means it raises an alert because it's OUTSIDE the range
+			$result = 'CRITICAL';
+	}
+	elsif (Monitoring::Plugin::Range->parse_range_string($opt_C)
+		->check_range($size) == 1) {
+			$result = 'CRITICAL';
+	}
+	elsif (Monitoring::Plugin::Range->parse_range_string($opt_w)
+		->check_range($age) == 1) {
+			$result = 'WARNING';
+	}
+	elsif (Monitoring::Plugin::Range->parse_range_string($opt_W)
+		->check_range($size) == 1) {
+			$result = 'WARNING';
+	}
 }
-elsif (($opt_w and $age > $opt_w) or ($opt_W and $size < $opt_W)) {
-	$result = 'WARNING';
+else {
+	# use permissive defaults for size when none specified
+	$opt_W = 0 unless ($opt_W);
+	$opt_C = 0 unless ($opt_C);
+	if ($age > $opt_c or $size < $opt_C) {
+		$result = 'CRITICAL';
+	}
+	elsif ($age > $opt_w or $size < $opt_W) {
+		$result = 'WARNING';
+	}
 }
 
+$perfdata = "age=${age}s;${opt_w};${opt_c} size=${size}B;${opt_W};${opt_C};0";
 print "FILE_AGE $result: $opt_f is $age seconds old and $size bytes | $perfdata\n";
 exit $ERRORS{$result};
 
@@ -120,7 +147,15 @@ sub print_help () {
 	print "\n";
 	print "  -i | --ignore-missing :  return OK if the file does not exist\n";
 	print "  <secs>  File must be no more than this many seconds old (default: warn 240 secs, crit 600)\n";
-	print "  <size>  File must be at least this many bytes long (default: crit 0 bytes)\n";
+	print "  <size>  File must be at least this many bytes long (default: crit 0 bytes)\n\n";
+	print "  Both <secs> and <size> can specify a range using the standard plugin syntax\n";
+	print "  If any of the warning and critical arguments are in range syntax (not just bare numbers)\n";
+	print "  then all warning and critical arguments will be interpreted as ranges.\n";
+	print "  To use range processing the perl module Monitoring::Plugin must be installed\n";
+	print "  For range syntax see https://nagios-plugins.org/doc/guidelines.html#THRESHOLDFORMAT\n";
+	print "  It is strongly recommended when using range syntax that all four of -w, -W, -c and -C are specified\n";
+	print "  otherwise it is unlikely that the size test will be doint wat is desired\n";
 	print "\n";
 	support();
 }
+

--- a/plugins-scripts/t/check_file_age.t
+++ b/plugins-scripts/t/check_file_age.t
@@ -5,14 +5,14 @@
 #
 
 use strict;
-use Test::More tests => 17;
+use Test::More tests => 27;
 use NPTest;
 
 my $successOutput = '/^FILE_AGE OK: /';
 my $warningOutput = '/^FILE_AGE WARNING: /';
 my $criticalOutput = '/^FILE_AGE CRITICAL: /';
 my $unknownOutput = '/^FILE_AGE UNKNOWN: /';
-my $performanceOutput = '/ \| age=[0-9]+s;[0-9]+;[0-9]+ size=[0-9]+B;[0-9]+;[0-9]+;0$/';
+my $performanceOutput = '/ \| age=[0-9]+s;[0-9:]+;[0-9:]+ size=[0-9]+B;[0-9:]+;[0-9:]+;0$/';
 
 my $result;
 my $temp_file = "/tmp/check_file_age.tmp";
@@ -48,10 +48,22 @@ cmp_ok( $result->return_code, '==', 1, "Warning for file over 1 second old" );
 like  ( $result->output, $warningOutput, "Output for warning correct" );
 
 $result = NPTest->testCmd(
+	"./check_file_age -f $temp_file -w 0:1"
+	);
+cmp_ok( $result->return_code, '==', 1, "Warning for file over 1 second old by range" );
+like  ( $result->output, $warningOutput, "Output for warning by range correct" );
+
+$result = NPTest->testCmd(
 	"./check_file_age -f $temp_file -c 1"
 	);
 cmp_ok( $result->return_code, '==', 2, "Critical for file over 1 second old" );
 like  ( $result->output, $criticalOutput, "Output for critical correct" );
+
+$result = NPTest->testCmd(
+	"./check_file_age -f $temp_file -c 0:1"
+	);
+cmp_ok( $result->return_code, '==', 2, "Critical for file over 1 second old by range" );
+like  ( $result->output, $criticalOutput, "Output for critical by range correct" );
 
 $result = NPTest->testCmd(
 	"./check_file_age -f $temp_file -c 1000 -W 100"
@@ -59,9 +71,19 @@ $result = NPTest->testCmd(
 cmp_ok( $result->return_code, '==', 0, "Checking file size" );
 
 $result = NPTest->testCmd(
+	"./check_file_age -f $temp_file -c 0:1000 -W 0:100"
+	);
+cmp_ok( $result->return_code, '==', 0, "Checking file size by range" );
+
+$result = NPTest->testCmd(
 	"./check_file_age -f $temp_file -c 1000 -W 100"
 	);
 like( $result->output, $performanceOutput, "Checking for performance Output" );
+
+$result = NPTest->testCmd(
+	"./check_file_age -f $temp_file -c 1000 -W 100"
+	);
+like( $result->output, $performanceOutput, "Checking for performance Output from range" );
 
 $result = NPTest->testCmd(
 	"./check_file_age -f /non/existent --ignore-missing"
@@ -74,9 +96,29 @@ $result = NPTest->testCmd(
 cmp_ok( $result->return_code, '==', 1, "One byte too short" );
 
 $result = NPTest->testCmd(
+	"./check_file_age -f $temp_file -c 1000 -W 101:"
+	);
+cmp_ok( $result->return_code, '==', 1, "One byte too short by range" );
+
+$result = NPTest->testCmd(
 	"./check_file_age -f $temp_file -c 1000 -C 101"
 	);
 cmp_ok( $result->return_code, '==', 2, "One byte too short - critical" );
+
+$result = NPTest->testCmd(
+	"./check_file_age -f $temp_file -c 1000 -C 101:"
+	);
+cmp_ok( $result->return_code, '==', 2, "One byte too short by range - critical" );
+
+$result = NPTest->testCmd(
+	"./check_file_age -f $temp_file -c 1000 -W 0:99"
+	);
+cmp_ok( $result->return_code, '==', 1, "One byte too long by range" );
+
+$result = NPTest->testCmd(
+	"./check_file_age -f $temp_file -c 1000 -C 0:99"
+	);
+cmp_ok( $result->return_code, '==', 2, "One byte too long by range - critical" );
 
 symlink $temp_file, $temp_link or die "Cannot create symlink";
 $result = NPTest->testCmd("./check_file_age -f $temp_link -c 10");


### PR DESCRIPTION
Useful when a regular process overwrites a file showing the current status. In my use case, the error output from a regular rsync so I can check there were no errors