### PR TITLE
make tests more reliable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,18 @@ before_install:
 install:
   - sudo apt-get install -qq --no-install-recommends perl autotools-dev libdbi-dev libldap2-dev libpq-dev libmysqlclient-dev libradcli-dev libkrb5-dev libnet-snmp-perl procps
   - sudo apt-get install -qq --no-install-recommends libdbi0-dev libdbd-sqlite3 libssl-dev dnsutils snmp-mibs-downloader libsnmp-perl snmpd
-  - sudo apt-get install -qq --no-install-recommends fping snmp netcat smbclient fping pure-ftpd apache2 postfix libhttp-daemon-ssl-perl
+  - sudo apt-get install -qq --no-install-recommends fping snmp netcat smbclient fping pure-ftpd apache2 ssl-cert postfix libhttp-daemon-ssl-perl
   - sudo apt-get install -qq --no-install-recommends libdbd-sybase-perl libnet-dns-perl
   - sudo apt-get install -qq --no-install-recommends slapd ldap-utils
   - sudo apt-get install -qq --no-install-recommends autoconf automake
   - sudo apt-get install -qq --no-install-recommends faketime
   # Trusty related dependencies (not yet provided)
   - test "$(dpkg -l | grep -E "mysql-(client|server)-[0-9].[0-9]" | grep -c ^ii)" -gt 0 || sudo apt-get install -qq --no-install-recommends mariadb-client mariadb-server
+  # enable ssl apache
+  - sudo a2enmod ssl
+  - sudo a2ensite default-ssl
+  - sudo make-ssl-cert generate-default-snakeoil --force-overwrite
+  - sudo service apache2 reload
 
 before_script:
   # ensure we have a test database in place for tests
@@ -73,6 +78,7 @@ before_script:
   - sudo rm -f /usr/share/mibs/ietf/SNMPv2-PDU /usr/share/mibs/ietf/IPSEC-SPD-MIB /usr/share/mibs/ietf/IPATM-IPMC-MIB /usr/share/mibs/iana/IANA-IPPM-METRICS-REGISTRY-MIB
   - sudo mkdir -p /var/lib/snmp/mib_indexes
   - sudo mkdir /media/ramdisk && sudo chmod 777 /media/ramdisk && sudo mount -t tmpfs -o size=20% none /media/ramdisk
+  - sed "/host_tls_cert/s/.*/'host_tls_cert' => '$(hostname)',/" -i $NPTEST_CACHE
 
 script:
   - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then make test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,12 @@ matrix:
 before_install:
   # Trusty related fixed
   # multiverse is no on trusty activated (https://github.com/travis-ci/travis-ci/issues/4979)
+  - sudo apt-get install -qq --no-install-recommends software-properties-common
   - sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty multiverse" && sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu/ trusty-updates multiverse"
   # /etc/hosts has IPv6 hosts (https://github.com/travis-ci/travis-ci/issues/4978)
-  - sudo [ $(ip addr show | grep "inet6 ::1" | wc -l) -lt "1" ] && sudo sed -i '/^::1/d' /etc/hosts
+  - sudo [ $(ip addr show | grep "inet6 ::1" | wc -l) -eq "0" ] || sudo sed -i '/^::1/d' /etc/hosts
   # Trusty has running ntpd on localhost, but we don't like that for our tests
-  - sudo killall -9 ntpd
+  - "sudo killall -9 ntpd ||:"
   # Trusty has no swap, lets create some
   - sudo fallocate -l 20M /swapfile; sudo chmod 600 /swapfile; sudo mkswap /swapfile; sudo swapon /swapfile
   - sudo add-apt-repository -y ppa:waja/trusty-backports

--- a/plugins-scripts/check_disk_smb.pl
+++ b/plugins-scripts/check_disk_smb.pl
@@ -19,7 +19,7 @@
 #
 
 require 5.004;
-use POSIX;
+use POSIX qw(setsid);
 use strict;
 use Getopt::Long;
 use vars qw($opt_P $opt_V $opt_h $opt_H $opt_s $opt_W $opt_u $opt_p $opt_w $opt_c $opt_a $verbose);
