### PR TITLE
plugins: check_dig: Fix spelling

### DIFF
--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -331,7 +331,7 @@ print_help (void)
   printf ("Copyright (c) 2000 Karl DeBisschop <kdebisschop@users.sourceforge.net>\n");
   printf (COPYRIGHT, copyright, email);
 
-  printf (_("This plugin test the DNS service on the specified host using dig"));
+  printf (_("This plugin tests the DNS service on the specified host using dig"));
 
   printf ("\n\n");
 


### PR DESCRIPTION
This fixes a minor spelling issue. The localization files need to be adjusted accordingly, but I couldn't find any documentation on how to update the pot file and didn't want to do this by hand.