### PR TITLE
New general output functions for checks

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -166,7 +166,7 @@ main (int argc, char **argv)
   argv=np_extra_opts (&argc, argv, progname);
 
   if (process_arguments (argc, argv) == ERROR)
-    usage4 (_("Could not parse arguments"));
+    print_singleline_exit (STATE_UNKNOWN, _("Could not parse arguments"));
 
   if (display_html == TRUE)
     printf ("<A HREF=\"%s://%s:%d%s\" target=\"_blank\">",
@@ -188,7 +188,7 @@ test_file (char *path)
 {
   if (access(path, R_OK) == 0)
     return;
-  usage2 (_("file does not exist or is not readable"), path);
+  print_singleline_exit (STATE_UNKNOWN, _("File does not exist or is not readable %s"), path);
 }
 
 /* process command-line arguments */
@@ -277,7 +277,7 @@ process_arguments (int argc, char **argv)
       break;
     case 't': /* timeout period */
       if (!is_intnonneg (optarg))
-        usage2 (_("Timeout interval must be a positive integer"), optarg);
+        print_singleline_exit (STATE_UNKNOWN, _("Timeout interval must be a positive integer %i"), optarg);
       else
         socket_timeout = atoi (optarg);
       break;
@@ -295,7 +295,7 @@ process_arguments (int argc, char **argv)
         http_opt_headers = malloc (sizeof (char *) * (++http_opt_headers_count));
       else
         http_opt_headers = realloc (http_opt_headers, sizeof (char *) * (++http_opt_headers_count));
-      http_opt_headers[http_opt_headers_count - 1] = optarg;
+        http_opt_headers[http_opt_headers_count - 1] = optarg;
       /* xasprintf (&http_opt_headers, "%s", optarg); */
       break;
     case 'L': /* show html link */
@@ -309,18 +309,18 @@ process_arguments (int argc, char **argv)
       if ((temp=strchr(optarg,','))!=NULL) {
         *temp='\0';
         if (!is_intnonneg (optarg))
-          usage2 (_("Invalid certificate expiration period"), optarg);
+          print_singleline_exit (STATE_UNKNOWN, _("Invalid certificate expiration period %i"), optarg);
         days_till_exp_warn = atoi(optarg);
         *temp=',';
         temp++;
         if (!is_intnonneg (temp))
-          usage2 (_("Invalid certificate expiration period"), temp);
+          print_singleline_exit (STATE_UNKNOWN, _("Invalid certificate expiration period %i"), temp);
         days_till_exp_crit = atoi (temp);
       }
       else {
         days_till_exp_crit=0;
         if (!is_intnonneg (optarg))
-          usage2 (_("Invalid certificate expiration period"), optarg);
+          print_singleline_exit (STATE_UNKNOWN, _("Invalid certificate expiration period %i"), optarg);
         days_till_exp_warn = atoi (optarg);
       }
       check_cert = TRUE;
@@ -358,13 +358,13 @@ process_arguments (int argc, char **argv)
         else if (optarg[0] == '2')
           ssl_version = got_plus ? MP_SSLv2_OR_NEWER : MP_SSLv2;
         else
-          usage4 (_("Invalid option - Valid SSL/TLS versions: 2, 3, 1, 1.1, 1.2 (with optional '+' suffix)"));
+          print_singleline_exit (STATE_UNKNOWN, _("Invalid option - Valid SSL/TLS versions: 2, 3, 1, 1.1, 1.2 (with optional '+' suffix)"));
       }
       if (specify_port == FALSE)
         server_port = HTTPS_PORT;
 #else
       /* -C -J and -K fall through to here without SSL */
-      usage4 (_("Invalid option - SSL is not available"));
+      print_singleline_exit (STATE_UNKNOWN, _("Invalid option - SSL is not available"));
 #endif
       break;
     case SNI_OPTION:
@@ -385,7 +385,8 @@ process_arguments (int argc, char **argv)
         onredirect = STATE_WARNING;
       else if (!strcmp (optarg, "critical"))
         onredirect = STATE_CRITICAL;
-      else usage2 (_("Invalid onredirect option"), optarg);
+      else
+        print_singleline_exit (STATE_UNKNOWN, _("Invalid onredirect option %s"), optarg);
       if (verbose)
         printf(_("option f:%d \n"), onredirect);
       break;
@@ -422,7 +423,7 @@ process_arguments (int argc, char **argv)
       break;
     case 'p': /* Server port */
       if (!is_intnonneg (optarg))
-        usage2 (_("Invalid port number"), optarg);
+        print_singleline_exit (STATE_UNKNOWN, _("Invalid port number %i"), optarg);
       else {
         server_port = atoi (optarg);
         specify_port = TRUE;
@@ -474,8 +475,7 @@ process_arguments (int argc, char **argv)
       errcode = regcomp (&preg, regexp, cflags);
       if (errcode != 0) {
         (void) regerror (errcode, &preg, errbuf, MAX_INPUT_BUFFER);
-        printf (_("Could Not Compile Regular Expression: %s"), errbuf);
-        return ERROR;
+        return print_singleline_return (ERROR, _("Could not compile regular expression: %s"), errbuf);
       }
       break;
     case INVERT_REGEX:
@@ -488,7 +488,7 @@ process_arguments (int argc, char **argv)
 #ifdef USE_IPV6
       address_family = AF_INET6;
 #else
-      usage4 (_("IPv6 support not available"));
+      print_singleline_exit (STATE_UNKNOWN, _("IPv6 support not available"));
 #endif
       break;
     case 'v': /* verbose */
@@ -501,15 +501,13 @@ process_arguments (int argc, char **argv)
         /* range, so get two values, min:max */
         tmp = strtok(optarg, ":");
         if (tmp == NULL) {
-          printf("Bad format: try \"-m min:max\"\n");
-          exit (STATE_WARNING);
+          print_singleline_exit (STATE_WARNING, ("Bad format: try \"-m min:max\""));
         } else
           min_page_len = atoi(tmp);
 
         tmp = strtok(NULL, ":");
         if (tmp == NULL) {
-          printf("Bad format: try \"-m min:max\"\n");
-          exit (STATE_WARNING);
+          print_singleline_exit (STATE_WARNING, ("Bad format: try \"-m min:max\""));
         } else
           max_page_len = atoi(tmp);
       } else
