### PR TITLE
check_ping: check PING_COMMAND existence

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -86,6 +86,10 @@ check_ups:
 check_ide_smart:
 	- Uses the Linux specific SMART interface [http://smartlinux.sourceforge.net/smart/index.php]. 
 
+check_ide_smart:
+	- Requires iputils or iputils-ping package
+	  https://github.com/iputils/iputils
+
 OS Specific Issues
 ------------------
 

--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -86,7 +86,7 @@ check_ups:
 check_ide_smart:
 	- Uses the Linux specific SMART interface [http://smartlinux.sourceforge.net/smart/index.php]. 
 
-check_ide_smart:
+check_ping:
 	- Requires iputils or iputils-ping package
 	  https://github.com/iputils/iputils
 

--- a/configure.ac
+++ b/configure.ac
@@ -1029,7 +1029,7 @@ AC_ARG_WITH(ping_command,
 AC_MSG_CHECKING(for ICMP ping syntax)
 ac_cv_ping_packets_first=no
 ac_cv_ping_has_timeout=no
-if test -n "$with_ping_command"
+if test -n "$PATH_TO_PING" && test -n "$with_ping_command"
 then
 	AC_MSG_RESULT([(command-line) $with_ping_command])
 	if echo "$with_ping_command" | grep '%d.*%d.*%s' >/dev/null
@@ -1121,7 +1121,7 @@ then
 	AC_MSG_RESULT([$with_ping_command])
 
 else
-	AC_MSG_WARN([unable to find usable ping syntax])
+	AC_MSG_WARN([unable to find usable ping command or syntax])
 fi
 
 AC_DEFINE_UNQUOTED(PING_COMMAND,"$with_ping_command",
@@ -1147,7 +1147,7 @@ AC_ARG_WITH(ping6_command,
 if test x"$with_ipv6" != xno ; then
 AC_MSG_CHECKING(for ICMPv6 ping syntax)
 ac_cv_ping6_packets_first=no
-if test -n "$with_ping6_command"
+if test -n "$PATH_TO_PING6" && test -n "$with_ping6_command"
 then
 	AC_MSG_RESULT([(command-line) $with_ping6_command])
 	if echo "$with_ping6_command" | grep '%d.*%d.*%s' >/dev/null
@@ -1300,7 +1300,8 @@ elif test "x$PATH_TO_PING" != "x"; then
 		AC_MSG_RESULT([$with_ping6_command])
 
 	fi
-
+else
+	AC_MSG_WARN([unable to find usable ping command or syntax for inet6])
 fi
 
 if test "x$with_ping6_command" != "x"; then

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -99,6 +99,18 @@ main (int argc, char **argv)
 		usage4 (_("Cannot catch SIGALRM"));
 	}
 
+#ifdef PING6_COMMAND
+	/* Check if PING6_COMMAND existence */
+	if (strlen (PING6_COMMAND) <= 0) {
+		usage4 (_("Could not find usable PING6_COMMAND"));
+	}
+#else
+	/* Check if PING_COMMAND existence */
+	if (strlen (PING_COMMAND) <= 0) {
+		usage4 (_("Could not find usable PING_COMMAND"));
+	}
+#endif
+
 	/* If ./configure finds ping has timeout values, set plugin alarm slightly
 	 * higher so that we can use response from command line ping */
 #if defined(PING_PACKETS_FIRST) && defined(PING_HAS_TIMEOUT)


### PR DESCRIPTION
`PING_COMMAND` and `PING6_COMMAND` should be checked before compile

Fixed #1509 