@@ -27,6 +27,9 @@ use vars qw($PROGNAME);
 use FindBin;
 use lib "$FindBin::Bin";
 use utils qw($TIMEOUT %ERRORS &print_revision &support &usage);
+
+# make us session leader which makes all childs exit if we do
+setsid;
 
 sub print_help ();
 sub print_usage ();
@@ -175,6 +178,8 @@ my @lines = undef;
 # Just in case of problems, let's not hang the monitoring system
 $SIG{'ALRM'} = sub { 
 	print "No Answer from Client\n";
+    $SIG{'INT'} = 'IGNORE';
+    kill(-2, $$);
 	exit $ERRORS{"UNKNOWN"};
 };
 alarm($TIMEOUT);

--- a/plugins/t/NPTest.cache.travis
+++ b/plugins/t/NPTest.cache.travis
@@ -57,4 +57,6 @@
   'snmp_community' => '',
   'user_snmp' => '',
   'host_udp_time' => 'none',
+  'host_tls_http' => 'localhost',
+  'host_tls_cert' => 'localhost',
 }

--- a/plugins/t/check_disk.t
+++ b/plugins/t/check_disk.t
@@ -248,11 +248,11 @@ $result = NPTest->testCmd( "./check_disk -w 100% -c 100% ".${mountpoint_valid} )
 cmp_ok( $result->return_code, "==", 2, "100% empty" );
 like( $result->output, $failureOutput, "Right output" );
 
-$result = NPTest->testCmd( "./check_disk -w 100000 -c 100000 $mountpoint_valid" );
-cmp_ok( $result->return_code, '==', 2, "Check for 100GB free" );
+$result = NPTest->testCmd( "./check_disk -w 100000000 -c 100000000 $mountpoint_valid" );
+cmp_ok( $result->return_code, '==', 2, "Check for 100TB free" );
 
-$result = NPTest->testCmd( "./check_disk -w 100 -c 100 -u GB ".${mountpoint_valid} );      # 100 GB empty
-cmp_ok( $result->return_code, "==", 2, "100 GB empty" );
+$result = NPTest->testCmd( "./check_disk -w 100 -c 100 -u TB ".${mountpoint_valid} );      # 100 TB empty
+cmp_ok( $result->return_code, "==", 2, "100 TB empty" );
 
 
 # Checking old syntax of check_disk warn crit [fs], with warn/crit at USED% thresholds

--- a/plugins/t/check_http.t
+++ b/plugins/t/check_http.t
@@ -19,6 +19,13 @@ my $host_tcp_http      = getTestParameter( "NP_HOST_TCP_HTTP",
 		"A host providing the HTTP Service (a web server)",
 		"localhost" );
 
+my $host_tls_http      = getTestParameter( "host_tls_http",      "NP_HOST_TLS_HTTP",      "localhost",
+					   "A host providing the HTTPS Service (a tls web server)" );
+
+my $host_tls_cert      = getTestParameter( "host_tls_cert",      "NP_HOST_TLS_CERT",      "localhost",
+					   "the common name of the certificate." );
+
+
 my $host_nonresponsive = getTestParameter( "NP_HOST_NONRESPONSIVE",
 		"The hostname of system not responsive to network requests",
 		"10.0.0.1" );
