### PR TITLE
check_procs: support of light weight processes (threads)

### DIFF
--- a/THANKS.in
+++ b/THANKS.in
@@ -426,3 +426,4 @@ Eunice Remoquillo
 Louis Sautier
 Sven Hartge
 Alvar Penning
+Benjamin Kübler

--- a/configure.ac
+++ b/configure.ac
@@ -790,6 +790,16 @@ dnl 	ac_cv_ps_format=["%*s %d %d %d %d %*d %*d %d %d%*[ 0123456789abcdef]%[OSRZT
 dnl 	ac_cv_ps_cols=8
 dnl 	AC_MSG_RESULT([$ac_cv_ps_command])
 
+dnl Check support for threads and etime on gnu/linux systems...
+elif ps axwo 'stat comm vsz rss nlwp user uid pid ppid etime args' 2>/dev/null | \
+	grep -E -i ["^ *STAT +[UCOMAND]+ +VSZ +RSS +NLWP +USER +UID +PID +PPID +ELAPSED +COMMAND"] > /dev/null
+then
+	ac_cv_ps_varlist="[procstat,&procuid,&procpid,&procppid,&procvsz,&procrss,&procnlwp,&procpcpu,procetime,procprog,&pos]"
+	ac_cv_ps_command="$PATH_TO_PS axwo 'stat uid pid ppid vsz rss nlwp pcpu etime comm args'"
+	ac_cv_ps_format="%s %d %d %d %d %d %d %f %s %s %n"
+	ac_cv_ps_cols=11
+	AC_MSG_RESULT([$ac_cv_ps_command])
+
 dnl This one is the exact same test as the next one but includes etime
 elif ps axwo 'stat comm vsz rss user uid pid ppid etime args' 2>/dev/null | \
 	grep -E -i ["^ *STAT +[UCOMAND]+ +VSZ +RSS +USER +UID +PID +PPID +ELAPSED +COMMAND"] > /dev/null
@@ -797,6 +807,16 @@ then
 	ac_cv_ps_varlist="[procstat,&procuid,&procpid,&procppid,&procvsz,&procrss,&procpcpu,procetime,procprog,&pos]"
 	ac_cv_ps_command="$PATH_TO_PS axwo 'stat uid pid ppid vsz rss pcpu etime comm args'"
 	ac_cv_ps_format="%s %u %d %d %d %d %f %s %s %n"
+	ac_cv_ps_cols=10
+	AC_MSG_RESULT([$ac_cv_ps_command])
+
+dnl Check support for threads on gnu/linux systems...
+elif ps axwo 'stat comm vsz rss nlwp user uid pid ppid args' 2>/dev/null | \
+	grep -E -i ["^ *STAT +[UCOMAND]+ +VSZ +RSS +NLWP +USER +UID +PID +PPID +COMMAND"] > /dev/null
+then
+	ac_cv_ps_varlist="[procstat,&procuid,&procpid,&procppid,&procvsz,&procrss,&procnlwp,&procpcpu,procprog,&pos]"
+	ac_cv_ps_command="$PATH_TO_PS axwo 'stat uid pid ppid vsz rss nlwp pcpu comm args'"
+	ac_cv_ps_format="%s %d %d %d %d %d %d %f %s %n"
 	ac_cv_ps_cols=10
 	AC_MSG_RESULT([$ac_cv_ps_command])
 
@@ -811,6 +831,16 @@ then
 	ac_cv_ps_cols=9
 	AC_MSG_RESULT([$ac_cv_ps_command])
 
+dnl Check support for threads on OpenBSD / FreeBSD systems...
+elif ps -axwo 'stat comm vsz rss nlwp user uid pid ppid args' 2>/dev/null | \
+	grep -E -i ["^ *STAT +[UCOMAND]+ +VSZ +RSS +NLWP +USER +UID +PID +PPID +COMMAND"] > /dev/null
+then
+	ac_cv_ps_varlist="[procstat,&procuid,&procpid,&procppid,&procvsz,&procrss,&procnlwp,&procpcpu,procprog,&pos]"
+	ac_cv_ps_command="$PATH_TO_PS -axwo 'stat uid pid ppid vsz rss nlwp pcpu comm args'"
+	ac_cv_ps_format="%s %d %d %d %d %d %d %f %s %n"
+	ac_cv_ps_cols=10
+	AC_MSG_RESULT([$ac_cv_ps_command])
+
 dnl For OpenBSD 3.2 & 3.3. Must come before ps -weo
 dnl Should also work for FreeBSD 5.2.1 and 5.3
 dnl  STAT UCOMM              VSZ   RSS USER      PPID COMMAND
@@ -821,6 +851,16 @@ then
 	ac_cv_ps_command="$PATH_TO_PS -axwo 'stat uid pid ppid vsz rss pcpu comm args'"
 	ac_cv_ps_format="%s %d %d %d %d %d %f %s %n"
 	ac_cv_ps_cols=9
+	AC_MSG_RESULT([$ac_cv_ps_command])
+
+dnl Check support for threads on *BSD...
+elif ps -axwo 'stat uid pid ppid vsz rss wq pcpu ucomm command' 2>/dev/null | \
+	grep -E -i ["^ *STAT +UID +PID +PPID +VSZ +RSS +WQ +%CPU +UCOMM +COMMAND"] > /dev/null
+then
+	ac_cv_ps_varlist="[procstat,&procuid,&procpid,&procppid,&procvsz,&procrss,&procnlwp,&procpcpu,procprog,&pos]"
+	ac_cv_ps_command="$PATH_TO_PS -axwo 'stat uid pid ppid vsz rss wq pcpu ucomm command'"
+	ac_cv_ps_format="%s %d %d %d %d %d %d %f %s %n"
+	ac_cv_ps_cols=10
 	AC_MSG_RESULT([$ac_cv_ps_command])
 
 dnl Some *BSDs have different format for ps. This is mainly to catch FreeBSD 4.
@@ -1072,6 +1112,10 @@ if test -n "$ac_cv_ps_varlist" ; then
 	if echo "$ac_cv_ps_varlist" | grep "procpcpu" >/dev/null; then
 		AC_DEFINE(PS_USES_PROCPCPU,"yes",
 		          [Whether the ps utility uses the "procpcpu" field])
+	fi
+	if echo "$ac_cv_ps_varlist" | grep "procnlwp" >/dev/null; then
+		AC_DEFINE(PS_USES_PROCNLWP,"yes",
+		          [Whether the ps utility uses the "procnlwp" field])
 	fi
 fi
 

--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -427,6 +427,9 @@ int cmpstringp(const void *p1, const void *p2) {
 	int procppid = 0;
 	int procvsz = 0;
 	int procrss = 0;
+#ifdef PS_USES_PROCNLWP
+    int procnlwp = 0;
+#endif
 	float procpcpu = 0;
 	char procstat[8];
 #	ifdef PS_USES_PROCETIME

--- a/plugins/check_nagios.c
+++ b/plugins/check_nagios.c
@@ -119,6 +119,9 @@ int main(int argc, char **argv) {
 	int procppid = 0;
 	int procvsz = 0;
 	int procrss = 0;
+#ifdef PS_USES_PROCNLWP
+	int procnlwp = 0;
+#endif
 	int proc_entries = 0;
 	float procpcpu = 0;
 	char procstat[8];

--- a/plugins/check_procs.c
+++ b/plugins/check_procs.c
@@ -182,6 +182,27 @@ int main(int argc, char **argv) {
 		/* number of columns in ps output */
 		int cols = sscanf(input_line, PS_FORMAT, PS_VARLIST);
 
+#ifdef PS_USES_PROCNLWP
+		/* Hotfix to parse non number output on field "nlwp" mostly on MacOS X */
+		if ( cols < 7 ) {
+			/* replace first occurrence of "-" in process list and parse again */
+			int i=0;
+			while(input_line[i] != '\0') {
+				/* avoid transform negative uid */
+				if ( input_line[i] == '-' && procuid < 0 ) {
+					procuid = 0;
+				} else if ( input_line[i] == '-' ) {
+					input_line[i] = '1';
+					break;
+				}
+			i++;
+			}
+		}
+
+		cols = sscanf (input_line, PS_FORMAT, PS_VARLIST);
+		/* End of Hotfix */
+#endif
+
 		/* Zombie processes do not give a procprog command */
 		const char *zombie = "Z";
 		if (cols < expected_cols && strstr(procstat, zombie)) {

--- a/plugins/check_procs.d/config.h
+++ b/plugins/check_procs.d/config.h
@@ -12,7 +12,8 @@ enum metric {
 	METRIC_VSZ,
 	METRIC_RSS,
 	METRIC_CPU,
-	METRIC_ELAPSED
+	METRIC_ELAPSED,
+	METRIC_NLWP
 };
 
 typedef struct {
@@ -30,11 +31,13 @@ typedef struct {
 	regex_t re_args;
 
 	bool kthread_filter;
+	bool usethreads; /* whether to test for threads or processes */
 	bool usepid; /* whether to test for pid or /proc/pid/exe */
 	uid_t uid;
 	pid_t ppid;
 	int vsz;
 	int rss;
+	int nlwp;
 	float pcpu;
 	char *statopts;
 
@@ -64,6 +67,7 @@ check_procs_config check_procs_config_init() {
 		.ppid = 0,
 		.vsz = 0,
 		.rss = 0,
+		.nlwp = 0,
 		.pcpu = 0,
 		.statopts = NULL,
 

--- a/plugins/tests/check_procs.t
+++ b/plugins/tests/check_procs.t
@@ -14,8 +14,22 @@ if (-x "./check_procs") {
 }
 
 my $result;
-my $command   = "./check_procs --input-file=tests/var/ps-axwo.darwin";
-my $cmd_etime = "./check_procs --input-file=tests/var/ps-axwo.debian";
+my $command;
+my $cmd_etime;
+my $command;
+my $withNLWP;
+
+$result = NPTest->testCmd( "./check_procs -m NLWP");
+
+if ($result->return_code == 0) {
+	$withNLWP = 1;
+	$command = "./check_procs --input-file=tests/var/ps-axwo-nlwp.darwin";
+	$cmd_etime = "./check_procs --input-file=tests/var/ps-axwo-nlwp.debian";
+} else {
+	$withNLWP = 0;
+	$command = "./check_procs --input-file=tests/var/ps-axwo.darwin";
+	$cmd_etime = "./check_procs --input-file=tests/var/ps-axwo.debian";
+}
 
 $result = NPTest->testCmd( "$command" );
 is( $result->return_code, 0, "Run with no options" );
@@ -120,7 +134,11 @@ is( $result->output, 'PROCS OK: 8 processes with PCPU >= 0.70 | procs=8;;;0;', "
 
 $result = NPTest->testCmd( "$command --metric=CPU -w 8" );
 is( $result->return_code, 1, "Checking against metric of CPU > 8" );
-is( $result->output, 'CPU WARNING: 1 warn out of 95 processes | procs=95;;;0; procs_warn=1;;;0; procs_crit=0;;;0;', "Output correct" );
+if( $withNLWP == 1 ) {
+	is( $result->output, 'CPU WARNING: 1 warn out of 95 processes | procs=95;;;0; threads=135;;;0; procs_warn=1;;;0; procs_crit=0;;;0;', "Output correct" );
+} else {
+	is( $result->output, 'CPU WARNING: 1 warn out of 95 processes | procs=95;;;0; procs_warn=1;;;0; procs_crit=0;;;0;', "Output correct" );
+}
 
 # TODO: Because of a conversion to int, if CPU is 1.45%, will not alert, but 2.01% will.
 SKIP: {
@@ -133,15 +151,27 @@ SKIP: {
 
 $result = NPTest->testCmd( "$command --metric=VSZ -w 1200000 -v" );
 is( $result->return_code, 1, "Checking against VSZ > 1.2GB" );
-is( $result->output, 'VSZ WARNING: 4 warn out of 95 processes [WindowServer, Safari, Mail, Skype] | procs=95;;;0; procs_warn=4;;;0; procs_crit=0;;;0;', "Output correct" );
+if( $withNLWP == 1 ) {
+	is( $result->output, 'VSZ WARNING: 4 warn out of 95 processes [WindowServer, Safari, Mail, Skype] | procs=95;;;0; threads=135;;;0; procs_warn=4;;;0; procs_crit=0;;;0;', "Output correct" );
+} else {
+	is( $result->output, 'VSZ WARNING: 4 warn out of 95 processes [WindowServer, Safari, Mail, Skype] | procs=95;;;0; procs_warn=4;;;0; procs_crit=0;;;0;', "Output correct" );
+}
 
 $result = NPTest->testCmd( "$command --metric=VSZ -w 1200000 -v" );
 is( $result->return_code, 1, "Checking against VSZ > 1.2GB" );
-is( $result->output, 'VSZ WARNING: 4 warn out of 95 processes [WindowServer, Safari, Mail, Skype] | procs=95;;;0; procs_warn=4;;;0; procs_crit=0;;;0;', "Output correct" );
+if( $withNLWP == 1 ) {
+	is( $result->output, 'VSZ WARNING: 4 warn out of 95 processes [WindowServer, Safari, Mail, Skype] | procs=95;;;0; threads=135;;;0; procs_warn=4;;;0; procs_crit=0;;;0;', "Output correct" );
+} else {
+	is( $result->output, 'VSZ WARNING: 4 warn out of 95 processes [WindowServer, Safari, Mail, Skype] | procs=95;;;0; procs_warn=4;;;0; procs_crit=0;;;0;', "Output correct" );
+}
 
 $result = NPTest->testCmd( "$command --metric=RSS -c 70000 -v" );
 is( $result->return_code, 2, "Checking against RSS > 70MB" );
-is( $result->output, 'RSS CRITICAL: 5 crit, 0 warn out of 95 processes [WindowServer, SystemUIServer, Safari, Mail, Safari] | procs=95;;;0; procs_warn=0;;;0; procs_crit=5;;;0;', "Output correct" );
+if( $withNLWP == 1 ) {
+	is( $result->output, 'RSS CRITICAL: 5 crit, 0 warn out of 95 processes [WindowServer, SystemUIServer, Safari, Mail, Safari] | procs=95;;;0; threads=135;;;0; procs_warn=0;;;0; procs_crit=5;;;0;', "Output correct" );
+} else {
+	is( $result->output, 'RSS CRITICAL: 5 crit, 0 warn out of 95 processes [WindowServer, SystemUIServer, Safari, Mail, Safari] | procs=95;;;0; procs_warn=0;;;0; procs_crit=5;;;0;', "Output correct" );
+}
 
 $result = NPTest->testCmd( "$command --ereg-argument-array='(nosuchname|nosuch2name)'" );
 is( $result->return_code, 0, "Checking no pipe symbol in output" );

--- a/plugins/tests/var/ps-axwo-nlwp.darwin
+++ b/plugins/tests/var/ps-axwo-nlwp.darwin
@@ -1,0 +1,96 @@
+STAT   UID   PID  PPID      VSZ    RSS NLWP  %CPU UCOMM            COMMAND
+Ss       0     1     0   603456    976    3   0.0 launchd          /sbin/launchd
+Ss       0    10     1   612820   3608    1   0.0 kextd            /usr/libexec/kextd
+Ss       0    11     1   632980   8680    7   0.0 DirectoryService /usr/sbin/DirectoryService
+Ss       0    12     1   602832    720    -   0.0 notifyd          /usr/sbin/notifyd
+Ss       0    13     1   603916   1136    -   0.0 syslogd          /usr/sbin/syslogd
+Ss       0    14     1   614928   4928    1   0.0 configd          /usr/sbin/configd
+Ss      65    15     1   615496   5616    1   0.0 mDNSResponder    /usr/sbin/mDNSResponder -launchd
+Ss       1    16     1   608960   2212    4   0.0 distnoted        /usr/sbin/distnoted
+Ss      65    18     1   602432    504    1   0.0 launchd          /sbin/launchd
+Ss       0    20     1   614836   5844    1   0.3 securityd        /usr/sbin/securityd -i
+Ss       0    24     1   610536   2704    2   0.0 ntpd             /usr/sbin/ntpd -n -g -p /var/run/ntpd.pid -f /var/db/ntp.drift
+Ss       0    25     1   602228    496    -   0.0 update           /usr/sbin/update
+Ss       0    26     1   609900   2320    -   0.0 SystemStarter    /sbin/SystemStarter
+Ss       0    30     1   834352  36264    1   0.3 mds              /System/Library/Frameworks/CoreServices.framework/Frameworks/Metadata.framework/Support/mds
+Ss     501    31     1  1110572  23948    1   0.0 loginwindow      /System/Library/CoreServices/loginwindow.app/Contents/MacOS/loginwindow console
+Ss       0    32     1   609448   2616    1   0.0 KernelEventAgent /usr/sbin/KernelEventAgent
+Ss       0    34     1   609892   2204    1   0.0 hidd             /usr/libexec/hidd
+Ss       0    35     1   624704   4284    1   0.0 fseventsd        /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/Support/fseventsd
+Ss       0    36     1   610256   2876    -   0.0 dynamic_pager    /sbin/dynamic_pager -F /private/var/vm/swapfile
+Ss       0    39     1   613408   4140    -   0.0 diskarbitrationd /usr/sbin/diskarbitrationd
+Ss       0    43     1   665708   8024    -   0.0 blued            /usr/sbin/blued
+Ss       0    44     1   609408   2828    1   0.0 autofsd          autofsd
+Ss       0    45     1   654084   9600    1   0.0 socketfilterfw   /usr/libexec/ApplicationFirewall/socketfilterfw
+Ss       0    46     1   704764  12788    5   0.0 ccc_helper       /Applications/Carbon Copy Cloner.app/Contents/Resources/ccc_helper.app/Contents/MacOS/ccc_helper 3231BC22-F30F-45D8-BDE8-47A098D57ABD
+Ss       0    54     1   667956  19212    1   0.0 coreservicesd    /System/Library/CoreServices/coreservicesd
+Ss      88    56     1  1205840  85700    1   1.6 WindowServer     /System/Library/Frameworks/ApplicationServices.framework/Frameworks/CoreGraphics.framework/Resources/WindowServer -daemon
+Ss       0    67     1   602992    612    1   0.0 llipd            /Library/StartupItems/ParallelsTransporter/llipd
+S        0    83     1   613352   2312    1   0.0 pvsnatd          /Library/StartupItems/Parallels/pvsnatd
+Ss       0    94     1   712036  15056    1   0.0 coreaudiod       /usr/sbin/coreaudiod
+Ss     501   102     1   602432   1040    1   0.0 launchd          /sbin/launchd
+S      501   109   102  1176668  28068    1   0.0 Spotlight        /System/Library/CoreServices/Spotlight.app/Contents/MacOS/Spotlight
+S      501   110   102   941796  10988    1   0.0 UserEventAgent   /usr/sbin/UserEventAgent -l Aqua
+S      501   112   102   610028   2056    1   0.0 pboard           /usr/sbin/pboard
+S      501   114   102  1090056  29196    3   1.3 Dock             /System/Library/CoreServices/Dock.app/Contents/MacOS/Dock -psn_0_24582
+S      501   115   102   685360  14048    -   0.0 ATSServer        /System/Library/Frameworks/ApplicationServices.framework/Frameworks/ATS.framework/Support/ATSServer
+S      501   117   102  1121904  94432    -   0.1 SystemUIServer   /System/Library/CoreServices/SystemUIServer.app/Contents/MacOS/SystemUIServer -psn_0_32776
+S      501   118   102  1110388  42064    9   1.4 Finder           /System/Library/CoreServices/Finder.app/Contents/MacOS/Finder -psn_0_36873
+S      501   123   102   718264  34752    1   0.0 FileSyncAgent    /System/Library/CoreServices/FileSyncAgent.app/Contents/MacOS/FileSyncAgent -launchedByLaunchd
+S      501   127   102  1048388  25344    1   0.0 smcFanControl    /Applications/smcFanControl.app/Contents/MacOS/smcFanControl -psn_0_53261
+S      501   128   102   970912  12924    1   0.0 iTunesHelper     /Applications/iTunes.app/Contents/Resources/iTunesHelper.app/Contents/MacOS/iTunesHelper -psn_0_57358
+S      501   129   102  1095920  23364    1   1.4 Activity Monitor /Applications/Utilities/Activity Monitor.app/Contents/MacOS/Activity Monitor -psn_0_61455
+S      501   132   102   657212   8356    1   0.0 dmnotifyd        /System/Library/PrivateFrameworks/DMNotification.framework/Versions/Current/Resources/dmnotifyd
+Ss      -2   133     1   610464   2328    1   0.0 usbmuxd          /System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/Resources/usbmuxd -launchd
+Ss       0   136   129   637456   6340    1  10.6 pmTool           /Applications/Utilities/Activity Monitor.app/Contents/Resources/pmTool
+Ss     501   142     1   676652   8984    1   0.1 diskimages-helpe /System/Library/PrivateFrameworks/DiskImages.framework/Resources/diskimages-helper -uuid F2225770-5EFF-467C-91FD-C990F056B22F -post-exec
+Ss       0   147     1   627640   5928    1   0.0 hdiejectd        /System/Library/PrivateFrameworks/DiskImages.framework/Resources/hdiejectd
+S      501   157   102  1045492  27480    1   0.0 GrowlHelperApp   /Library/PreferencePanes/Growl.prefPane/Contents/Resources/GrowlHelperApp.app/Contents/MacOS/GrowlHelperApp -psn_0_81940
+U      501   158   102  1878012 388136    5   0.7 Safari           /Applications/Safari.app/Contents/MacOS/Safari -psn_0_86037
+S      501   172   102   645560  11344    1   0.0 AppleSpell       /System/Library/Services/AppleSpell.service/Contents/MacOS/AppleSpell -psn_0_98328
+S      501   175   102  1055412  33396    1   0.0 Terminal         /Applications/Utilities/Terminal.app/Contents/MacOS/Terminal -psn_0_102425
+Z      501   186   158        0      0    1   0.0 Meeting Manager  (Meeting Manager)
+S      501   214   102   616988   3808    -   0.0 ssh-agent        /usr/bin/ssh-agent -l
+Ss     502   217     1   602432   1016    -   0.0 launchd          /sbin/launchd
+S      501   499   102  1313808 130396    1   0.3 Mail             /Applications/Mail.app/Contents/MacOS/Mail -psn_0_180268
+S      501   502   102  1091652  52168    1   0.0 NetNewsWire Lite /Applications/NetNewsWire Lite.app/Contents/MacOS/NetNewsWire Lite -psn_0_184365
+Ss     502   572    56   818908  20988    1   0.0 loginwindow      /System/Library/CoreServices/loginwindow.app/Contents/MacOS/loginwindow
+S      502   585   217   741824  19056    2   0.0 Spotlight        /System/Library/CoreServices/Spotlight.app/Contents/MacOS/Spotlight
+S      502   586   217   941900  11044    1   0.0 UserEventAgent   /usr/sbin/UserEventAgent -l Aqua
+S      502   588   217   757320  18080    1   0.0 Dock             /System/Library/CoreServices/Dock.app/Contents/MacOS/Dock -psn_0_237626
+S      502   590   217   610072   2068    1   0.0 pboard           /usr/sbin/pboard
+S      502   592   217   794140  25456    1   0.0 SystemUIServer   /System/Library/CoreServices/SystemUIServer.app/Contents/MacOS/SystemUIServer -psn_0_245820
+S      502   593   217   845552  30596    1   0.0 Finder           /System/Library/CoreServices/Finder.app/Contents/MacOS/Finder -psn_0_249917
+S      502   594   217   671780   7872    1   0.0 ATSServer        /System/Library/Frameworks/ApplicationServices.framework/Frameworks/ATS.framework/Support/ATSServer
+U      502   605   217   938844  64964    1   0.0 Pages            /Applications/iWork '08/Pages.app/Contents/MacOS/Pages -psn_0_266305
+S      502   609   217   644432  10828    1   0.0 AppleSpell       /System/Library/Services/AppleSpell.service/Contents/MacOS/AppleSpell -psn_0_270402
+S      502   610   217   638552   5216    1   0.0 AppleSpell       /System/Library/Services/AppleSpell.service/Contents/MacOS/AppleSpell -psn_0_274499
+U      502   710   217  1029148 223312    5   0.0 Safari           /Applications/Safari.app/Contents/MacOS/Safari -psn_0_331857
+S      502   712   217   904056  62928    3   0.3 Mail             /Applications/Mail.app/Contents/MacOS/Mail -psn_0_335954
+U      501   998   102  1068272  26532    1   0.0 Address Book     /Applications/Address Book.app/Contents/MacOS/Address Book -psn_0_417894
+S      502  2228   217   820940  30600    1   0.0 TextEdit         /Applications/TextEdit.app/Contents/MacOS/TextEdit -psn_0_729266
+S      501  2431   102  1067868  43492    1   0.0 iCal             /Applications/iCal.app/Contents/MacOS/iCal -psn_0_803012
+S      501  2531   102  1250108  68792    2   2.4 Skype            /Applications/Skype.app/Contents/MacOS/Skype -psn_0_823497
+Ss      92  3143     1   602432    828    -   0.0 launchd          /sbin/launchd
+S      501  3491   102  1048620  31256    1   0.0 TextEdit         /Applications/TextEdit.app/Contents/MacOS/TextEdit -psn_0_962795
+S      501  3536   102  1073340  30524    1   0.0 Preview          /Applications/Preview.app/Contents/MacOS/Preview -psn_0_983280
+S      501  4045   102  1041544  29168    1   0.0 PasswordWallet   /Applications/PasswordWallet.app/Contents/MacOS/PasswordWallet -psn_0_1138966
+S      501  4892   114  1064948  43488    1   0.0 DashboardClient  /System/Library/CoreServices/Dock.app/Contents/Resources/DashboardClient.app/Contents/MacOS/DashboardClient
+S      501  6806   102  1163836  67356    1   0.0 Colloquy         /Applications/Colloquy.app/Contents/MacOS/Colloquy -psn_0_2220574
+U      501  6969   102  1156804  58764    1   0.0 Adium            /Applications/Adium.app/Contents/MacOS/Adium -psn_0_2294320
+S      501  7530   102   671612  17440    1   0.0 helpdatad        /System/Library/PrivateFrameworks/HelpData.framework/Versions/A/Resources/helpdatad
+Ss      -2 38255     1   602432    952    -   0.0 launchd          /sbin/launchd
+S      501 40569   102  1160664  49484    1   0.0 Dictionary       /Applications/Dictionary.app/Contents/MacOS/Dictionary -psn_0_4387887
+SNs    501 42683     1   744096  21084    2   0.0 mdworker         /System/Library/Frameworks/CoreServices.framework/Frameworks/Metadata.framework/Versions/A/Support/mdworker MDSImporterWorker com.apple.Spotlight.ImporterWorker.501
+S      501 62225   102   711004  18040    1   0.0 SyncServer       /System/Library/Frameworks/SyncServices.framework/Versions/Current/Resources/SyncServer.app/Contents/MacOS/SyncServer
+SNs     -2 62284     1   671812  10880    2   0.0 mdworker         /System/Library/Frameworks/CoreServices.framework/Frameworks/Metadata.framework/Versions/A/Support/mdworker MDSImporterWorker com.apple.Spotlight.ImporterWorker.-2
+Ss       0 62285     1   617056   5472    1   0.0 cupsd            /usr/sbin/cupsd -l
+S      502 62287   217   632360  10044    1   0.0 PubSubAgent      /System/Library/Frameworks/PubSub.framework/Versions/A/Resources/PubSubAgent.app/Contents/MacOS/PubSubAgent
+SNs    502 62288     1   668876  10440    1   0.0 mdworker         /System/Library/Frameworks/CoreServices.framework/Frameworks/Metadata.framework/Versions/A/Support/mdworker MDSImporterWorker com.apple.Spotlight.Impor terWorker.502
+S      501 62296   102   643688  11980    1   2.2 PubSubAgent      /System/Library/Frameworks/PubSub.framework/Versions/A/Resources/PubSubAgent.app/Contents/MacOS/PubSubAgent
+Ss       0  4558   175   630816   6960    -   0.0 login            login -pf tonvoon
+S      501  4559  4558   603600   1736    1   0.0 bash             -bash
+R+       0 62297  4559   602388    852    1   0.0 ps               /bin/ps -axwo stat
+Ss       0  7301   175   630816   6960    1   0.0 login            login -pf tonvoon
+S      501  7302  7301   603600   1584    1   0.0 bash             -bash
+S+     501 41381  7302   615408   4196    1   0.0 ssh              ssh dev.net.altinity

--- a/plugins/tests/var/ps-axwo-nlwp.debian
+++ b/plugins/tests/var/ps-axwo-nlwp.debian
@@ -1,0 +1,135 @@
+STAT   UID     PID    PPID    VSZ   RSS NLWP %CPU     ELAPSED COMMAND         COMMAND
+Ss       0       1       0 168412 12756    1  0.0 30-02:18:03 systemd         /sbin/init
+S        0       2       0      0     0    1  0.0 30-02:18:03 kthreadd        [kthreadd]
+I<       0       3       2      0     0    1  0.0 30-02:18:03 rcu_gp          [rcu_gp]
+I<       0       4       2      0     0    1  0.0 30-02:18:03 rcu_par_gp      [rcu_par_gp]
+I<       0       5       2      0     0    1  0.0 30-02:18:03 slub_flushwq    [slub_flushwq]
+I<       0       6       2      0     0    1  0.0 30-02:18:03 netns           [netns]
+I<       0       8       2      0     0    1  0.0 30-02:18:03 kworker/0:0H-ev [kworker/0:0H-events_highpri]
+I<       0      10       2      0     0    1  0.0 30-02:18:03 mm_percpu_wq    [mm_percpu_wq]
+I        0      11       2      0     0    1  0.0 30-02:18:03 rcu_tasks_kthre [rcu_tasks_kthread]
+I        0      12       2      0     0    1  0.0 30-02:18:03 rcu_tasks_rude_ [rcu_tasks_rude_kthread]
+I        0      13       2      0     0    1  0.0 30-02:18:03 rcu_tasks_trace [rcu_tasks_trace_kthread]
+S        0      14       2      0     0    1  0.0 30-02:18:03 ksoftirqd/0     [ksoftirqd/0]
+I        0      15       2      0     0    1  0.0 30-02:18:03 rcu_preempt     [rcu_preempt]
+S        0      16       2      0     0    1  0.0 30-02:18:03 migration/0     [migration/0]
+S        0      18       2      0     0    1  0.0 30-02:18:03 cpuhp/0         [cpuhp/0]
+S        0      19       2      0     0    1  0.0 30-02:18:03 cpuhp/1         [cpuhp/1]
+S        0      20       2      0     0    1  0.0 30-02:18:03 migration/1     [migration/1]
+S        0      21       2      0     0    1  0.0 30-02:18:03 ksoftirqd/1     [ksoftirqd/1]
+I<       0      23       2      0     0    1  0.0 30-02:18:03 kworker/1:0H-ev [kworker/1:0H-events_highpri]
+S        0      24       2      0     0    1  0.0 30-02:18:03 cpuhp/2         [cpuhp/2]
+S        0      25       2      0     0    1  0.0 30-02:18:03 migration/2     [migration/2]
+S        0      26       2      0     0    1  0.0 30-02:18:03 ksoftirqd/2     [ksoftirqd/2]
+I<       0      28       2      0     0    1  0.0 30-02:18:03 kworker/2:0H-ev [kworker/2:0H-events_highpri]
+S        0      29       2      0     0    1  0.0 30-02:18:03 cpuhp/3         [cpuhp/3]
+S        0      30       2      0     0    1  0.0 30-02:18:03 migration/3     [migration/3]
+S        0      31       2      0     0    1  0.0 30-02:18:03 ksoftirqd/3     [ksoftirqd/3]
+I<       0      33       2      0     0    1  0.0 30-02:18:03 kworker/3:0H-ev [kworker/3:0H-events_highpri]
+S        0      38       2      0     0    1  0.0 30-02:18:03 kdevtmpfs       [kdevtmpfs]
+I<       0      39       2      0     0    1  0.0 30-02:18:03 inet_frag_wq    [inet_frag_wq]
+S        0      40       2      0     0    1  0.0 30-02:18:03 kauditd         [kauditd]
+S        0      41       2      0     0    1  0.0 30-02:18:03 khungtaskd      [khungtaskd]
+S        0      42       2      0     0    1  0.0 30-02:18:03 oom_reaper      [oom_reaper]
+I<       0      43       2      0     0    1  0.0 30-02:18:03 writeback       [writeback]
+S        0      44       2      0     0    1  0.0 30-02:18:03 kcompactd0      [kcompactd0]
+SN       0      45       2      0     0    1  0.0 30-02:18:03 ksmd            [ksmd]
+SN       0      47       2      0     0    1  0.0 30-02:18:03 khugepaged      [khugepaged]
+I<       0      48       2      0     0    1  0.0 30-02:18:03 kintegrityd     [kintegrityd]
+I<       0      49       2      0     0    1  0.0 30-02:18:03 kblockd         [kblockd]
+I<       0      50       2      0     0    1  0.0 30-02:18:03 blkcg_punt_bio  [blkcg_punt_bio]
+I<       0      51       2      0     0    1  0.0 30-02:18:03 tpm_dev_wq      [tpm_dev_wq]
+I<       0      52       2      0     0    1  0.0 30-02:18:03 edac-poller     [edac-poller]
+I<       0      53       2      0     0    1  0.0 30-02:18:03 devfreq_wq      [devfreq_wq]
+I<       0      54       2      0     0    1  0.0 30-02:18:03 kworker/3:1H-kb [kworker/3:1H-kblockd]
+S        0      55       2      0     0    1  0.0 30-02:18:03 kswapd0         [kswapd0]
+I<       0      62       2      0     0    1  0.0 30-02:18:03 kthrotld        [kthrotld]
+I<       0      65       2      0     0    1  0.0 30-02:18:03 acpi_thermal_pm [acpi_thermal_pm]
+I<       0      66       2      0     0    1  0.0 30-02:18:03 mld             [mld]
+I<       0      67       2      0     0    1  0.0 30-02:18:03 ipv6_addrconf   [ipv6_addrconf]
+I<       0      69       2      0     0    1  0.0 30-02:18:03 kworker/0:1H-kb [kworker/0:1H-kblockd]
+I<       0      73       2      0     0    1  0.0 30-02:18:03 kstrp           [kstrp]
+I<       0      78       2      0     0    1  0.0 30-02:18:02 zswap-shrink    [zswap-shrink]
+I<       0      79       2      0     0    1  0.0 30-02:18:02 kworker/u9:0    [kworker/u9:0]
+I<       0     123       2      0     0    1  0.0 30-02:18:02 kworker/1:1H-kb [kworker/1:1H-kblockd]
+I<       0     133       2      0     0    1  0.0 30-02:18:02 kworker/2:1H-kb [kworker/2:1H-kblockd]
+I<       0     154       2      0     0    1  0.0 30-02:18:02 ata_sff         [ata_sff]
+S        0     155       2      0     0    1  0.0 30-02:18:02 scsi_eh_0       [scsi_eh_0]
+I<       0     156       2      0     0    1  0.0 30-02:18:02 scsi_tmf_0      [scsi_tmf_0]
+S        0     157       2      0     0    1  0.0 30-02:18:02 scsi_eh_1       [scsi_eh_1]
+I<       0     158       2      0     0    1  0.0 30-02:18:02 scsi_tmf_1      [scsi_tmf_1]
+S        0     167       2      0     0    1  0.0 30-02:18:01 card0-crtc0     [card0-crtc0]
+S        0     168       2      0     0    1  0.0 30-02:18:01 card0-crtc1     [card0-crtc1]
+I<       0     173       2      0     0    1  0.0 30-02:18:00 kdmflush/254:0  [kdmflush/254:0]
+I<       0     174       2      0     0    1  0.0 30-02:18:00 kdmflush/254:1  [kdmflush/254:1]
+I<       0     176       2      0     0    1  0.0 30-02:18:00 kdmflush/254:2  [kdmflush/254:2]
+I<       0     179       2      0     0    1  0.0 30-02:18:00 kdmflush/254:3  [kdmflush/254:3]
+I<       0     184       2      0     0    1  0.0 30-02:18:00 kdmflush/254:4  [kdmflush/254:4]
+I<       0     185       2      0     0    1  0.0 30-02:18:00 kdmflush/254:5  [kdmflush/254:5]
+S        0     222       2      0     0    1  0.0 30-02:17:57 jbd2/dm-0-8     [jbd2/dm-0-8]
+I<       0     223       2      0     0    1  0.0 30-02:17:57 ext4-rsv-conver [ext4-rsv-conver]
+Ss       0     272       1  66264 18948    1  0.0 30-02:17:56 systemd-journal /lib/systemd/systemd-journald
+Ss       0     293       1  26568  6092    1  0.0 30-02:17:56 systemd-udevd   /lib/systemd/systemd-udevd
+S        0     344       2      0     0    1  0.0 30-02:17:55 watchdogd       [watchdogd]
+I<       0     345       2      0     0    1  0.0 30-02:17:55 cryptd          [cryptd]
+I<       0     425       2      0     0    1  0.0 30-02:17:55 led_workqueue   [led_workqueue]
+S        0     509       2      0     0    1  0.0 30-02:17:55 jbd2/dm-4-8     [jbd2/dm-4-8]
+I<       0     510       2      0     0    1  0.0 30-02:17:55 ext4-rsv-conver [ext4-rsv-conver]
+S        0     512       2      0     0    1  0.0 30-02:17:55 jbd2/dm-3-8     [jbd2/dm-3-8]
+I<       0     513       2      0     0    1  0.0 30-02:17:55 ext4-rsv-conver [ext4-rsv-conver]
+S        0     514       2      0     0    1  0.0 30-02:17:55 jbd2/dm-1-8     [jbd2/dm-1-8]
+I<       0     515       2      0     0    1  0.0 30-02:17:55 ext4-rsv-conver [ext4-rsv-conver]
+S        0     519       2      0     0    1  0.0 30-02:17:54 jbd2/dm-5-8     [jbd2/dm-5-8]
+I<       0     520       2      0     0    1  0.0 30-02:17:54 ext4-rsv-conver [ext4-rsv-conver]
+I<       0     528       2      0     0    1  0.0 30-02:17:54 ext4-rsv-conver [ext4-rsv-conver]
+Ss       0     566       1   2504  1088    1  0.0 30-02:17:54 acpid           /usr/sbin/acpid
+Ss       0     567       1   6612  2732    1  0.0 30-02:17:54 cron            /usr/sbin/cron -f
+Ss     105     568       1   9140  4896    1  0.0 30-02:17:54 dbus-daemon     /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --sy
+Ssl      0     570       1  82620  3728    2  0.0 30-02:17:54 irqbalance      /usr/sbin/irqbalance --foreground
+Ssl      0     573       1 221796  8688    4  0.0 30-02:17:54 rsyslogd        /usr/sbin/rsyslogd -n -iNONE
+Ss       0     574       1  33472  8200    1  0.0 30-02:17:54 systemd-logind  /lib/systemd/systemd-logind
+I<       0     635       2      0     0    1  0.0 30-02:17:53 tls-strp        [tls-strp]
+I<       0     643       2      0     0    1  0.0 30-02:17:53 ebond0          [ebond0]
+I<       0     961       2      0     0    1  0.0 30-02:17:52 ibond0          [ibond0]
+Ssl      0    1321       1 1875928 50692   9  0.1 30-02:17:51 containerd      /usr/bin/containerd
+Ss+      0    1322       1   5876  1008    1  0.0 30-02:17:51 agetty          /sbin/agetty -o -p -- \u --noclear - linux
+Ss       0    1333       1  15580  9464    1  0.0 30-02:17:51 sshd            sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups
+S<s      0    1338       1   3436  1576    1  0.0 30-02:17:51 ntpd            /usr/sbin/ntpd -f /etc/openntpd/ntpd.conf
+S<     114    1339    1338   3588  2220    1  0.0 30-02:17:51 ntpd            ntpd: ntp engine
+S      114    1342    1339   3516  2312    1  0.0 30-02:17:51 ntpd            ntpd: dns engine
+Ss       0    1354       1   2544   116    1  0.0 30-02:17:51 radvd           /usr/sbin/radvd --logmethod stderr_clean
+S        0    1355    1354   2544   120    1  0.0 30-02:17:51 radvd           /usr/sbin/radvd --logmethod stderr_clean
+Ss       0    1411       1   9928  7412    1  0.0 30-02:17:51 dhcpd           /usr/sbin/dhcpd -4 -q -cf /etc/dhcp/dhcpd.conf ibond0.700 ibond0.710 ibond
+I<       0    1412       2      0     0    1  0.0 30-02:17:51 wg-crypt-wg53   [wg-crypt-wg53]
+I<       0    1414       2      0     0    1  0.0 30-02:17:51 wg-crypt-wg7t1  [wg-crypt-wg7t1]
+Ssl      0    1438       1 1973036 75888  10  0.0 30-02:17:51 dockerd         /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+Ss       0    1842       1  42668  4608    1  0.0 30-02:17:49 master          /usr/lib/postfix/sbin/master -w
+S      115    1844    1842  43112  7008    1  0.0 30-02:17:49 qmgr            qmgr -l -t unix -u
+S      999   42681       1  14276  2468    1  0.0  8-08:36:13 dnsmasq         /usr/sbin/dnsmasq -x /run/dnsmasq/dnsmasq.pid -u dnsmasq -7 /etc/dnsmasq.d
+S<s      0   43269       1   8852  3324    1  0.0  8-07:04:54 watchfrr        /usr/lib/frr/watchfrr -d -F traditional zebra mgmtd bgpd staticd
+S<sl   113   43280       1 466884 12876    8  0.0  8-07:04:54 zebra           /usr/lib/frr/zebra -d -F traditional -A 127.0.0.1 -s 90000000
+S<s    113   43285       1  14156  9488    1  0.0  8-07:04:53 mgmtd           /usr/lib/frr/mgmtd -d -F traditional -A 127.0.0.1
+S<sl   113   43287       1 180268 16936    4  0.0  8-07:04:53 bgpd            /usr/lib/frr/bgpd -d -F traditional -A 127.0.0.1
+S<s    113   43294       1  10764  5952    1  0.0  8-07:04:53 staticd         /usr/lib/frr/staticd -d -F traditional -A 127.0.0.1
+Ssl    116   43472       1 220708 91336   14  0.0  8-06:36:27 named           /usr/sbin/named -f -u bind
+I        0   56550       2      0     0    1  0.0    20:26:30 kworker/3:0-mm_ [kworker/3:0-mm_percpu_wq]
+I        0   57367       2      0     0    1  0.0    07:27:28 kworker/1:1-wg- [kworker/1:1-wg-crypt-wg53]
+I        0   57783       2      0     0    1  0.0    02:26:39 kworker/0:0-wg- [kworker/0:0-wg-crypt-wg7t1]
+Ss       0   57837    1333  17756 11096    1  0.0    01:38:22 sshd            sshd: bkuebler [priv]
+Ss    1000   57840       1  19140 10684    1  0.0    01:38:19 systemd         /lib/systemd/systemd --user
+S     1000   57841   57840 169472  3868    1  0.0    01:38:19 (sd-pam)        (sd-pam)
+I        0   57842       2      0     0    1  0.0    01:38:19 kworker/3:2-wg- [kworker/3:2-wg-crypt-wg7t1]
+S     1000   57861   57837  18016  6872    1  0.0    01:38:19 sshd            sshd: bkuebler@pts/0
+Ss    1000   57862   57861   8372  5088    1  0.0    01:38:18 bash            -bash
+S+       0   57869   57862  10248  5252    1  0.0    01:38:16 sudo            sudo -i
+Ss       0   57870   57869  10248   540    1  0.0    01:38:13 sudo            sudo -i
+S        0   57871   57870   8504  5160    1  0.0    01:38:13 bash            -bash
+I        0   57975       2      0     0    1  0.0       25:28 kworker/1:0-mm_ [kworker/1:0-mm_percpu_wq]
+I        0   57987       2      0     0    1  0.0       15:58 kworker/2:0-wg- [kworker/2:0-wg-crypt-wg7t1]
+I        0   57991       2      0     0    1  0.0       15:57 kworker/0:1-eve [kworker/0:1-events]
+I        0   57995       2      0     0    1  0.0       15:27 kworker/u8:3-ev [kworker/u8:3-events_unbound]
+S      115   57997    1842  43068  6936    1  0.0       13:12 pickup          pickup -l -t unix -u -c
+I        0   58001       2      0     0    1  0.0       10:23 kworker/u8:0-ev [kworker/u8:0-events_unbound]
+I        0   58002       2      0     0    1  0.0       10:19 kworker/2:1-eve [kworker/2:1-events]
+I        0   58008       2      0     0    1  0.1       04:23 kworker/u8:1-ib [kworker/u8:1-ibond0]
+I        0   58013       2      0     0    1  0.0       02:32 kworker/u8:2-ib [kworker/u8:2-ibond0]


### PR DESCRIPTION
To use check_procs and it's mechanism to check threads on systems instead of processes. With this feature you can use "-n" flag to switch to threads overall instead of processes.

If you would like to use threads (lwp) in ps so calls NLWP (number of light weight processes) as metric now you can use "-m NLWP". For example if you use this you can check if the given process or any of the checked processes are reach the thread threshold defined with -c or -w