### PR TITLE
Add support for MariaDB 10.3.

### DIFF
--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -45,6 +45,10 @@ const char *email = "devel@monitoring-plugins.org";
 #include <mysqld_error.h>
 #include <errmsg.h>
 
+#ifndef MYSQL_PORT
+#define MYSQL_PORT 3306
+#endif
+
 char *db_user = NULL;
 char *db_host = NULL;
 char *db_socket = NULL;

--- a/plugins/check_mysql_query.c
+++ b/plugins/check_mysql_query.c
@@ -41,6 +41,10 @@ const char *email = "devel@monitoring-plugins.org";
 #include <mysql.h>
 #include <errmsg.h>
 
+#ifndef MYSQL_PORT
+#define MYSQL_PORT 3306
+#endif
+
 char *db_user = NULL;
 char *db_host = NULL;
 char *db_socket = NULL;


### PR DESCRIPTION
As reported by Andreas Beckmann in [Debian Bug #919375](https://bugs.debian.org/919375), monitoring-plugins 2.2 fails to build with MariaDB 10.3 because `MYSQL_PORT` is not defined in its compat headers:
> monitoring-plugins FTBFS with mariadb-10.3 in sid:
> ```
> i686-linux-gnu-gcc -DLOCALEDIR=\"/usr/share/locale\" -DHAVE_CONFIG_H -I. -I..  -I.. -I../lib -I../gl -I../intl -I/usr/include/ldap -I/usr/include/postgresql -I/usr/include -I/usr/include/mariadb -I/usr/include/ma
> riadb/mysql -Wdate-time -D_FORTIFY_SOURCE=2 -DNP_VERSION='"2.2"' -I/usr/include/mariadb -I/usr/include/mariadb/mysql -g -O2 -fdebug-prefix-map=/build/monitoring-plugins-2.2=. -fstack-protector-strong -Wformat -We
> rror=format-security -Wall -Wl,-z,now -MT check_mysql-check_mysql.o -MD -MP -MF .deps/check_mysql-check_mysql.Tpo -c -o check_mysql-check_mysql.o `test -f 'check_mysql.c' || echo './'`check_mysql.c
> check_mysql.c:61:24: error: 'MYSQL_PORT' undeclared here (not in a function); did you mean 'MYSQL_STMT'?
>  unsigned int db_port = MYSQL_PORT;
>                         ^~~~~~~~~~
>                         MYSQL_STMT
> make[3]: *** [Makefile:1869: check_mysql-check_mysql.o] Error 1
> ```

To fix this `MYSQL_PORT` is set to `3306` when it's not defined.