### PR TITLE
check_mysql: Allow sockets to be specified to -H

### DIFF
--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -379,6 +379,9 @@ process_arguments (int argc, char **argv)
 			if (is_host (optarg)) {
 				db_host = optarg;
 			}
+			else if (*optarg == '/') {
+				db_socket = optarg;
+			}
 			else {
 				usage2 (_("Invalid hostname/address"), optarg);
 			}


### PR DESCRIPTION
The help text says that -H accepts a "unix socket (must be an absolute
path)". Now that actually corresponds to reality.

Signed-off-by: Robin Sonefors <robin.sonefors@op5.com>