### PR TITLE
Remove doc parts which mention non existing Files

### DIFF
--- a/README
+++ b/README
@@ -1,14 +1,7 @@
 Monitoring Plugins
 ==================
 
-* For instructions on installing these plugins for use with your monitoring
-  system, see below.  In addition, generic instructions for the GNU
-  toolchain can be found in the `INSTALL` file.
-
 * For major changes between releases, read the `NEWS` file.
-
-* For information on detailed changes that have been made or plugins
-  that have been added, read the `ChangeLog` file.
 
 * Some plugins require that you have additional programs or
   libraries installed on your system before they can be used.  Plugins that


### PR DESCRIPTION
There is no "ChangeLog" or "INSTALL" file anymore in the repository. Mentioning them in the README is confusing.