### PR TITLE
fix maxfd being zero

### DIFF
--- a/plugins/popen.c
+++ b/plugins/popen.c
@@ -78,13 +78,8 @@ RETSIGTYPE popen_timeout_alarm_handler (int);
 
 #define	min(a,b)	((a) < (b) ? (a) : (b))
 #define	max(a,b)	((a) > (b) ? (a) : (b))
-static void err_sys (const char *, ...) __attribute__((noreturn,format(printf, 1, 2)));
-char *rtrim (char *, const char *);
 
 char *pname = NULL;							/* caller can set this from argv[0] */
-
-/*int *childerr = NULL;*//* ptr to array allocated at run-time */
-/*extern pid_t *childpid = NULL; *//* ptr to array allocated at run-time */
 
 #ifdef REDHAT_SPOPEN_ERROR
 static volatile int childtermd = 0;
@@ -183,6 +178,9 @@ spopen (const char *cmdstring)
 
 	}
 	argv[i] = NULL;
+
+	if(maxfd == 0)
+		maxfd = open_max();
 
 	if (childpid == NULL) {				/* first time through */
 		if ((childpid = calloc ((size_t)maxfd, sizeof (pid_t))) == NULL)
@@ -295,48 +293,4 @@ popen_timeout_alarm_handler (int signo)
 		}
 		exit (STATE_CRITICAL);
 	}
-}
-
-
-/* Fatal error related to a system call.
- * Print a message and die. */
-
-#define MAXLINE 2048
-static void
-err_sys (const char *fmt, ...)
-{
-	int errnoflag = 1;
-	int errno_save;
-	char buf[MAXLINE];
-
-	va_list ap;
-
-	va_start (ap, fmt);
-	/* err_doit (1, fmt, ap); */
-	errno_save = errno;						/* value caller might want printed */
-	vsprintf (buf, fmt, ap);
-	if (errnoflag)
-		sprintf (buf + strlen (buf), ": %s", strerror (errno_save));
-	strcat (buf, "\n");
-	fflush (stdout);							/* in case stdout and stderr are the same */
-	fputs (buf, stderr);
-	fflush (NULL);								/* flushes all stdio output streams */
-	va_end (ap);
-	exit (1);
-}
-
-char *
-rtrim (char *str, const char *tok)
-{
-	int i = 0;
-	int j = sizeof (str);
-
-	while (str != NULL && i < j) {
-		if (*(str + i) == *tok) {
-			sprintf (str + i, "%s", "\0");
-			return str;
-		}
-		i++;
-	}
-	return str;
 }

--- a/plugins/runcmd.c
+++ b/plugins/runcmd.c
@@ -86,14 +86,8 @@ extern void die (int, const char *, ...)
  * through this api and thus achieve async-safeness throughout the api */
 void np_runcmd_init(void)
 {
-#ifndef maxfd
-	if(!maxfd && (maxfd = sysconf(_SC_OPEN_MAX)) < 0) {
-		/* possibly log or emit a warning here, since there's no
-		 * guarantee that our guess at maxfd will be adequate */
-		maxfd = 256;
-	}
-#endif
-
+	if(maxfd == 0)
+		maxfd = open_max();
 	if(!np_pids) np_pids = calloc(maxfd, sizeof(pid_t));
 }
 

--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -678,3 +678,19 @@ char *sperfdata_int (const char *label,
 
 	return data;
 }
+
+int
+open_max (void)
+{
+	errno = 0;
+	if (maxfd > 0)
+		return(maxfd);
+
+	if ((maxfd = sysconf (_SC_OPEN_MAX)) < 0) {
+		if (errno == 0)
+			maxfd = DEFAULT_MAXFD;   /* it's indeterminate */
+	else
+		die (STATE_UNKNOWN, _("sysconf error for _SC_OPEN_MAX\n"));
+	}
+	return(maxfd);
+}

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -97,6 +97,8 @@ char *sperfdata (const char *, double, const char *, char *, char *,
 char *sperfdata_int (const char *, int, const char *, char *, char *,
                      int, int, int, int);
 
+int open_max (void);
+
 /* The idea here is that, although not every plugin will use all of these, 
    most will or should.  Therefore, for consistency, these very common 
    options should have only these meanings throughout the overall suite */


### PR DESCRIPTION
If _SC_OPEN_MAX is available then maxfd was zero initialized and never set to the value from sysconf.
This leads to segfaults with free(): invalid size.

Signed-off-by: Sven Nierlein <sven@nierlein.de>