### PR TITLE
check_ping: pass -4 to the ping command, fixes #898

### DIFF
--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -113,7 +113,7 @@ main (int argc, char **argv)
 		if (address_family != AF_INET && is_inet6_addr(addresses[i]))
 			rawcmd = strdup(PING6_COMMAND);
 		else
-			rawcmd = strdup(PING_COMMAND);
+			xasprintf (&rawcmd, "%s %s", PING_COMMAND, "-4");
 #else
 		rawcmd = strdup(PING_COMMAND);
 #endif


### PR DESCRIPTION
When trying to ping a host which has A and AAAA records, we need to pass
'-4' to the ping command.