@@ -532,8 +530,7 @@ process_arguments (int argc, char **argv)
                                    isdigit (optarg[L-1])))
                       maximum_age = atoi (optarg);
                     else {
-                      fprintf (stderr, "unparsable max-age: %s\n", optarg);
-                      exit (STATE_WARNING);
+                      print_singleline_exit (STATE_WARNING, ("Unparsable max-age: %s", optarg));
                     }
                   }
                   break;
@@ -553,7 +550,7 @@ process_arguments (int argc, char **argv)
 
   if (server_address == NULL) {
     if (host_name == NULL)
-      usage4 (_("You must specify a server address or host name"));
+      print_singleline_exit (STATE_UNKNOWN, _("You must specify a server address or host name"));
     else
       server_address = strdup (host_name);
   }
@@ -567,7 +564,7 @@ process_arguments (int argc, char **argv)
     http_method = strdup ("GET");
 
   if (client_cert && !client_privkey)
-    usage4 (_("If you use a client certificate you must also specify a private key file"));
+    print_singleline_exit (STATE_UNKNOWN, _("If you use a client certificate you must also specify a private key file"));
 
   if (virtual_port == 0)
     virtual_port = server_port;
@@ -694,7 +691,7 @@ expected_statuscode (const char *reply, const char *statuscodes)
   int result = 0;
 
   if ((expected = strdup (statuscodes)) == NULL)
