### PR TITLE
Simply initializes n before it is used

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -293,6 +293,7 @@ main (int argc, char **argv)
 		    printf("%s", buffer);
 		}
 
+		n = 0;
 		while (n < ncommands) {
 			xasprintf (&cmd_str, "%s%s", commands[n], "\r\n");
 			my_send(cmd_str, strlen(cmd_str));


### PR DESCRIPTION
When SSL is enabled, n is assigned the size of the server's second EHLO
response (I think in bytes), which will usually be significantly higher
than the command passed. As such, no commands are executed and no responses
are checked, which - silently - defeats the desired checks and results in a
success value.