### PR TITLE
Using snprintf which honors the buffers size and guarantees null temination. (Closes: #1601)

### DIFF
--- a/plugins/check_pgsql.c
+++ b/plugins/check_pgsql.c
@@ -347,7 +347,7 @@ process_arguments (int argc, char **argv)
 			if (!is_pg_dbname (optarg)) /* checks length and valid chars */
 				usage2 (_("Database name is not valid"), optarg);
 			else /* we know length, and know optarg is terminated, so us strcpy */
-				strcpy (dbName, optarg);
+				snprintf(dbName, NAMEDATALEN, "%s", optarg);
 			break;
 		case 'l':     /* login name */
 			if (!is_pg_logname (optarg))


### PR DESCRIPTION
As strcpy may overflow the resulting buffer:

flo@p5:~$ /tmp/f/usr/lib/nagios/plugins/check_pgsql -d "$(seq 1 10000)"
*** buffer overflow detected ***: terminated
Aborted

I would propose to change the code rather like this, using snprintf
which honors the buffers size and guarantees null termination.