-    die (STATE_UNKNOWN, _("HTTP UNKNOWN - Memory allocation error\n"));
+    print_singleline_exit (STATE_UNKNOWN, _("Memory allocation error"));
 
   for (code = strtok (expected, ","); code != NULL; code = strtok (NULL, ","))
     if (strstr (reply, code) != NULL) {
@@ -862,7 +859,7 @@ prepend_slash (char *path)
     return path;
 
   if ((newpath = malloc (strlen(path) + 2)) == NULL)
-    die (STATE_UNKNOWN, _("HTTP UNKNOWN - Memory allocation error\n"));
+    print_singleline_exit (STATE_UNKNOWN, _("Memory allocation error"));
   newpath[0] = '/';
   strcpy (newpath + 1, path);
   free (path);
@@ -904,7 +901,7 @@ check_http (void)
   /* try to connect to the host at the given port number */
   gettimeofday (&tv_temp, NULL);
   if (my_tcp_connect (server_address, server_port, &sd) != STATE_OK)
-    die (STATE_CRITICAL, _("HTTP CRITICAL - Unable to open TCP socket\n"));
+    print_singleline_exit (STATE_CRITICAL, _("Unable to open TCP socket"));
   microsec_connect = deltime (tv_temp);
 
     /* if we are called with the -I option, the -j method is CONNECT and */
@@ -936,7 +933,7 @@ check_http (void)
     result = np_net_ssl_init_with_hostname_version_and_cert(sd, (use_sni ? host_name : NULL), ssl_version, client_cert, client_privkey);
     if (verbose) printf ("SSL initialized\n");
     if (result != STATE_OK)
-      die (STATE_CRITICAL, NULL);
+      print_singleline_exit (STATE_CRITICAL, _("SSL error"));
     microsec_ssl = deltime (tv_temp);
     elapsed_time_ssl = (double)microsec_ssl / 1.0e6;
     if (check_cert == TRUE) {
@@ -1073,7 +1070,7 @@ check_http (void)
     else {
     */
 #endif
-      die (STATE_CRITICAL, _("HTTP CRITICAL - Error on receive\n"));
+      print_singleline_exit (STATE_CRITICAL, _("Error on receive"));
 #ifdef HAVE_SSL
       /* XXX
     }
@@ -1083,7 +1080,7 @@ check_http (void)
 
   /* return a CRITICAL status if we couldn't read any data */
   if (pagesize == (size_t) 0)
-    die (STATE_CRITICAL, _("HTTP CRITICAL - No data received from host\n"));
+    print_singleline_exit (STATE_CRITICAL, _("No data received from host"));
 
   /* close the connection */
   if (sd) close(sd);
@@ -1140,7 +1137,7 @@ check_http (void)
       xasprintf (&msg,
                 _("Invalid HTTP response received from host on port %d: %s\n"),
                 server_port, status_line);
-    die (STATE_CRITICAL, "HTTP CRITICAL - %s", msg);
+    print_singleline_exit (STATE_CRITICAL, msg);
   }
 
   /* Bypass normal status line check if server_expect was set by user and not default */
@@ -1158,14 +1155,14 @@ check_http (void)
 
     status_code = strchr (status_line, ' ') + sizeof (char);
     if (strspn (status_code, "1234567890") != 3)
-      die (STATE_CRITICAL, _("HTTP CRITICAL: Invalid Status Line (%s)\n"), status_line);
+      print_singleline_exit (STATE_CRITICAL, _("Invalid Status Line (%s)"), status_line);
 
     http_status = atoi (status_code);
 
     /* check the return code */
 
     if (http_status >= 600 || http_status < 100) {
-      die (STATE_CRITICAL, _("HTTP CRITICAL: Invalid Status (%s)\n"), status_line);
+      print_singleline_exit (STATE_CRITICAL, _("Invalid Status (%s)"), status_line);
     }
     /* server errors result in a critical state */
     else if (http_status >= 500) {
@@ -1292,7 +1289,7 @@ check_http (void)
 
   result = max_state_alt(get_status(elapsed_time, thlds), result);
 
-  die (result, "HTTP %s: %s\n", state_text(result), msg);
+  print_singleline_exit (result, msg);
   /* die failed? */
   return STATE_UNKNOWN;
 }
@@ -1322,12 +1319,12 @@ redir (char *pos, char *status_line)
 
   addr = malloc (MAX_IPV4_HOSTLENGTH + 1);
   if (addr == NULL)
-    die (STATE_UNKNOWN, _("HTTP UNKNOWN - Could not allocate addr\n"));
+    print_singleline_exit (STATE_UNKNOWN, _("Could not allocate addr"));
 
   memset(addr, 0, MAX_IPV4_HOSTLENGTH);
   url = malloc (strcspn (pos, "\r\n"));
   if (url == NULL)
-    die (STATE_UNKNOWN, _("HTTP UNKNOWN - Could not allocate URL\n"));
+    print_singleline_exit (STATE_UNKNOWN, _("Could not allocate URL"));
 
   while (pos) {
     sscanf (pos, "%1[Ll]%*1[Oo]%*1[Cc]%*1[Aa]%*1[Tt]%*1[Ii]%*1[Oo]%*1[Nn]:%n", xx, &i);
@@ -1335,8 +1332,8 @@ redir (char *pos, char *status_line)
       pos += (size_t) strcspn (pos, "\r\n");
       pos += (size_t) strspn (pos, "\r\n");
       if (strlen(pos) == 0)
-        die (STATE_UNKNOWN,
-             _("HTTP UNKNOWN - Could not find redirect location - %s%s\n"),
+        print_singleline_exit (STATE_UNKNOWN,
+             _("Could not find redirect location - %s%s"),
              status_line, (display_html ? "</A>" : ""));
       continue;
     }
@@ -1351,14 +1348,14 @@ redir (char *pos, char *status_line)
     for (; (i = strspn (pos, "\r\n")); pos += i) {
       pos += i;
       if (!(i = strspn (pos, " \t"))) {
-        die (STATE_UNKNOWN, _("HTTP UNKNOWN - Empty redirect location%s\n"),
+        print_singleline_exit (STATE_UNKNOWN, _("Empty redirect location%s"),
              display_html ? "</A>" : "");
       }
     }
 
     url = realloc (url, strcspn (pos, "\r\n") + 1);
     if (url == NULL)
-      die (STATE_UNKNOWN, _("HTTP UNKNOWN - Could not allocate URL\n"));
+      print_singleline_exit (STATE_UNKNOWN, _("Could not allocate URL"));
 
     /* URI_HTTP, URI_HOST, URI_PORT, URI_PATH */
     if (sscanf (pos, HD1, type, addr, &i, url) == 4) {
@@ -1400,8 +1397,8 @@ redir (char *pos, char *status_line)
     }
 
     else {
-      die (STATE_UNKNOWN,
-           _("HTTP UNKNOWN - Could not parse redirect location - %s%s\n"),
+      print_singleline_exit (STATE_UNKNOWN,
+           _("Could not parse redirect location - %s%s"),
            pos, (display_html ? "</A>" : ""));
     }
 
@@ -1410,16 +1407,16 @@ redir (char *pos, char *status_line)
   } /* end while (pos) */
 
   if (++redir_depth > max_depth)
-    die (STATE_WARNING,
-         _("HTTP WARNING - maximum redirection depth %d exceeded - %s://%s:%d%s%s\n"),
+    print_singleline_exit (STATE_WARNING,
+         _("Maximum redirection depth %d exceeded - %s://%s:%d%s%s"),
          max_depth, type, addr, i, url, (display_html ? "</A>" : ""));
 
   if (server_port==i &&
       !strncmp(server_address, addr, MAX_IPV4_HOSTLENGTH) &&
       (host_name && !strncmp(host_name, addr, MAX_IPV4_HOSTLENGTH)) &&
       !strcmp(server_url, url))
-    die (STATE_WARNING,
-         _("HTTP WARNING - redirection creates an infinite loop - %s://%s:%d%s%s\n"),
+    print_singleline_exit (STATE_WARNING,
+         _("Redirection creates an infinite loop - %s://%s:%d%s%s"),
          type, addr, i, url, (display_html ? "</A>" : ""));
 
   strcpy (server_type, type);
@@ -1439,8 +1436,8 @@ redir (char *pos, char *status_line)
   server_url = url;
 
   if (server_port > MAX_PORT)
-    die (STATE_UNKNOWN,
-         _("HTTP UNKNOWN - Redirection to port above %d - %s://%s:%d%s%s\n"),
+    print_singleline_exit (STATE_UNKNOWN,
+         _("Redirection to port above %d - %s://%s:%d%s%s"),
          MAX_PORT, server_type, server_address, server_port, server_url,
          display_html ? "</A>" : "");
 

--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -54,56 +54,49 @@ int np_net_ssl_init_with_hostname_version_and_cert(int sd, char *host_name, int 
 	switch (version) {
 	case MP_SSLv2: /* SSLv2 protocol */
 #if defined(USE_GNUTLS) || defined(OPENSSL_NO_SSL2)
-		printf("%s\n", _("UNKNOWN - SSL protocol version 2 is not supported by your SSL library."));
-		return STATE_UNKNOWN;
+		return print_singleline_return (STATE_UNKNOWN, _("SSL protocol version 2 is not supported by your SSL library."));
 #else
 		method = SSLv2_client_method();
 		break;
 #endif
 	case MP_SSLv3: /* SSLv3 protocol */
 #if defined(OPENSSL_NO_SSL3)
-		printf("%s\n", _("UNKNOWN - SSL protocol version 3 is not supported by your SSL library."));
-		return STATE_UNKNOWN;
+		return print_singleline_return (STATE_UNKNOWN, _("SSL protocol version 3 is not supported by your SSL library."));
 #else
 		method = SSLv3_client_method();
 		break;
 #endif
 	case MP_TLSv1: /* TLSv1 protocol */
 #if defined(OPENSSL_NO_TLS1)
-		printf("%s\n", _("UNKNOWN - TLS protocol version 1 is not supported by your SSL library."));
-		return STATE_UNKNOWN;
+		return print_singleline_return (STATE_UNKNOWN, _("TLS protocol version 1 is not supported by your SSL library."));
 #else
 		method = TLSv1_client_method();
 		break;
 #endif
 	case MP_TLSv1_1: /* TLSv1.1 protocol */
 #if !defined(SSL_OP_NO_TLSv1_1)
-		printf("%s\n", _("UNKNOWN - TLS protocol version 1.1 is not supported by your SSL library."));
-		return STATE_UNKNOWN;
+		return print_singleline_return (STATE_UNKNOWN, _("TLS protocol version 1.1 is not supported by your SSL library."));
 #else
 		method = TLSv1_1_client_method();
 		break;
 #endif
 	case MP_TLSv1_2: /* TLSv1.2 protocol */
 #if !defined(SSL_OP_NO_TLSv1_2)
-		printf("%s\n", _("UNKNOWN - TLS protocol version 1.2 is not supported by your SSL library."));
-		return STATE_UNKNOWN;
+		return print_singleline_return (STATE_UNKNOWN, _("TLS protocol version 1.2 is not supported by your SSL library."));
 #else
 		method = TLSv1_2_client_method();
 		break;
 #endif
 	case MP_TLSv1_2_OR_NEWER:
 #if !defined(SSL_OP_NO_TLSv1_1)
-		printf("%s\n", _("UNKNOWN - Disabling TLSv1.1 is not supported by your SSL library."));
-		return STATE_UNKNOWN;
+		return print_singleline_return (STATE_UNKNOWN, _("Disabling TLSv1.1 is not supported by your SSL library."));
 #else
 		options |= SSL_OP_NO_TLSv1_1;
 #endif
 		/* FALLTHROUGH */
 	case MP_TLSv1_1_OR_NEWER:
 #if !defined(SSL_OP_NO_TLSv1)
-		printf("%s\n", _("UNKNOWN - Disabling TLSv1 is not supported by your SSL library."));
-		return STATE_UNKNOWN;
+		return print_singleline_return (STATE_UNKNOWN, _("Disabling TLSv1 is not supported by your SSL library."));
 #else
 		options |= SSL_OP_NO_TLSv1;
 #endif
@@ -130,16 +123,14 @@ int np_net_ssl_init_with_hostname_version_and_cert(int sd, char *host_name, int 
 		initialized = 1;
 	}
 	if ((c = SSL_CTX_new(method)) == NULL) {
-		printf("%s\n", _("CRITICAL - Cannot create SSL context."));
-		return STATE_CRITICAL;
+		return print_singleline_return (STATE_CRITICAL, _("Cannot create SSL context."));
 	}
 	if (cert && privkey) {
 		SSL_CTX_use_certificate_file(c, cert, SSL_FILETYPE_PEM);
 		SSL_CTX_use_PrivateKey_file(c, privkey, SSL_FILETYPE_PEM);
 #ifdef USE_OPENSSL
 		if (!SSL_CTX_check_private_key(c)) {
-			printf ("%s\n", _("CRITICAL - Private key does not seem to match certificate!\n"));
-			return STATE_CRITICAL;
+			return print_singleline_return (STATE_CRITICAL, _("Private key does not seem to match certificate!"));
 		}
 #endif
 	}
@@ -157,15 +148,14 @@ int np_net_ssl_init_with_hostname_version_and_cert(int sd, char *host_name, int 
 		if (SSL_connect(s) == 1) {
 			return OK;
 		} else {
-			printf("%s\n", _("CRITICAL - Cannot make SSL connection."));
 #  ifdef USE_OPENSSL /* XXX look into ERR_error_string */
 			ERR_print_errors_fp(stdout);
 #  endif /* USE_OPENSSL */
+			return print_singleline_return (STATE_CRITICAL, _("Cannot make SSL connection."));
 		}
 	} else {
-			printf("%s\n", _("CRITICAL - Cannot initiate SSL handshake."));
+			return print_singleline_return (STATE_CRITICAL, _("Cannot initiate SSL handshake."));
 	}
-	return STATE_CRITICAL;
 }
 
 void np_net_ssl_cleanup() {
@@ -212,16 +202,14 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 
 	certificate=SSL_get_peer_certificate(s);
 	if (!certificate) {
-		printf("%s\n",_("CRITICAL - Cannot retrieve server certificate."));
-		return STATE_CRITICAL;
+		return print_singleline_return (STATE_CRITICAL, _("Cannot retrieve server certificate."));
 	}
 
 	/* Extract CN from certificate subject */
 	subj=X509_get_subject_name(certificate);
 
 	if (!subj) {
-		printf("%s\n",_("CRITICAL - Cannot retrieve certificate subject."));
-		return STATE_CRITICAL;
+		return print_singleline_return (STATE_CRITICAL, _("Cannot retrieve certificate subject."));
 	}
 	cnlen = X509_NAME_get_text_by_NID(subj, NID_commonName, cn, sizeof(cn));
 	if (cnlen == -1)
@@ -233,8 +221,7 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 	/* Generate tm structure to process timestamp */
 	if (tm->type == V_ASN1_UTCTIME) {
 		if (tm->length < 10) {
-			printf("%s\n", _("CRITICAL - Wrong time format in certificate."));
-			return STATE_CRITICAL;
+			return print_singleline_return (STATE_CRITICAL, _("Wrong time format in certificate."));
 		} else {
 			stamp.tm_year = (tm->data[0] - '0') * 10 + (tm->data[1] - '0');
 			if (stamp.tm_year < 50)
@@ -243,8 +230,7 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 		}
 	} else {
 		if (tm->length < 12) {
-			printf("%s\n", _("CRITICAL - Wrong time format in certificate."));
-			return STATE_CRITICAL;
+			return print_singleline_return (STATE_CRITICAL, _("Wrong time format in certificate."));
 		} else {
 			stamp.tm_year =
 				(tm->data[0] - '0') * 1000 + (tm->data[1] - '0') * 100 +
@@ -279,43 +265,44 @@ int np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit){
 	tzset();
 
 	if (days_left > 0 && days_left <= days_till_exp_warn) {
-		printf (_("%s - Certificate '%s' expires in %d day(s) (%s).\n"), (days_left>days_till_exp_crit)?"WARNING":"CRITICAL", cn, days_left, timestamp);
 		if (days_left > days_till_exp_crit)
 			status = STATE_WARNING;
 		else
 			status = STATE_CRITICAL;
+
+	        X509_free(certificate);
+	        return print_singleline_return (status, _("Certificate '%s' expires in %d day(s) (%s)."), cn, days_left, timestamp);
 	} else if (days_left == 0 && time_left > 0) {
 		if (time_left >= 3600)
 			time_remaining = (int) time_left / 3600;
 		else
 			time_remaining = (int) time_left / 60;
 
-		printf (_("%s - Certificate '%s' expires in %u %s (%s)\n"),
-			(days_left>days_till_exp_crit) ? "WARNING" : "CRITICAL", cn, time_remaining,
-			time_left >= 3600 ? "hours" : "minutes", timestamp);
-
 		if ( days_left > days_till_exp_crit)
 			status = STATE_WARNING;
 		else
 			status = STATE_CRITICAL;
+
+		X509_free(certificate);
+		return print_singleline_return (status, _("Certificate '%s' expires in %u %s (%s)."),
+			cn, time_remaining, time_left >= 3600 ? "hours" : "minutes", timestamp);
 	} else if (time_left < 0) {
-		printf(_("CRITICAL - Certificate '%s' expired on %s.\n"), cn, timestamp);
-		status=STATE_CRITICAL;
+		X509_free(certificate);
+		return print_singleline_return (STATE_CRITICAL, _("Certificate '%s' expired on %s."), cn, timestamp);
 	} else if (days_left == 0) {
-		printf (_("%s - Certificate '%s' just expired (%s).\n"), (days_left>days_till_exp_crit)?"WARNING":"CRITICAL", cn, timestamp);
 		if (days_left > days_till_exp_crit)
 			status = STATE_WARNING;
 		else
 			status = STATE_CRITICAL;
+
+		X509_free(certificate);
+		return print_singleline_return (status, _("Certificate '%s' just expired (%s)."), cn, timestamp);
 	} else {
-		printf(_("OK - Certificate '%s' will expire on %s.\n"), cn, timestamp);
-		status = STATE_OK;
+		X509_free(certificate);
+		return print_singleline_return (STATE_OK, _("Certificate '%s' will expire on %s."), cn, timestamp);
 	}
-	X509_free(certificate);
-	return status;
 #  else /* ifndef USE_OPENSSL */
-	printf("%s\n", _("WARNING - Plugin does not support checking certificates."));
-	return STATE_WARNING;
+	return print_singleline_return (STATE_WARNING, _("Plugin does not support checking certificates."));
 #  endif /* USE_OPENSSL */
 }
 

--- a/plugins/t/check_ftp.t
+++ b/plugins/t/check_ftp.t
@@ -20,7 +20,7 @@ my $host_nonresponsive = getTestParameter( "host_nonresponsive", "NP_HOST_NONRES
 my $hostname_invalid   = getTestParameter( "hostname_invalid",   "NP_HOSTNAME_INVALID",   "nosuchhost",
                                            "An invalid (not known to DNS) hostname" );
 
-my $successOutput = '/FTP OK -\s+[0-9]?\.?[0-9]+ second response time/';
+my $successOutput = '/FTP OK:\s+[0-9]?\.?[0-9]+ second response time/';
 
 my $t;
 

--- a/plugins/t/check_http.t
+++ b/plugins/t/check_http.t
@@ -11,7 +11,7 @@ use NPTest;
 
 plan tests => 49;
 
-my $successOutput = '/OK.*HTTP.*second/';
+my $successOutput = '/HTTP OK.*HTTP.*second/';
 
 my $res;
 
@@ -132,7 +132,7 @@ SKIP: {
 
         $res = NPTest->testCmd( "./check_http -C 8000,1 --ssl $host_tls_http" );
         cmp_ok( $res->return_code, '==', 1, "Checking certificate for $host_tls_http");
-        like  ( $res->output, qr/WARNING - Certificate '$host_tls_cert' expires in \d+ day/, "Output Warning" );
+        like  ( $res->output, qr/HTTP WARNING: Certificate '$host_tls_cert' expires in \d+ day/, "Output Warning" );
 
         $res = NPTest->testCmd( "./check_http $host_tls_http -C 1" );
         is( $res->return_code, 0, "Old syntax for cert checking okay" );
@@ -152,7 +152,7 @@ SKIP: {
         SKIP: {
                 skip "No faketime binary found", 12 if !$faketime;
                 $res = NPTest->testCmd("LC_TIME=C TZ=UTC ./check_http -C 1 $host_tls_http");
-                like($res->output, qr/OK - Certificate '$host_tls_cert' will expire on/, "Catch cert output");
+                like($res->output, qr/HTTP OK: Certificate '$host_tls_cert' will expire on/, "Catch cert output");
                 is( $res->return_code, 0, "Catch cert output exit code" );
                 my($mon,$day,$hour,$min,$sec,$year) = ($res->output =~ /(\w+)\s+(\d+)\s+(\d+):(\d+):(\d+)\s+(\d+)/);
                 if(!defined $year) {
@@ -162,23 +162,23 @@ SKIP: {
                 my $ts   = mktime($sec, $min, $hour, $day, $months->{$mon}, $year-1900);
                 my $time = strftime("%Y-%m-%d %H:%M:%S", localtime($ts));
                 $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts))."' ./check_http -C 1 $host_tls_http");
-                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' just expired/, "Output on expire date");
+                like($res->output, qr/HTTP CRITICAL: Certificate '$host_tls_cert' just expired/, "Output on expire date");
                 is( $res->return_code, 2, "Output on expire date" );
 
                 $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts-1))."' ./check_http -C 1 $host_tls_http");
-                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' expires in 0 minutes/, "cert expires in 1 second output");
+                like($res->output, qr/HTTP CRITICAL: Certificate '$host_tls_cert' expires in 0 minutes/, "cert expires in 1 second output");
                 is( $res->return_code, 2, "cert expires in 1 second exit code" );
 
                 $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts-120))."' ./check_http -C 1 $host_tls_http");
-                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' expires in 2 minutes/, "cert expires in 2 minutes output");
+                like($res->output, qr/HTTP CRITICAL: Certificate '$host_tls_cert' expires in 2 minutes/, "cert expires in 2 minutes output");
                 is( $res->return_code, 2, "cert expires in 2 minutes exit code" );
 
                 $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts-7200))."' ./check_http -C 1 $host_tls_http");
-                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' expires in 2 hours/, "cert expires in 2 hours output");
+                like($res->output, qr/HTTP CRITICAL: Certificate '$host_tls_cert' expires in 2 hours/, "cert expires in 2 hours output");
                 is( $res->return_code, 2, "cert expires in 2 hours exit code" );
 
                 $res = NPTest->testCmd("LC_TIME=C TZ=UTC faketime -f '".strftime("%Y-%m-%d %H:%M:%S", localtime($ts+1))."' ./check_http -C 1 $host_tls_http");
-                like($res->output, qr/CRITICAL - Certificate '$host_tls_cert' expired on/, "Certificate expired output");
+                like($res->output, qr/HTTP CRITICAL: Certificate '$host_tls_cert' expired on/, "Certificate expired output");
                 is( $res->return_code, 2, "Certificate expired exit code" );
         };
 

--- a/plugins/t/check_http.t
+++ b/plugins/t/check_http.t
@@ -60,7 +60,7 @@ $res = NPTest->testCmd(
 	"./check_http $host_nonresponsive -wt 1 -ct 2 -t 3"
 	);
 cmp_ok( $res->return_code, '==', 2, "Webserver $host_nonresponsive not responding" );
-cmp_ok( $res->output, 'eq', "CRITICAL - Socket timeout after 3 seconds", "Output OK");
+cmp_ok( $res->output, 'eq', "HTTP CRITICAL: Socket timeout after 3 seconds", "Output OK");
 
 $res = NPTest->testCmd(
 	"./check_http $hostname_invalid -wt 1 -ct 2"

--- a/plugins/t/check_jabber.t
+++ b/plugins/t/check_jabber.t
@@ -29,11 +29,11 @@ my $hostname_invalid   = getTestParameter(
 			);
 
 
-my $jabberOK = '/JABBER OK\s-\s\d+\.\d+\ssecond response time on '.$host_tcp_jabber.' port 5222/';
+my $jabberOK = '/JABBER OK:\s\d+\.\d+\ssecond response time on '.$host_tcp_jabber.' port 5222/';
 
 my $jabberUnresponsive = '/JABBER CRITICAL: Socket timeout after\s\d+\sseconds/';
 
-my $jabberInvalid = '/JABBER CRITICAL - Invalid hostname, address or socket:\s.+/';
+my $jabberInvalid = '/JABBER CRITICAL: Invalid hostname, address or socket:\s.+/';
 
 my $r;
 

--- a/plugins/t/check_jabber.t
+++ b/plugins/t/check_jabber.t
@@ -10,19 +10,19 @@ use NPTest;
 
 plan tests => 10;
 
-my $host_tcp_jabber = getTestParameter( 
+my $host_tcp_jabber = getTestParameter(
 			"NP_HOST_TCP_JABBER",
 			"A host providing the Jabber Service",
 			"jabber.org"
 			);
 
 my $host_nonresponsive = getTestParameter(
-			"NP_HOST_NONRESPONSIVE", 
+			"NP_HOST_NONRESPONSIVE",
 			"The hostname of system not responsive to network requests",
 			"10.0.0.1",
 			);
 
-my $hostname_invalid   = getTestParameter( 
+my $hostname_invalid   = getTestParameter(
 			"NP_HOSTNAME_INVALID",
 			"An invalid (not known to DNS) hostname",
 			"nosuchhost",
@@ -31,7 +31,7 @@ my $hostname_invalid   = getTestParameter(
 
 my $jabberOK = '/JABBER OK\s-\s\d+\.\d+\ssecond response time on '.$host_tcp_jabber.' port 5222/';
 
-my $jabberUnresponsive = '/CRITICAL\s-\sSocket timeout after\s\d+\sseconds/';
+my $jabberUnresponsive = '/JABBER CRITICAL: Socket timeout after\s\d+\sseconds/';
 
 my $jabberInvalid = '/JABBER CRITICAL - Invalid hostname, address or socket:\s.+/';
 
@@ -47,7 +47,7 @@ SKIP: {
 	$r = NPTest->testCmd( "./check_jabber -H $host_tcp_jabber -w 9 -c 9 -t 10" );
 	is( $r->return_code, 0, "Connected okay, within limits" );
 	like( $r->output, $jabberOK, "Output as expected" );
-	
+
 	$r = NPTest->testCmd( "./check_jabber -H $host_tcp_jabber -wt 9 -ct 9 -to 10" );
 	is( $r->return_code, 0, "Old syntax okay" );
 	like( $r->output, $jabberOK, "Output as expected" );

--- a/plugins/t/check_ldap.t
+++ b/plugins/t/check_ldap.t
@@ -33,7 +33,7 @@ SKIP: {
 
     $result = NPTest->testCmd("$command -H $host_nonresponsive -b ou=blah -t 2 -w 1 -c 1");
     is( $result->return_code, 2, "$command -H $host_nonresponsive -b ou=blah -t 5 -w 2 -c 3" );
-    is( $result->output, 'CRITICAL - Socket timeout after 2 seconds', "output ok" );
+    is( $result->output, 'LDAP CRITICAL: Socket timeout after 2 seconds', "output ok" );
 };
 
 SKIP: {

--- a/plugins/t/check_ntp.t
+++ b/plugins/t/check_ntp.t
@@ -37,7 +37,7 @@ my $ntp_critmatch1 = '/^NTP\sCRITICAL:\sOffset\s-?[0-9]+(\.[0-9]+)?(e-[0-9]{2})?
 my $ntp_okmatch2 = '/^NTP\sOK:\sOffset\s-?[0-9]+(\.[0-9]+)?(e-[0-9]{2})?\ssecs,\sjitter=[0-9]+\.[0-9]+,\sstratum=[0-9]{1,2},\struechimers=[0-9]+/';
 my $ntp_warnmatch2 = '/^NTP\sWARNING:\sOffset\s-?[0-9]+(\.[0-9]+)?(e-[0-9]{2})?\ssecs,\sjitter=[0-9]+\.[0-9]+,\sstratum=[0-9]{1,2}\s\(WARNING\),\struechimers=[0-9]+/';
 my $ntp_critmatch2 = '/^NTP\sCRITICAL:\sOffset\s-?[0-9]+(\.[0-9]+)?(e-[0-9]{2})?\ssecs,\sjitter=[0-9]+\.[0-9]+\s\(CRITICAL\),\sstratum=[0-9]{1,2},\struechimers=[0-9]+/';
-my $ntp_noresponse = '/^(CRITICAL - Socket timeout after 3 seconds)|(NTP CRITICAL: No response from NTP server)$/';
+my $ntp_noresponse = '/^(PEER CRITICAL: Socket timeout after 3 seconds)|(NTP CRITICAL: No response from NTP server)$/';
 my $ntp_nosuchhost = '/^check_ntp.*: Invalid hostname/address - ' . $hostname_invalid . '/';
 
 

--- a/plugins/t/check_ssh.t
+++ b/plugins/t/check_ssh.t
@@ -37,7 +37,7 @@ $result = NPTest->testCmd(
     "./check_ssh -H $host_nonresponsive -t 2"
     );
 cmp_ok($result->return_code, '==', 2, "Exit with return code 0 (OK)");
-like($result->output, '/^CRITICAL - Socket timeout after 2 seconds/', "Status text if command returned none (OK)");
+like($result->output, '/^SSH CRITICAL: Socket timeout after 2 seconds/', "Status text if command returned none (OK)");
 
 
 

--- a/plugins/t/check_ssh.t
+++ b/plugins/t/check_ssh.t
@@ -30,7 +30,7 @@ my $result = NPTest->testCmd(
     "./check_ssh -H $ssh_host"
     );
 cmp_ok($result->return_code, '==', 0, "Exit with return code 0 (OK)");
-like($result->output, '/^SSH OK - /', "Status text if command returned none (OK)");
+like($result->output, '/^SSH OK:/', "Status text if command returned none (OK)");
 
 
 $result = NPTest->testCmd(
@@ -45,5 +45,5 @@ $result = NPTest->testCmd(
     "./check_ssh -H $hostname_invalid -t 2"
     );
 cmp_ok($result->return_code, '==', 3, "Exit with return code 0 (OK)");
-like($result->output, '/^check_ssh: Invalid hostname/', "Status text if command returned none (OK)");
+like($result->output, '/^SSH UNKNOWN: Invalid hostname/', "Status text if command returned none (OK)");
 

--- a/plugins/t/check_tcp.t
+++ b/plugins/t/check_tcp.t
@@ -31,9 +31,9 @@ my $internet_access    = getTestParameter( "NP_INTERNET_ACCESS",
                                            "Is this system directly connected to the internet?",
                                            "yes");
 
-my $successOutput = '/^TCP OK\s-\s+[0-9]?\.?[0-9]+ second response time on port [0-9]+/';
+my $successOutput = '/^TCP OK:\s+[0-9]?\.?[0-9]+ second response time on port [0-9]+/';
 
-my $failedExpect = '/^TCP WARNING\s-\sUnexpected response from host/socket on port [0-9]+/';
+my $failedExpect = '/^TCP WARNING:\sUnexpected response from host/socket on port [0-9]+/';
 
 my $t;
 

--- a/plugins/tests/check_http.t
+++ b/plugins/tests/check_http.t
@@ -188,21 +188,21 @@ SKIP: {
 
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 14" );
 	is( $result->return_code, 0, "$command -p $port_https -S -C 14" );
-	is( $result->output, 'OK - Certificate \'Ton Voon\' will expire on Sun Mar  3 21:41:28 2019 +0000.', "output ok" );
+	is( $result->output, 'HTTP OK: Certificate \'Ton Voon\' will expire on Sun Mar  3 21:41:28 2019 +0000.', "output ok" );
 
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 14000" );
 	is( $result->return_code, 1, "$command -p $port_https -S -C 14000" );
-	like( $result->output, '/WARNING - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019 \+0000\)./', "output ok" );
+	like( $result->output, '/HTTP WARNING: Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019 \+0000\)./', "output ok" );
 
 	# Expired cert tests
 	$result = NPTest->testCmd( "$command -p $port_https -S -C 13960,14000" );
 	is( $result->return_code, 2, "$command -p $port_https -S -C 13960,14000" );
-	like( $result->output, '/CRITICAL - Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019 \+0000\)./', "output ok" );
+	like( $result->output, '/HTTP CRITICAL: Certificate \'Ton Voon\' expires in \d+ day\(s\) \(Sun Mar  3 21:41:28 2019 \+0000\)./', "output ok" );
 
 	$result = NPTest->testCmd( "$command -p $port_https_expired -S -C 7" );
 	is( $result->return_code, 2, "$command -p $port_https_expired -S -C 7" );
 	is( $result->output,
-		'CRITICAL - Certificate \'Ton Voon\' expired on Thu Mar  5 00:13:16 2009 +0000.',
+		'HTTP CRITICAL: Certificate \'Ton Voon\' expired on Thu Mar  5 00:13:16 2009 +0000.',
 		"output ok" );
 
 }

--- a/plugins/tests/check_http.t
+++ b/plugins/tests/check_http.t
@@ -269,7 +269,7 @@ sub run_common_tests {
 	$cmd = "$command -u /statuscode/201 -e 200";
 	$result = NPTest->testCmd( $cmd );
 	is( $result->return_code, 2, $cmd);
-	like( $result->output, '/^HTTP CRITICAL - Invalid HTTP response received from host on port \d+: HTTP/1.1 201 Created/', "Output correct: ".$result->output );
+	like( $result->output, '/^HTTP CRITICAL: Invalid HTTP response received from host on port \d+: HTTP/1.1 201 Created/', "Output correct: ".$result->output );
 
 	$cmd = "$command -u /statuscode/200 -e 200,201,202";
 	$result = NPTest->testCmd( $cmd );
@@ -284,7 +284,7 @@ sub run_common_tests {
 	$cmd = "$command -u /statuscode/203 -e 200,201,202";
 	$result = NPTest->testCmd( $cmd );
 	is( $result->return_code, 2, $cmd);
-	like( $result->output, '/^HTTP CRITICAL - Invalid HTTP response received from host on port (\d+): HTTP/1.1 203 Non-Authoritative Information/', "Output correct: ".$result->output );
+	like( $result->output, '/^HTTP CRITICAL: Invalid HTTP response received from host on port (\d+): HTTP/1.1 203 Non-Authoritative Information/', "Output correct: ".$result->output );
 
 	$cmd = "$command -j HEAD -u /method";
 	$result = NPTest->testCmd( $cmd );

--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -208,16 +208,16 @@ print_singleline_exit (int service_state, const char *fmt, ...)
 /*
  * Helper functions for standard output functions
  */
-const char *
+char *
 service_name(void)
 {
         /* Prepare service name from progname */
         char *service_name = NULL;
         service_name = strscpy(service_name, progname);
-        service_name = strrev((const char *)service_name);
+        service_name = strrev(service_name);
         service_name = strpcpy(service_name, service_name, "_");
         service_name = strrev(service_name);
-        service_name = strupper((const char *)service_name);
+        service_name = strupper(service_name);
         return service_name;
 }
 const char *
@@ -237,27 +237,25 @@ state_text (int result)
         }
 }
 char *
-strrev (const char *string)
+strrev (char *string)
 {
         if (! string || ! *string)
                 return string;
 
-        char *p1 = NULL, *p2 = NULL, *str = NULL;
-        str = strscpy(str, string);
+        char *p1 = NULL, *p2 = NULL;
 
-        for (p1 = str, p2 = str + strlen(str) - 1; p2 > p1; ++p1, --p2)
+        for (p1 = string, p2 = string + strlen(string) - 1; p2 > p1; ++p1, --p2)
         {
                 *p1 ^= *p2;
                 *p2 ^= *p1;
                 *p1 ^= *p2;
         }
 
-        return str;
+        return string;
 }
 char *
-strupper (const char *str)
+strupper (char *str)
 {
-        char *dest = NULL;
         size_t len = 0, i = 0;
 
         if (str)
@@ -265,16 +263,11 @@ strupper (const char *str)
         else
                 return NULL;
 
-        if (dest == NULL || strlen (dest) < len)
-                dest = realloc (dest, len + 1);
-        if (dest == NULL)
-                die (STATE_UNKNOWN, _("failed realloc in strupper\n"));
-
         for (i=0; i<len; ++i)
-                dest[i] = toupper(str[i]);
+                str[i] = toupper(str[i]);
 
-        dest[len] = '\0';
-        return dest;
+        str[len] = '\0';
+        return str;
 }
 
 

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -89,7 +89,22 @@ void usage4(const char *) __attribute__((noreturn));
 void usage5(void) __attribute__((noreturn));
 void usage_va(const char *fmt, ...) __attribute__((noreturn));
 
+
+/*
+ * Standard output functions
+ */
+void print_singleline (int service_state, const char *fmt, ...);
+int print_singleline_return (int service_state, const char *fmt, ...);
+void print_singleline_exit (int service_state, const char *fmt, ...) __attribute__((noreturn));
+
+
+/*
+ * Helper functions for standard output functions
+ */
+const char *service_name(void);
 const char *state_text (int);
+char *strrev (const char *str);
+char *strupper (const char *str);
 
 #define max(a,b) (((a)>(b))?(a):(b))
 #define min(a,b) (((a)<(b))?(a):(b))

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -13,6 +13,8 @@ in order to resist overflow attacks. In addition, a few functions are
 provided to standardize version and error reporting across the entire
 suite of plugins. */
 
+#include <ctype.h>
+
 /* now some functions etc are being defined in ../lib/utils_base.c */
 #include "utils_base.h"
 
@@ -101,10 +103,10 @@ void print_singleline_exit (int service_state, const char *fmt, ...) __attribute
 /*
  * Helper functions for standard output functions
  */
-const char *service_name(void);
+char *service_name(void);
 const char *state_text (int);
-char *strrev (const char *str);
-char *strupper (const char *str);
+char *strrev (char *str);
+char *strupper (char *str);
 
 #define max(a,b) (((a)>(b))?(a):(b))
 #define min(a,b) (((a)<(b))?(a):(b))


### PR DESCRIPTION
Dear Monitoring Team,

I had a look at your checks and they are working great. I will introduce a new software, which the monitoring plugins will be one part of it. I have written some test cases for my own software and got some troubles. I have implemented my interpretation of the result to the general output specification: SERVICE STATUS: First line of output|First part of performance data|Second part of performance data
or
SERVICE STATUS: First line of output|First part of performance data|Second part of performance data
Third part of performance data|Fourth part of performance data ...

Some of the checks I have tested, does not take care about this behaviour. So I checked the code and tried to find the problem. I was successful and had a great look into the code from you.

As a general solution for this problem, I have done the following steps:
- Introduced general output functions for this use case
- print_singleline (int service_state, const char * msg, ...)
  Will print the output and returns to caller
- print_singleline_return (int service_state, const char * msg, ...)
  Will print the output, returns the service_state as a return value and returns to caller
- print_singleline_exit (int service_state, const char * msg, ...)
  Will print the output and exits program with service_state
- Declaration and implementation is done in utils.h and utils.c

The first step is to get this new function accepted by you.

After that, my next steps will be the following:
- Adapt sshutils.c and netutils.c to use this new functions
- Adapt some tests, to take care about the new output results
- Step by step change the checks to use this new functions and replace the usage* functions
- Take care about the tests, that they will be successfully tested

Best regards
Sven