### PR TITLE
check_by_ssh: fix child process leak on timeouts

### DIFF
--- a/lib/utils_cmd.h
+++ b/lib/utils_cmd.h
@@ -32,4 +32,17 @@ void cmd_init (void);
 #define CMD_NO_ARRAYS 0x01   /* don't populate arrays at all */
 #define CMD_NO_ASSOC 0x02    /* output.line won't point to buf */
 
+/* This variable must be global, since there's no way the caller
+ * can forcibly slay a dead or ungainly running program otherwise.
+ * Multithreading apps and plugins can initialize it (via CMD_INIT)
+ * in an async safe manner PRIOR to calling cmd_run() or cmd_run_array()
+ * for the first time.
+ *
+ * The check for initialized values is atomic and can
+ * occur in any number of threads simultaneously. */
+static pid_t *_cmd_pids = NULL;
+
+RETSIGTYPE timeout_alarm_handler (int);
+
+
 #endif /* _UTILS_CMD_ */

--- a/plugins/check_dbi.c
+++ b/plugins/check_dbi.c
@@ -35,6 +35,7 @@ const char *email = "devel@monitoring-plugins.org";
 
 #include "common.h"
 #include "utils.h"
+#include "utils_cmd.h"
 
 #include "netutils.h"
 

--- a/plugins/check_pgsql.c
+++ b/plugins/check_pgsql.c
@@ -34,6 +34,7 @@ const char *email = "devel@monitoring-plugins.org";
 
 #include "common.h"
 #include "utils.h"
+#include "utils_cmd.h"
 
 #include "netutils.h"
 #include <libpq-fe.h>

--- a/plugins/common.h
+++ b/plugins/common.h
@@ -225,4 +225,18 @@ enum {
 # define __attribute__(x) /* do nothing */
 #endif
 
+/* Try sysconf(_SC_OPEN_MAX) first, as it can be higher than OPEN_MAX.
+ * If that fails and the macro isn't defined, we fall back to an educated
+ * guess. There's no guarantee that our guess is adequate and the program
+ * will die with SIGSEGV if it isn't and the upper boundary is breached. */
+#define DEFAULT_MAXFD  256   /* fallback value if no max open files value is set */
+#define MAXFD_LIMIT   8192   /* upper limit of open files */
+#ifdef _SC_OPEN_MAX
+static long maxfd = 0;
+#elif defined(OPEN_MAX)
+# define maxfd OPEN_MAX
+#else	/* sysconf macro unavailable, so guess (may be wildly inaccurate) */
+# define maxfd DEFAULT_MAXFD
+#endif
+
 #endif /* _COMMON_H_ */

--- a/plugins/popen.c
+++ b/plugins/popen.c
@@ -78,7 +78,6 @@ RETSIGTYPE popen_timeout_alarm_handler (int);
 
 #define	min(a,b)	((a) < (b) ? (a) : (b))
 #define	max(a,b)	((a) > (b) ? (a) : (b))
-int open_max (void);						/* {Prog openmax} */
 static void err_sys (const char *, ...) __attribute__((noreturn,format(printf, 1, 2)));
 char *rtrim (char *, const char *);
 
@@ -86,7 +85,6 @@ char *pname = NULL;							/* caller can set this from argv[0] */
 
 /*int *childerr = NULL;*//* ptr to array allocated at run-time */
 /*extern pid_t *childpid = NULL; *//* ptr to array allocated at run-time */
-static int maxfd;								/* from our open_max(), {Prog openmax} */
 
 #ifdef REDHAT_SPOPEN_ERROR
 static volatile int childtermd = 0;
@@ -187,13 +185,11 @@ spopen (const char *cmdstring)
 	argv[i] = NULL;
 
 	if (childpid == NULL) {				/* first time through */
-		maxfd = open_max ();				/* allocate zeroed out array for child pids */
 		if ((childpid = calloc ((size_t)maxfd, sizeof (pid_t))) == NULL)
 			return (NULL);
 	}
 
 	if (child_stderr_array == NULL) {	/* first time through */
-		maxfd = open_max ();				/* allocate zeroed out array for child pids */
 		if ((child_stderr_array = calloc ((size_t)maxfd, sizeof (int))) == NULL)
 			return (NULL);
 	}
@@ -273,15 +269,6 @@ spclose (FILE * fp)
 	return (1);
 }
 
-#ifdef	OPEN_MAX
-static int openmax = OPEN_MAX;
-#else
-static int openmax = 0;
-#endif
-
-#define	OPEN_MAX_GUESS	256			/* if OPEN_MAX is indeterminate */
-				/* no guarantee this is adequate */
-
 #ifdef REDHAT_SPOPEN_ERROR
 RETSIGTYPE
 popen_sigchld_handler (int signo)
@@ -308,22 +295,6 @@ popen_timeout_alarm_handler (int signo)
 		}
 		exit (STATE_CRITICAL);
 	}
-}
-
-
-int
-open_max (void)
-{
-	if (openmax == 0) {						/* first time through */
-		errno = 0;
-		if ((openmax = sysconf (_SC_OPEN_MAX)) < 0) {
-			if (errno == 0)
-				openmax = OPEN_MAX_GUESS;	/* it's indeterminate */
-			else
-				err_sys (_("sysconf error for _SC_OPEN_MAX"));
-		}
-	}
-	return (openmax);
 }
 
 

--- a/plugins/runcmd.c
+++ b/plugins/runcmd.c
@@ -67,19 +67,6 @@
  * occur in any number of threads simultaneously. */
 static pid_t *np_pids = NULL;
 
-/* Try sysconf(_SC_OPEN_MAX) first, as it can be higher than OPEN_MAX.
- * If that fails and the macro isn't defined, we fall back to an educated
- * guess. There's no guarantee that our guess is adequate and the program
- * will die with SIGSEGV if it isn't and the upper boundary is breached. */
-#ifdef _SC_OPEN_MAX
-static long maxfd = 0;
-#elif defined(OPEN_MAX)
-# define maxfd OPEN_MAX
-#else /* sysconf macro unavailable, so guess (may be wildly inaccurate) */
-# define maxfd 256
-#endif
-
-
 /** prototypes **/
 static int np_runcmd_open(const char *, int *, int *)
 	__attribute__((__nonnull__(1, 2, 3)));

--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -165,16 +165,6 @@ state_text (int result)
 	}
 }
 
-void
-timeout_alarm_handler (int signo)
-{
-	if (signo == SIGALRM) {
-		printf (_("%s - Plugin timed out after %d seconds\n"),
-						state_text(timeout_state), timeout_interval);
-		exit (timeout_state);
-	}
-}
-
 int
 is_numeric (char *number)
 {
@@ -708,4 +698,3 @@ char *sperfdata_int (const char *label,
 
 	return data;
 }
-

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -34,8 +34,6 @@ void print_revision (const char *, const char *);
 extern unsigned int timeout_state;
 extern unsigned int timeout_interval;
 
-RETSIGTYPE timeout_alarm_handler (int);
-
 extern time_t start_time, end_time;
 
 /* Test input types */


### PR DESCRIPTION
When check_by_ssh runs into a timeout it simply exits keeping all child processes running.
Simply adopting the kill loop from runcmd_timeout_alarm_handler() fixes this.
In order to do this, i had to move some code into the common header. On the other hand, this
eliminates some duplicate code.

Signed-off-by: Sven Nierlein <sven@nierlein.de>