### PR TITLE
check_snmp: put the "c" (to mark a counter) after the perfdata value

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -576,6 +576,9 @@ main (int argc, char **argv)
 			len = sizeof(perfstr)-strlen(perfstr)-1;
 			strncat(perfstr, show, len>ptr-show ? ptr-show : len);
 
+			if (type)
+				strncat(perfstr, type, sizeof(perfstr)-strlen(perfstr)-1);
+
 			if (warning_thresholds) {
 				strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
 				strncat(perfstr, warning_thresholds, sizeof(perfstr)-strlen(perfstr)-1);
@@ -588,8 +591,6 @@ main (int argc, char **argv)
 				strncat(perfstr, critical_thresholds, sizeof(perfstr)-strlen(perfstr)-1);
 			}
 
-			if (type)
-				strncat(perfstr, type, sizeof(perfstr)-strlen(perfstr)-1);
 			strncat(perfstr, " ", sizeof(perfstr)-strlen(perfstr)-1);
 		}
 	}


### PR DESCRIPTION
Hi,

`
OMD /tmp$ /omd/sites/nonprod/lib/nagios/plugins/check_snmp -H razormail1 -o 1.3.6.1.4.1.3246.2.2.1.4.3.1 -n -C 'public' -P 2c -w 100 -c 100 -l 'Mail queue length' -vv
/bin/snmpgetnext -Le -t 10 -r 5 -m '' -v 2c [context] [authpriv] razormail1:161 1.3.6.1.4.1.3246.2.2.1.4.3.1
iso.3.6.1.4.1.3246.2.2.1.4.3.1.0 = Counter32: 0
SNMP OK - Mail queue length 0 | 'Mail queue length'=0;100;100c 
`

The "c" does not belong at the end of the perfdata string. It must be _'Mail queue length'=0c;100;100_

Gerhard