@@ -80,14 +87,14 @@ like( $res->output, '/^Host: '.$host_tcp_http.':8080\s*$/ms', "Host Header OK" )
 SKIP: {
         skip "No internet access", 3 if $internet_access eq "no";
 
-        $res = NPTest->testCmd("./check_http -v -H www.verisign.com -S");
-        like( $res->output, '/^Host: www.verisign.com\s*$/ms', "Host Header OK" );
+        $res = NPTest->testCmd("./check_http -v -H $host_tls_http -S");
+        like( $res->output, '/^Host: '.$host_tls_http.'\s*$/ms', "Host Header OK" );
 
-        $res = NPTest->testCmd("./check_http -v -H www.verisign.com:8080 -S -p 443");
-        like( $res->output, '/^Host: www.verisign.com:8080\s*$/ms', "Host Header OK" );
+        $res = NPTest->testCmd("./check_http -v -H $host_tls_http:8080 -S -p 443");
+        like( $res->output, '/^Host: '.$host_tls_http.':8080\s*$/ms', "Host Header OK" );
 
-        $res = NPTest->testCmd("./check_http -v -H www.verisign.com:443 -S -p 443");
-        like( $res->output, '/^Host: www.verisign.com\s*$/ms', "Host Header OK" );
+        $res = NPTest->testCmd("./check_http -v -H $host_tls_http:443 -S -p 443");
+        like( $res->output, '/^Host: '.$host_tls_http.'\s*$/ms', "Host Header OK" );
 };
 
 SKIP: {
@@ -114,38 +121,38 @@ SKIP: {
         skip "No internet access", 16 if $internet_access eq "no";
 
         $res = NPTest->testCmd(
-                "./check_http --ssl www.verisign.com"
+                "./check_http --ssl $host_tls_http"
                 );
-        cmp_ok( $res->return_code, '==', 0, "Can read https for www.verisign.com" );
+        cmp_ok( $res->return_code, '==', 0, "Can read https for $host_tls_http" );
 
-        $res = NPTest->testCmd( "./check_http -C 1 --ssl www.verisign.com" );
-        cmp_ok( $res->return_code, '==', 0, "Checking certificate for www.verisign.com");
-        like  ( $res->output, "/Certificate 'www.verisign.com' will expire on/", "Output OK" );
+        $res = NPTest->testCmd( "./check_http -C 1 --ssl $host_tls_http" );
+        cmp_ok( $res->return_code, '==', 0, "Checking certificate for $host_tls_http");
+        like  ( $res->output, "/Certificate '$host_tls_cert' will expire on/", "Output OK" );
         my $saved_cert_output = $res->output;
 
-        $res = NPTest->testCmd( "./check_http -C 8000,1 --ssl www.verisign.com" );
-        cmp_ok( $res->return_code, '==', 1, "Checking certificate for www.verisign.com");
-        like  ( $res->output, qr/WARNING - Certificate 'www.verisign.com' expires in \d+ day/, "Output Warning" );
+        $res = NPTest->testCmd( "./check_http -C 8000,1 --ssl $host_tls_http" );
+        cmp_ok( $res->return_code, '==', 1, "Checking certificate for $host_tls_http");
+        like  ( $res->output, qr/WARNING - Certificate '$host_tls_cert' expires in \d+ day/, "Output Warning" );
 
-        $res = NPTest->testCmd( "./check_http www.verisign.com -C 1" );
+        $res = NPTest->testCmd( "./check_http $host_tls_http -C 1" );
         is( $res->return_code, 0, "Old syntax for cert checking okay" );
         is( $res->output, $saved_cert_output, "Same output as new syntax" );
 
-        $res = NPTest->testCmd( "./check_http -H www.verisign.com -C 1" );
+        $res = NPTest->testCmd( "./check_http -H $host_tls_http -C 1" );
         is( $res->return_code, 0, "Updated syntax for cert checking okay" );
         is( $res->output, $saved_cert_output, "Same output as new syntax" );
 
-        $res = NPTest->testCmd( "./check_http -C 1 www.verisign.com" );
+        $res = NPTest->testCmd( "./check_http -C 1 $host_tls_http" );
         cmp_ok( $res->output, 'eq', $saved_cert_output, "--ssl option automatically added");
 
-        $res = NPTest->testCmd( "./check_http www.verisign.com -C 1" );
+        $res = NPTest->testCmd( "./check_http $host_tls_http -C 1" );
         cmp_ok( $res->output, 'eq', $saved_cert_output, "Old syntax for cert checking still works");
 
         # run some certificate checks with faketime
         SKIP: {
                 skip "No faketime binary found", 12 if !$faketime;
-                $res = NPTest->testCmd("LC_TIME=C TZ=UTC ./check_http -C 1 www.verisign.com");
-                like($res->output, qr/OK - Certificate 'www.verisign.com' will expire on/, "Catch cert output");
+                $res = NPTest->testCmd("LC_TIME=C TZ=UTC ./check_http -C 1 $host_tls_http");
+                like($res->output, qr/OK - Certificate '$host_tls_cert' will expire on/, "Catch cert output");
                 is( $res->return_code, 0, "Catch cert output exit code" );
                 my($mon,$day,$hour,$min,$sec,$year) = ($res->output =~ /(\w+)\s+(\d+)\s+(\d+):(\d+):(\d+)\s+(\d+)/);
                 if(!defined $year) {
@@ -154,28 +161,28 @@ SKIP: {
                 my $months = {'Jan' => 0, 'Feb' => 1, 'Mar' => 2, 'Apr' => 3, 'May' => 4, 'Jun' => 5, 'Jul' => 6, 'Aug' => 7, 'Sep' => 8, 'Oct' => 9, 'Nov' => 10, 'Dec' => 11};
                 my $ts   = mktime($sec, $min, $hour, $day, $months->{$mon}, $year-1900);
                 my $time = strftime("%Y-%m-%d %H:%M:%S", localtime($ts));
-                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts))."' ./check_http -C 1 www.verisign.com");
-                like($res->output, qr/CRITICAL - Certificate 'www.verisign.com' just expired/, "Output on expire date");
+                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts))."' ./check_http -C 1 $host_tls_http");
+                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' just expired/, "Output on expire date");
                 is( $res->return_code, 2, "Output on expire date" );
 
