### PR TITLE
Also support the --show-body/-B flag when --expect is used

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1155,6 +1155,8 @@ check_http (void)
       xasprintf (&msg,
                 _("Invalid HTTP response received from host on port %d: %s\n"),
                 server_port, status_line);
+    if (show_body)
+        xasprintf (&msg, _("%s\n%s"), msg, page);
     die (STATE_CRITICAL, "HTTP CRITICAL - %s", msg);
   }
 


### PR DESCRIPTION
This PR is a follow-up to PR #1560 

We discovered that in the spaghetti of check_http, if an `--expect` parameter is specified, the code does `die()` before the body is appended.

This commit appends the body also when expect is used.

Problem:

**good**
```
/check_http -H iovation-api.example.com -u /health/check -B 
HTTP CRITICAL: HTTP/1.1 500 Internal Server Error - 206 bytes in 0.018 second response time |time=0.017735s;;;0.000000;10.000000 size=206B;;;0
The last 20 call to Iovation failed
```

**bad**
```
# ./check_http -H iovation-api.example.com -u /health/check -B -e 'HTTP/1.1 200'
HTTP CRITICAL - Invalid HTTP response received from host: HTTP/1.1 500 Internal Server Error
```