### PR TITLE
plugins: check_http: Increase regexp limit

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -72,7 +72,7 @@ int maximum_age = -1;
 
 enum {
   REGS = 2,
-  MAX_RE_SIZE = 256
+  MAX_RE_SIZE = 1024
 };
 #include "regex.h"
 regex_t preg;


### PR DESCRIPTION
Happened to have a regexp hitting the 256 limit, please consider increasing the limit. Thank you.