### PR TITLE
script tests: fix relative lib path in utils test

### DIFF
--- a/plugins-scripts/t/utils.t
+++ b/plugins-scripts/t/utils.t
@@ -10,6 +10,7 @@ use strict;
 use Test::More;
 use NPTest;
 
+use lib ".";
 use lib "..";
 use utils;
 


### PR DESCRIPTION
utils.pm uses relative include ".." but the path is relativ to the current folder, so it
does not work when running "perl t/utils.t". Just add another lib of "." fixes that. We could
use FindBin but we don't want to make it unnecessarily complicated.

Signed-off-by: Sven Nierlein <sven@nierlein.de>