-                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts-1))."' ./check_http -C 1 www.verisign.com");
-                like($res->output, qr/CRITICAL - Certificate 'www.verisign.com' expires in 0 minutes/, "cert expires in 1 second output");
+                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts-1))."' ./check_http -C 1 $host_tls_http");
+                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' expires in 0 minutes/, "cert expires in 1 second output");
                 is( $res->return_code, 2, "cert expires in 1 second exit code" );
 
-                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts-120))."' ./check_http -C 1 www.verisign.com");
-                like($res->output, qr/CRITICAL - Certificate 'www.verisign.com' expires in 2 minutes/, "cert expires in 2 minutes output");
+                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts-120))."' ./check_http -C 1 $host_tls_http");
+                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' expires in 2 minutes/, "cert expires in 2 minutes output");
                 is( $res->return_code, 2, "cert expires in 2 minutes exit code" );
 
-                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts-7200))."' ./check_http -C 1 www.verisign.com");
-                like($res->output, qr/CRITICAL - Certificate 'www.verisign.com' expires in 2 hours/, "cert expires in 2 hours output");
+                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts-7200))."' ./check_http -C 1 $host_tls_http");
+                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' expires in 2 hours/, "cert expires in 2 hours output");
                 is( $res->return_code, 2, "cert expires in 2 hours exit code" );
 
-                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts+1))."' ./check_http -C 1 www.verisign.com");
-                like($res->output, qr/CRITICAL - Certificate 'www.verisign.com' expired on/, "Certificate expired output");
+                $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts+1))."' ./check_http -C 1 $host_tls_http");
+                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' expired on/, "Certificate expired output");
                 is( $res->return_code, 2, "Certificate expired exit code" );
         };
 
-        $res = NPTest->testCmd( "./check_http --ssl www.verisign.com -E" );
+        $res = NPTest->testCmd( "./check_http --ssl $host_tls_http -E" );
         like  ( $res->output, '/time_connect=[\d\.]+/', 'Extended Performance Data Output OK' );
         like  ( $res->output, '/time_ssl=[\d\.]+/', 'Extended Performance Data SSL Output OK' );
 

