### PR TITLE
Missing oldlog now aborts check_log + Typos + superfluous whitespace

### DIFF
--- a/plugins-scripts/check_log.sh
+++ b/plugins-scripts/check_log.sh
@@ -19,7 +19,7 @@
 # On the first run of the plugin, it will return an OK state with a message
 # of "Log check data initialized".  On successive runs, it will return an OK
 # state if *no* pattern matches have been found in the *difference* between the
-# log file and the older copy of the log file.  If the plugin detects any 
+# log file and the older copy of the log file.  If the plugin detects any
 # pattern matches in the log diff, it will return a CRITICAL state and print
 # out a message is the following format: "(x) last_match", where "x" is the
 # total number of pattern matches found in the file and "last_match" is the
@@ -43,6 +43,9 @@
 #        you define to use this plugin script - even if the different services
 #        check the same <log_file> for pattern matches.  This is necessary
 #        because of the way the script operates.
+#
+#	 4.  This plugin does NOT have an understanding of logrotation or similar
+#		 mechanisms. Therefore bad timing could lead to missing events
 #
 # Examples:
 #
@@ -165,6 +168,12 @@ elif [ ! -r $logfile ] ; then
     exit $STATE_UNKNOWN
 fi
 
+# If no oldlog was given this can not work properly, abort then
+if [ ! -v oldlog ]; then
+	echo "Oldlog parameter is needed"
+	exit $STATE_UNKNOWN
+fi
+
 # If the old log file doesn't exist, this must be the first time
 # we're running this test, so copy the original log file over to
 # the old diff file and exit
@@ -202,7 +211,7 @@ cat $logfile > $oldlog
 if [ "$count" = "0" ]; then # no matches, exit with no error
     echo "Log check ok - 0 pattern matches found"
     exitstatus=$STATE_OK
-else # Print total matche count and the last entry we found
+else # Print total match count and the last entry we found
     echo "($count) $lastentry"
     exitstatus=$STATE_CRITICAL
 fi


### PR DESCRIPTION
check_log can not work if the oldlog parameter is missing. This patch will abort the execution if this is the case.