### PR TITLE
Fix build issue with MariaDB 10.2

### DIFF
--- a/plugins/common.h
+++ b/plugins/common.h
@@ -174,6 +174,11 @@
  *
  */
 
+/* MariaDB 10.2 client does not set MYSQL_PORT */
+#ifndef MYSQL_PORT
+#  define MYSQL_PORT 3306
+#endif
+
 enum {
 	OK = 0,
 	ERROR = -1


### PR DESCRIPTION
As of 10.2 MariaDB no longer defines MYSQL_PORT.