### PR TITLE
fix check_curl crash if http header contains leading spaces

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -2037,7 +2037,7 @@ get_header_value (const struct phr_header* headers, const size_t nof_headers, co
 {
   int i;
   for( i = 0; i < nof_headers; i++ ) {
-    if( strncasecmp( header, headers[i].name, max( headers[i].name_len, 4 ) ) == 0 ) {
+    if(headers[i].name != NULL && strncasecmp( header, headers[i].name, max( headers[i].name_len, 4 ) ) == 0 ) {
       return strndup( headers[i].value, headers[i].value_len );
     }
   }


### PR DESCRIPTION
check_curl crashes when a (broken) http server returns invalid http header with
leading spaces or double colons. This PR adds a fix and a test case for this.

Signed-off-by: Sven Nierlein <sven@nierlein.de>