### PR TITLE
Simply initializes n before it is used

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -293,6 +293,7 @@ main (int argc, char **argv)
 		    printf("%s", buffer);
 		}
 
+		n = 0;
 		while (n < ncommands) {
 			xasprintf (&cmd_str, "%s%s", commands[n], "\r\n");
 			my_send(cmd_str, strlen(cmd_str));


### PR DESCRIPTION
In Debian we got reported this issue: https://bugs.debian.org/886888

The check_smtp command has a bug when both SSL is enable and check
command (-C) are passed.

The code for check commands is:

```
                while (n < ncommands) {
                        xasprintf (&cmd_str, "%s%s", commands[n], "\r\n");
                        my_send(cmd_str, strlen(cmd_str));

                        …
```

And this works when SSL is not used, because n in initialized at the
start of main, and not used until this block. However, when SSL is
enabled, n is assigned the size of the server's second EHLO response (I
think in bytes), which will usually be significantly higher than the
command passed. As such, no commands are executed and no responses are
checked, which - silently - defeats the desired checks and results in a
success value.

Attached a trivial patch which simply initializes n before it is used