### PR TITLE
Added option for null zero length string exit codes

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -113,7 +113,7 @@ char *authproto = NULL;
 char *privproto = NULL;
 char *authpasswd = NULL;
 char *privpasswd = NULL;
-int nulloid = 3;
+int nulloid = STATE_UNKNOWN;
 char **oids = NULL;
 size_t oids_size = 0;
 char *label;

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -113,6 +113,7 @@ char *authproto = NULL;
 char *privproto = NULL;
 char *authpasswd = NULL;
 char *privpasswd = NULL;
+int nulloid = 3;
 char **oids = NULL;
 size_t oids_size = 0;
 char *label;
@@ -472,8 +473,16 @@ main (int argc, char **argv)
 				print_thresholds("  thresholds", thlds[i]);
 			}
 			ptr = strpbrk (show, "-0123456789");
-			if (ptr == NULL)
-				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
+			if (ptr == NULL){
+				if (nulloid == 3)
+					die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
+				else if (nulloid == 0)
+					die (STATE_OK,_("No valid data returned (%s)\n"), show);
+				else if (nulloid == 1)
+					die (STATE_WARNING,_("No valid data returned (%s)\n"), show);
+				else if (nulloid == 2)
+					die (STATE_CRITICAL,_("No valid data returned (%s)\n"), show);
+			}
 			while (i >= response_size) {
 				response_size += OID_COUNT_STEP;
 				response_value = realloc(response_value, response_size * sizeof(*response_value));
@@ -661,6 +670,7 @@ process_arguments (int argc, char **argv)
 		{"oid", required_argument, 0, 'o'},
 		{"object", required_argument, 0, 'o'},
 		{"delimiter", required_argument, 0, 'd'},
+		{"nulloid", required_argument, 0, 'z'},
 		{"output-delimiter", required_argument, 0, 'D'},
 		{"string", required_argument, 0, 's'},
 		{"timeout", required_argument, 0, 't'},
@@ -705,7 +715,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	while (1) {
-		c = getopt_long (argc, argv, "nhvVO46t:c:w:H:C:o:e:E:d:D:s:t:R:r:l:u:p:m:P:N:L:U:a:x:A:X:",
+		c = getopt_long (argc, argv, "nhvVO46t:c:w:H:C:o:e:E:d:D:s:t:R:r:l:u:p:m:P:N:L:U:a:x:A:X:z:",
 									 longopts, &option);
 
 		if (c == -1 || c == EOF)
@@ -815,6 +825,12 @@ process_arguments (int argc, char **argv)
 				else if (c == 'e')
 					eval_method[j+1] |= CRIT_PRESENT;
 			}
+			break;
+		case 'z':	/* Null OID Return Check */
+			if (!is_integer (optarg))
+				usage2 (_("Exit status must be a positive integer"), optarg);
+			else
+				nulloid = atoi(optarg);
 			break;
 		case 's':									/* string or substring */
 			strncpy (string_value, optarg, sizeof (string_value) - 1);
@@ -1181,6 +1197,14 @@ print_help (void)
 	printf ("    %s \"%s\"\n", _("Delimiter to use when parsing returned data. Default is"), DEFAULT_DELIMITER);
 	printf ("    %s\n", _("Any data on the right hand side of the delimiter is considered"));
 	printf ("    %s\n", _("to be the data that should be used in the evaluation."));
+	printf (" %s\n", "-z, --nulloid=#");
+	printf ("    %s\n", _("If the check returns a 0 length string or NULL value"));
+	printf ("    %s\n", _("This option allows you to choose what status you want it to exit"));
+	printf ("    %s\n", _("Excluding this option renders the default exit of 3(STATE_UNKNOWN)"));
+	printf ("    %s\n", _("0 = OK"));
+	printf ("    %s\n", _("1 = WARNING"));
+	printf ("    %s\n", _("2 = CRITICAL"));
+	printf ("    %s\n", _("3 = UNKNOWN"));
 
 	/* Tests Against Integers */
 	printf (" %s\n", "-w, --warning=THRESHOLD(s)");


### PR DESCRIPTION
When using a large distributed network with the same group of checks used against a large number of devices, occasionally there are missing cards in a few devices that are present in other devices. Rather than having a large number of unknown results, disable active checking on those large number of result or having to create a unique check configuration for those devices.

This option allows you to select an OK, WARNING, CRITICAL or UNKNOWN status while still retaining the default behavior when not present. This also allows a for the check to immediately start checks as intended should the hardware be added that the check is looking for.