### PR TITLE
Adding print top consuming processes option to check_load

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1016,6 +1016,10 @@ if test -n "$ac_cv_ps_varlist" ; then
 		AC_DEFINE(PS_USES_PROCETIME,"yes",
 		          [Whether the ps utility uses the "procetime" field])
 	fi
+	if echo "$ac_cv_ps_varlist" | grep "procpcpu" >/dev/null; then
+		AC_DEFINE(PS_USES_PROCPCPU,"yes",
+		          [Whether the ps utility uses the "procpcpu" field])
+	fi
 fi
 
 AC_PATH_PROG(PATH_TO_PING,ping)

--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -55,9 +55,7 @@ void print_help (void);
 void print_usage (void);
 static int print_top_consuming_processes();
 
-static int n_procs_to_show = 5;
-static int print_top_procs_on_warning = 0;
-static int print_top_procs_on_critical = 0;
+static int n_procs_to_show = 0;
 
 /* strictly for pretty-print usage in loops */
 static const int nums[3] = { 1, 5, 15 };
@@ -216,9 +214,7 @@ main (int argc, char **argv)
 		printf("load%d=%.3f;%.3f;%.3f;0; ", nums[i], la[i], wload[i], cload[i]);
 
 	putchar('\n');
-	if (result == STATE_CRITICAL && print_top_procs_on_critical) {
-		print_top_consuming_processes();
-	} else if (result == STATE_WARNING && print_top_procs_on_warning) {
+	if (n_procs_to_show > 0) {
 		print_top_consuming_processes();
 	}
 	return result;
@@ -238,8 +234,6 @@ process_arguments (int argc, char **argv)
 		{"percpu", no_argument, 0, 'r'},
 		{"version", no_argument, 0, 'V'},
 		{"help", no_argument, 0, 'h'},
-		{"print-top-warning", no_argument, 0, 'W'},
-		{"print-top-critical", no_argument, 0, 'C'},
 		{"procs-to-show", required_argument, 0, 'n'},
 		{0, 0, 0, 0}
 	};
@@ -248,7 +242,7 @@ process_arguments (int argc, char **argv)
 		return ERROR;
 
 	while (1) {
-		c = getopt_long (argc, argv, "Vhrc:w:WCn:", longopts, &option);
+		c = getopt_long (argc, argv, "Vhrc:w:n:", longopts, &option);
 
 		if (c == -1 || c == EOF)
 			break;
@@ -271,12 +265,6 @@ process_arguments (int argc, char **argv)
 			exit (STATE_UNKNOWN);
 		case 'n':
 			n_procs_to_show = atoi(optarg);
-			break;
-		case 'W':
-			print_top_procs_on_warning = 1;
-			break;
-		case 'C':
-			print_top_procs_on_critical = 1;
 			break;
 		case '?':									/* help */
 			usage5 ();
@@ -347,13 +335,9 @@ print_help (void)
   printf ("    %s\n", _("the load average format is the same used by \"uptime\" and \"w\""));
   printf (" %s\n", "-r, --percpu");
   printf ("    %s\n", _("Divide the load averages by the number of CPUs (when possible)"));
-  printf (" %s\n", "-W, --print-top-warning");
-  printf ("    %s\n", _("Print top consuming processes on WARNING status"));
-  printf (" %s\n", "-C, --print-top-critical");
-  printf ("    %s\n", _("Print top consuming processes on CRITICAL status"));
   printf (" %s\n", "-n, --procs-to-show=NUMBER_OF_PROCS");
-  printf ("    %s\n", _("Number of processes to show when printing top consuming"));
-  printf ("    %s\n", _("processes. Not useful without -W or -C. Default value is 5"));
+  printf ("    %s\n", _("Number of processes to show when printing the top consuming processes."));
+  printf ("    %s\n", _("NUMBER_OF_PROCS=0 disables this feature. Default value is 0"));
 
 	printf (UT_SUPPORT);
 }
@@ -362,7 +346,7 @@ void
 print_usage (void)
 {
   printf ("%s\n", _("Usage:"));
-  printf ("%s [-r] -w WLOAD1,WLOAD5,WLOAD15 -c CLOAD1,CLOAD5,CLOAD15 [-W] [-C] [-n NUMBER_OF_PROCS]\n", progname);
+  printf ("%s [-r] -w WLOAD1,WLOAD5,WLOAD15 -c CLOAD1,CLOAD5,CLOAD15 [-n NUMBER_OF_PROCS]\n", progname);
 }
 
 static int print_top_consuming_processes() {

--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -349,6 +349,7 @@ print_usage (void)
   printf ("%s [-r] -w WLOAD1,WLOAD5,WLOAD15 -c CLOAD1,CLOAD5,CLOAD15 [-n NUMBER_OF_PROCS]\n", progname);
 }
 
+#ifdef PS_USES_PROCPCPU
 int cmpstringp(const void *p1, const void *p2) {
 	int procuid = 0;
 	int procpid = 0;
@@ -367,6 +368,7 @@ int cmpstringp(const void *p1, const void *p2) {
 	sscanf (* (char * const *) p2, PS_FORMAT, PS_VARLIST);
 	return procpcpu1 < procpcpu;
 }
+#endif /* PS_USES_PROCPCPU */
 
 static int print_top_consuming_processes() {
 	int i = 0;
@@ -379,7 +381,9 @@ static int print_top_consuming_processes() {
 		fprintf(stderr, _("some error occurred getting procs list.\n"));
 		return STATE_UNKNOWN;
 	}
+#ifdef PS_USES_PROCPCPU
 	qsort(chld_out.line + 1, chld_out.lines - 1, sizeof(char*), cmpstringp);
+#endif /* PS_USES_PROCPCPU */
 	int lines_to_show = chld_out.lines < (n_procs_to_show + 1)
 			? chld_out.lines : n_procs_to_show + 1;
 	for (i = 0; i < lines_to_show; i += 1) {


### PR DESCRIPTION
```
 -W, --print-top-warning
    Print top consuming processes on WARNING status
 -C, --print-top-critical
    Print top consuming processes on CRITICAL status
 -n, --procs-to-show=NUMBER_OF_PROCS
    Number of processes to show when printing top consuming
    processes. Not useful without -W or -C. Default value is 5
```