### PR TITLE
check_dns: improve support for checking multiple addresses

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ This file documents the major additions and syntax changes between releases.
 	check_dns: allow 'expected address' (-a) to be specified in CIDR notation
 	  (IPv4 only).
 	check_dns: allow for IPv6 RDNS
+	check_dns: allow unsorted addresses
 	check_apt: add --only-critical switch
 	check_apt: add -l/--list option to print packages
 

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ This file documents the major additions and syntax changes between releases.
 	  (IPv4 only).
 	check_dns: allow for IPv6 RDNS
 	check_dns: allow unsorted addresses
+	check_dns: allow forcing complete match of all addresses
 	check_apt: add --only-critical switch
 	check_apt: add -l/--list option to print packages
 

--- a/THANKS.in
+++ b/THANKS.in
@@ -356,3 +356,4 @@ Sven Geggus
 Thomas Kurschel
 Yannick Charton
 Nicolai Søborg
+Rolf Eike Beer

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -230,10 +230,15 @@ main (int argc, char **argv)
     temp_buffer = "";
 
     for (i=0; i<expected_address_cnt; i++) {
+      int j;
       /* check if we get a match on 'raw' ip or cidr */
-      if ( strcmp(address, expected_address[i]) == 0
-           || ip_match_cidr(address, expected_address[i]) )
-        result = STATE_OK;
+      for (j=0; j<n_addresses; j++) {
+        if ( strcmp(addresses[j], expected_address[i]) == 0
+             || ip_match_cidr(addresses[j], expected_address[i]) ) {
+          result = STATE_OK;
+          break;
+        }
+      }
 
       /* prepare an error string */
       xasprintf(&temp_buffer, "%s%s; ", temp_buffer, expected_address[i]);
@@ -530,8 +535,7 @@ print_help (void)
   printf (" -a, --expected-address=IP-ADDRESS|CIDR|HOST\n");
   printf ("    %s\n", _("Optional IP-ADDRESS/CIDR you expect the DNS server to return. HOST must end"));
   printf ("    %s\n", _("with a dot (.). This option can be repeated multiple times (Returns OK if any"));
-  printf ("    %s\n", _("value match). If multiple addresses are returned at once, you have to match"));
-  printf ("    %s\n", _("the whole string of addresses separated with commas (sorted alphabetically)."));
+  printf ("    %s\n", _("value matches)."));
   printf (" -A, --expect-authority\n");
   printf ("    %s\n", _("Optionally expect the DNS server to be authoritative for the lookup"));
   printf (" -w, --warning=seconds\n");

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -168,8 +168,8 @@ main (int argc, char **argv)
       temp_buffer++;
 
       /* Strip leading spaces */
-      for (; *temp_buffer != '\0' && *temp_buffer == ' '; temp_buffer++)
-        /* NOOP */;
+      while (*temp_buffer == ' ')
+        temp_buffer++;
 
       strip(temp_buffer);
       if (temp_buffer==NULL || strlen(temp_buffer)==0) {


### PR DESCRIPTION
Improve the handling of multiple IPs in check_dns: my use case is a set of hosts with 2 addresses each (IPv4 + IPv6), which I don't want to split into "IPv4 is smaller in string compare than IPv6" and "the others". And I want to check that the exactly the addresses I have configured are returned, no more, no less.

This more or less intentionally breaks the previously working "pass addresses as comma separated string and compare that". The combination of -L and multiple -a does the same without breaking randomly on every IP change. I don't care. YMMV.