### PR TITLE
docs: fix simple typo, conspicuosly -> conspicuously

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -1134,7 +1134,7 @@ finish(int sig)
 	while(host) {
 		if(!host->icmp_recv) {
 			/* rta 0 is ofcourse not entirely correct, but will still show up
-			 * conspicuosly as missing entries in perfparse and cacti */
+			 * conspicuously as missing entries in perfparse and cacti */
 			pl = 100;
 			rta = 0;
 			status = STATE_CRITICAL;


### PR DESCRIPTION
There is a small typo in plugins-root/check_icmp.c.

Should read `conspicuously` rather than `conspicuosly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md