### PR TITLE
check_snmp: make calcualtion of timeout value in help output more clear

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -1209,7 +1209,7 @@ print_help (void)
 	printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
 	printf ("    %s\n", _("NOTE the final timeout value is calculated using this formula: timeout_interval * retries + 5"));
 	printf (" %s\n", "-e, --retries=INTEGER");
-	printf ("    %s%i%s\n", _("Number of retries to be used in the requests (default: "), DEFAULT_RETRIES, _(")"));
+	printf ("    %s%i\n", _("Number of retries to be used in the requests, default: "), DEFAULT_RETRIES);
 
 	printf (" %s\n", "-O, --perf-oids");
 	printf ("    %s\n", _("Label performance data with OIDs instead of --label's"));

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -1207,8 +1207,9 @@ print_help (void)
 	printf ("    %s\n", _("Separates output on multiple OID requests"));
 
 	printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
+	printf ("    %s\n", _("NOTE the final timeout value is calculated using this formula: timeout_interval * retries + 5"));
 	printf (" %s\n", "-e, --retries=INTEGER");
-	printf ("    %s\n", _("Number of retries to be used in the requests"));
+	printf ("    %s%i%s\n", _("Number of retries to be used in the requests (default: "), DEFAULT_RETRIES, _(")"));
 
 	printf (" %s\n", "-O, --perf-oids");
 	printf ("    %s\n", _("Label performance data with OIDs instead of --label's"));


### PR DESCRIPTION
Previously it was unclear that when setting a timeout using -t it is not the final timeout interval in check_snmp.

The final timeout interval is calculated using "timeout_interval * retries + 5" it seems.

This PR makes this more clear in the help output.