### PR TITLE
Fix timeout_interval declarations

### DIFF
--- a/plugins/popen.c
+++ b/plugins/popen.c
@@ -39,9 +39,9 @@
 *****************************************************************************/
 
 #include "common.h"
+#include "utils.h"
 
 /* extern so plugin has pid to kill exec'd process on timeouts */
-extern int timeout_interval;
 extern pid_t *childpid;
 extern int *child_stderr_array;
 extern FILE *child_process;
@@ -76,8 +76,6 @@ RETSIGTYPE popen_timeout_alarm_handler (int);
 #define	SIG_ERR	((Sigfunc *)-1)
 #endif
 
-#define	min(a,b)	((a) < (b) ? (a) : (b))
-#define	max(a,b)	((a) > (b) ? (a) : (b))
 
 char *pname = NULL;							/* caller can set this from argv[0] */
 

--- a/plugins/popen.h
+++ b/plugins/popen.h
@@ -7,7 +7,6 @@ FILE *spopen (const char *);
 int spclose (FILE *);
 RETSIGTYPE popen_timeout_alarm_handler (int);
 
-extern unsigned int timeout_interval;
 pid_t *childpid=NULL;
 int *child_stderr_array=NULL;
 FILE *child_process=NULL;


### PR DESCRIPTION
There are different declarations/definitions for `timeout_interval`:

`lib/utils_base.c` has the definition:
```c
unsigned int timeout_interval = DEFAULT_SOCKET_TIMEOUT;
```
`lib/utils_base.h` has the appropriate declaration:
```c
extern unsigned int timeout_interval;
```

`plugins/popen.h` has an extra declaration:
```
extern unsigned int timeout_interval;
```
This doesn't hurt, but it's a dupe. The one in `utils_base.h` should be enough, so remove this one.

`plugins/popen.c` has a WRONG one:
```c
extern int timeout_interval;
```
Remove it!
Use `#include "utils.h"` to get the right one.
This makes the local defines for `max`/`min` unnecessary, so remove them also.