### PR TITLE
[check_disk] add support to display inodes usage in perfdata

### DIFF
--- a/gl/fsusage.c
+++ b/gl/fsusage.c
@@ -143,6 +143,7 @@ get_fs_usage (char const *file, char const *disk, struct fs_usage *fsp)
       fsp->fsu_bavail_top_bit_set = EXTRACT_TOP_BIT (vfsd.f_bavail) != 0;
       fsp->fsu_files = PROPAGATE_ALL_ONES (vfsd.f_files);
       fsp->fsu_ffree = PROPAGATE_ALL_ONES (vfsd.f_ffree);
+      fsp->fsu_favail = PROPAGATE_ALL_ONES (vfsd.f_favail);
       return 0;
     }
 
@@ -174,6 +175,7 @@ get_fs_usage (char const *file, char const *disk, struct fs_usage *fsp)
   fsp->fsu_bavail_top_bit_set = EXTRACT_TOP_BIT (fsd.fd_req.bfreen) != 0;
   fsp->fsu_files = PROPAGATE_ALL_ONES (fsd.fd_req.gtot);
   fsp->fsu_ffree = PROPAGATE_ALL_ONES (fsd.fd_req.gfree);
+  fsp->fsu_favail = PROPAGATE_ALL_ONES (fsd.fd_req.gfree);
 
 #elif defined STAT_READ_FILSYS          /* SVR2 */
 # ifndef SUPERBOFF
@@ -209,6 +211,7 @@ get_fs_usage (char const *file, char const *disk, struct fs_usage *fsp)
                     ? UINTMAX_MAX
                     : (fsd.s_isize - 2) * INOPB * (fsd.s_type == Fs2b ? 2 : 1));
   fsp->fsu_ffree = PROPAGATE_ALL_ONES (fsd.s_tinode);
+  fsp->fsu_favail = PROPAGATE_ALL_ONES (fsd.s_tinode);
 
 #elif defined STAT_STATFS3_OSF1         /* OSF/1 */
 
@@ -296,6 +299,7 @@ get_fs_usage (char const *file, char const *disk, struct fs_usage *fsp)
   fsp->fsu_bavail_top_bit_set = EXTRACT_TOP_BIT (fsd.f_bavail) != 0;
   fsp->fsu_files = PROPAGATE_ALL_ONES (fsd.f_files);
   fsp->fsu_ffree = PROPAGATE_ALL_ONES (fsd.f_ffree);
+  fsp->fsu_favail = PROPAGATE_ALL_ONES (fsd.f_ffree);
 
 #endif
 
@@ -323,6 +327,7 @@ statfs (char *file, struct statfs *fsb)
   fsb->f_bavail = fsd.du_tfree;
   fsb->f_files  = (fsd.du_isize - 2) * fsd.du_inopb;
   fsb->f_ffree  = fsd.du_tinode;
+  fsb->f_favail  = fsd.du_tinode;
   fsb->f_fsid.val[0] = fsd.du_site;
   fsb->f_fsid.val[1] = fsd.du_pckno;
   return 0;

--- a/gl/fsusage.h
+++ b/gl/fsusage.h
@@ -32,7 +32,8 @@ struct fs_usage
   uintmax_t fsu_bavail;         /* Free blocks available to non-superuser. */
   bool fsu_bavail_top_bit_set;  /* 1 if fsu_bavail represents a value < 0.  */
   uintmax_t fsu_files;          /* Total file nodes. */
-  uintmax_t fsu_ffree;          /* Free file nodes. */
+  uintmax_t fsu_ffree;          /* Free file nodes to superuser. */
+  uintmax_t fsu_favail;         /* Free file nodes to non-superuser. */
 };
 
 int get_fs_usage (char const *file, char const *disk, struct fs_usage *fsp);

--- a/lib/utils_disk.c
+++ b/lib/utils_disk.c
@@ -69,6 +69,8 @@ np_add_parameter(struct parameter_list **list, const char *name)
   new_path->dtotal_units = 0;
   new_path->inodes_total = 0;
   new_path->inodes_free = 0;
+  new_path->inodes_free_to_root = 0;
+  new_path->inodes_used = 0;
   new_path->dused_inodes_percent = 0;
   new_path->dfree_inodes_percent = 0;
 

--- a/lib/utils_disk.h
+++ b/lib/utils_disk.h
@@ -24,7 +24,8 @@ struct parameter_list
   char *group;
   struct mount_entry *best_match;
   struct parameter_list *name_next;
-  uintmax_t total, available, available_to_root, used, inodes_free, inodes_total;
+  uintmax_t total, available, available_to_root, used,
+    inodes_free, inodes_free_to_root, inodes_used, inodes_total;
   double dfree_pct, dused_pct;
   double dused_units, dfree_units, dtotal_units;
   double dused_inodes_percent, dfree_inodes_percent;


### PR DESCRIPTION
This is not enabled by default
It can be enabled with the -P (--iperfdata) option

Of cause, option names can be changed, and it can be enabled by default if you think it would be a good thing.

Regards,
  Vincent