--- a/plugins/t/check_snmp.t
+++ b/plugins/t/check_snmp.t
@@ -154,9 +154,9 @@ SKIP: {
     cmp_ok( $res->return_code, '==', 0, "Timetick used as a string");
     like($res->output, '/^SNMP OK - Timeticks:\s\(\d+\)\s+(?:\d+ days?,\s+)?\d+:\d+:\d+\.\d+\s.*$/', "Timetick used as a string, result printed rather than parsed");
 
-    $res = NPTest->testCmd( "./check_snmp -H $host_snmp -C $snmp_community -o HOST-RESOURCES-MIB::hrSWRunParameters.1");
-    cmp_ok( $res->return_code, '==', 0, "Timetick used as a string");
-    is( $res->output, 'SNMP OK - "" | ', "snmp response without datatype" );
+    $res = NPTest->testCmd( "./check_snmp -H $host_snmp -C $snmp_community -o HOST-RESOURCES-MIB::hrSWRunName.1");
+    cmp_ok( $res->return_code, '==', 0, "snmp response without datatype");
+    like( $res->output, '/^SNMP OK - "(systemd|init)" \| $/', "snmp response without datatype" );
 }
 
 SKIP: {

--- a/plugins/t/check_tcp.t
+++ b/plugins/t/check_tcp.t
@@ -18,6 +18,9 @@ BEGIN {
 my $host_tcp_http      = getTestParameter( "host_tcp_http",      "NP_HOST_TCP_HTTP",      "localhost",
 					   "A host providing the HTTP Service (a web server)" );
 
+my $host_tls_http      = getTestParameter( "host_tls_http",      "NP_HOST_TLS_HTTP",      "localhost",
+					   "A host providing the HTTPS Service (a tls web server)" );
+
 my $host_nonresponsive = getTestParameter( "host_nonresponsive", "NP_HOST_NONRESPONSIVE", "10.0.0.1",
 					   "The hostname of system not responsive to network requests" );
 
@@ -42,10 +45,10 @@ $t += checkCmd( "./check_tcp $host_tcp_http      -p 81 -wt   0 -ct   0 -to 1", 2
 $t += checkCmd( "./check_tcp $host_nonresponsive -p 80 -wt   0 -ct   0 -to 1", 2 );
 $t += checkCmd( "./check_tcp $hostname_invalid   -p 80 -wt   0 -ct   0 -to 1", 2 );
 if($internet_access ne "no") {
-    $t += checkCmd( "./check_tcp -S -D 1 -H www.verisign.com -p 443",              0 );
-    $t += checkCmd( "./check_tcp -S -D 9000,1    -H www.verisign.com -p 443",      1 );
-    $t += checkCmd( "./check_tcp -S -D 9000      -H www.verisign.com -p 443",      1 );
-    $t += checkCmd( "./check_tcp -S -D 9000,8999 -H www.verisign.com -p 443",      2 );
+    $t += checkCmd( "./check_tcp -S -D 1 -H $host_tls_http -p 443",              0 );
+    $t += checkCmd( "./check_tcp -S -D 9000,1    -H $host_tls_http -p 443",      1 );
+    $t += checkCmd( "./check_tcp -S -D 9000      -H $host_tls_http -p 443",      1 );
+    $t += checkCmd( "./check_tcp -S -D 9000,8999 -H $host_tls_http -p 443",      2 );
 }
 
 # Need the \r\n to make it more standards compliant with web servers. Need the various quotes

--- a/plugins/t/check_udp.t
+++ b/plugins/t/check_udp.t
@@ -34,11 +34,11 @@ my $nc;
 if(system("which nc.traditional >/dev/null 2>&1") == 0) {
 	$nc = 'nc.traditional -w 3 -l -u -p 3333';
 }
-elsif(system("which netcat >/dev/null 2>&1") == 0) {
-	$nc = 'netcat -w 3 -l -u -p 3333';
-}
 elsif(system("which nc >/dev/null 2>&1") == 0) {
 	$nc = 'nc -w 3 -l -u -4 localhost 3333';
+}
+elsif(system("which netcat >/dev/null 2>&1") == 0) {
+	$nc = 'netcat -w 3 -l -u -p 3333';
 }
 
 SKIP: {


### PR DESCRIPTION
- check_disk_smb did not exit cleanly on timeouts.
- snmp tests failed with systemd
- replace hardcoded verisign.com tests with localhost tls apache