### PR TITLE
check_load: reports wrong load average using -r option

### DIFF
--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -155,16 +155,16 @@ main (int argc, char **argv)
 		printf (_("Could not open stderr for %s\n"), PATH_TO_UPTIME);
 	}
 	fgets (input_buffer, MAX_INPUT_BUFFER - 1, child_process);
-    if(strstr(input_buffer, "load average:")) {
-	    sscanf (input_buffer, "%*[^l]load average: %lf, %lf, %lf", &la1, &la5, &la15);
-    }
-    else if(strstr(input_buffer, "load averages:")) {
-	    sscanf (input_buffer, "%*[^l]load averages: %lf, %lf, %lf", &la1, &la5, &la15);
-    }
-    else {
+	if(strstr(input_buffer, "load average:")) {
+		sscanf (input_buffer, "%*[^l]load average: %lf, %lf, %lf", &la1, &la5, &la15);
+	}
+	else if(strstr(input_buffer, "load averages:")) {
+		sscanf (input_buffer, "%*[^l]load averages: %lf, %lf, %lf", &la1, &la5, &la15);
+	}
+	else {
 		printf (_("could not parse load from uptime %s: %s\n"), PATH_TO_UPTIME, result);
 		return STATE_UNKNOWN;
-    }
+	}
 
 	result = spclose (child_process);
 	if (result) {
@@ -176,13 +176,13 @@ main (int argc, char **argv)
 
 	if (take_into_account_cpus == 1) {
 		if ((numcpus = GET_NUMBER_OF_CPUS()) > 0) {
-		    la_divisor = numcpus;
+			la_divisor = numcpus;
 		}
 	}
 
-    la_scaled[0] = la[0] / la_divisor;
-    la_scaled[1] = la[1] / la_divisor;
-    la_scaled[2] = la[2] / la_divisor;
+	la_scaled[0] = la[0] / la_divisor;
+	la_scaled[1] = la[1] / la_divisor;
+	la_scaled[2] = la[2] / la_divisor;
 
 	if ((la_scaled[0] < 0.0) || (la_scaled[1] < 0.0) || (la_scaled[2] < 0.0)) {
 #ifdef HAVE_GETLOADAVG
@@ -315,7 +315,7 @@ print_help (void)
 
 	printf (_("This plugin tests the current system load average."));
 
-  printf ("\n\n");
+	printf ("\n\n");
 
 	print_usage ();
 
@@ -323,12 +323,12 @@ print_help (void)
 	printf (UT_EXTRA_OPTS);
 
 	printf (" %s\n", "-w, --warning=WLOAD1,WLOAD5,WLOAD15");
-  printf ("    %s\n", _("Exit with WARNING status if load average exceeds WLOADn"));
-  printf (" %s\n", "-c, --critical=CLOAD1,CLOAD5,CLOAD15");
-  printf ("    %s\n", _("Exit with CRITICAL status if load average exceed CLOADn"));
-  printf ("    %s\n", _("the load average format is the same used by \"uptime\" and \"w\""));
-  printf (" %s\n", "-r, --percpu");
-  printf ("    %s\n", _("Divide the load averages by the number of CPUs (when possible)"));
+	printf ("    %s\n", _("Exit with WARNING status if load average exceeds WLOADn"));
+	printf (" %s\n", "-c, --critical=CLOAD1,CLOAD5,CLOAD15");
+	printf ("    %s\n", _("Exit with CRITICAL status if load average exceed CLOADn"));
+	printf ("    %s\n", _("the load average format is the same used by \"uptime\" and \"w\""));
+	printf (" %s\n", "-r, --percpu");
+	printf ("    %s\n", _("Divide the load averages by the number of CPUs (when possible)"));
 
 	printf (UT_SUPPORT);
 }
@@ -336,6 +336,6 @@ print_help (void)
 void
 print_usage (void)
 {
-  printf ("%s\n", _("Usage:"));
+	printf ("%s\n", _("Usage:"));
 	printf ("%s [-r] -w WLOAD1,WLOAD5,WLOAD15 -c CLOAD1,CLOAD5,CLOAD15\n", progname);
 }

--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -102,6 +102,8 @@ main (int argc, char **argv)
 	long numcpus;
 
 	double la[3] = { 0.0, 0.0, 0.0 };	/* NetBSD complains about unitialized arrays */
+	double la_scaled[3] = { 0.0, 0.0, 0.0 };
+	long la_divisor = 1;
 #ifndef HAVE_GETLOADAVG
 	char input_buffer[MAX_INPUT_BUFFER];
 # ifdef HAVE_PROC_LOADAVG
@@ -174,12 +176,15 @@ main (int argc, char **argv)
 
 	if (take_into_account_cpus == 1) {
 		if ((numcpus = GET_NUMBER_OF_CPUS()) > 0) {
-			la[0] = la[0] / numcpus;
-			la[1] = la[1] / numcpus;
-			la[2] = la[2] / numcpus;
+		    la_divisor = numcpus;
 		}
 	}
-	if ((la[0] < 0.0) || (la[1] < 0.0) || (la[2] < 0.0)) {
+
+    la_scaled[0] = la[0] / la_divisor;
+    la_scaled[1] = la[1] / la_divisor;
+    la_scaled[2] = la[2] / la_divisor;
+
+	if ((la_scaled[0] < 0.0) || (la_scaled[1] < 0.0) || (la_scaled[2] < 0.0)) {
 #ifdef HAVE_GETLOADAVG
 		printf (_("Error in getloadavg()\n"));
 #else
@@ -198,16 +203,16 @@ main (int argc, char **argv)
 	xasprintf(&status_line, _("load average: %.2f, %.2f, %.2f"), la1, la5, la15);
 
 	for(i = 0; i < 3; i++) {
-		if(la[i] > cload[i]) {
+		if(la_scaled[i] > cload[i]) {
 			result = STATE_CRITICAL;
 			break;
 		}
-		else if(la[i] > wload[i]) result = STATE_WARNING;
+		else if(la_scaled[i] > wload[i]) result = STATE_WARNING;
 	}
 
 	printf("%s - %s|", state_text(result), status_line);
 	for(i = 0; i < 3; i++)
-		printf("load%d=%.3f;%.3f;%.3f;0; ", nums[i], la[i], wload[i], cload[i]);
+		printf("load%d=%.3f;%.3f;%.3f;0; ", nums[i], la_scaled[i], wload[i], cload[i]);
 
 	putchar('\n');
 	return result;


### PR DESCRIPTION
Hello,
check_load -r divides the load average by the number of cpu cores. The scaled values are then used in the output, which leads to interesting notices such as: 
> WARNING - load average: 0.08, 0.10, 0.06

While in fact the load was 72 time higher. 

I got this warning from Nagios when using the default nrpe config on ubuntu
> command[check_load]=@pluginsdir@/check_load -r -w .15,.10,.05 -c .30,.25,.20

The first commit fixes this problem, the second makes the file have uniform indents instead of mixed tabs and spaces. 
Have a nice day!