### PR TITLE
Use size_t instead of int when calling sysctl(3).

### DIFF
--- a/plugins-root/check_dhcp.c
+++ b/plugins-root/check_dhcp.c
@@ -323,7 +323,8 @@ int get_hardware_address(int sock,char *interface_name){
 #elif defined(__bsd__)
 						/* King 2004	see ACKNOWLEDGEMENTS */
 
-        int                     mib[6], len;
+        size_t                  len;
+        int                     mib[6];
         char                    *buf;
         unsigned char           *ptr;
         struct if_msghdr        *ifm;


### PR DESCRIPTION
Otherwise, it writes sizeof(size_t) bytes to &oldlen, smashing the stack.

Found on OpenBSD, but applies to all BSDs (oldlen sysctl(3) argument is size_t everywhere).