### PR TITLE
Exclude tmpfs, squashfs, and tracefs.

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -498,6 +498,9 @@ process_arguments (int argc, char **argv)
     return ERROR;
 
   np_add_name(&fs_exclude_list, "iso9660");
+  np_add_name(&fs_exclude_list, "squashfs");
+  np_add_name(&fs_exclude_list, "tmpfs");
+  np_add_name(&fs_exclude_list, "tracefs");
 
   for (c = 1; c < argc; c++)
     if (strcmp ("-to", argv[c]) == 0)


### PR DESCRIPTION
These synthetic filesystems always report 100% disk usage by design, so
can generate false-positive "disk full" alerts.  While it is possible to
exclude these via command line arguments, it is more convenient to
ignore them directly by the tool.

Fixes: https://github.com/monitoring-plugins/monitoring-plugins/issues/1608