### PR TITLE
Avoid passing NULL to vprintf().

### DIFF
--- a/lib/utils_base.c
+++ b/lib/utils_base.c
@@ -87,10 +87,13 @@ void _get_monitoring_plugin( monitoring_plugin **pointer ){
 void
 die (int result, const char *fmt, ...)
 {
-	va_list ap;
-	va_start (ap, fmt);
-	vprintf (fmt, ap);
-	va_end (ap);
+	if(fmt!=NULL) {
+		va_list ap;
+		va_start (ap, fmt);
+		vprintf (fmt, ap);
+		va_end (ap);
+	}
+
 	if(this_monitoring_plugin!=NULL) {
 		np_cleanup();
 	}


### PR DESCRIPTION
The die function is called with NULL as second argument in https://github.com/madpilot78/monitoring-plugins/blob/master/plugins/check_http.c#L939.

I'm almost sure that passing a NULL as the format string to printf functions falls in the undefined behavior category. In FreeBSD this causes a segmentation fault.

This simple patch checks for fmt not to be NULL and only it is not NULL proceeds to call the vprintf.

It avoids the segmentation fault on my systems.