### PR TITLE
check curl bugfixes

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1354,7 +1354,7 @@ process_arguments (int argc, char **argv)
           ssl_version = CURL_SSLVERSION_DEFAULT;
 #endif /* LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 52, 0) */
         else
-          usage4 (_("Invalid option - Valid SSL/TLS versions: 2, 3, 1, 1.1, 1.2 (with optional '+' suffix)"));
+          usage4 (_("Invalid option - Valid SSL/TLS versions: 2, 3, 1, 1.1, 1.2, 1.3 (with optional '+' suffix)"));
       }
 #if LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 54, 0)
       if (got_plus) {
@@ -1659,7 +1659,7 @@ print_help (void)
   printf (" %s\n", "-S, --ssl=VERSION[+]");
   printf ("    %s\n", _("Connect via SSL. Port defaults to 443. VERSION is optional, and prevents"));
   printf ("    %s\n", _("auto-negotiation (2 = SSLv2, 3 = SSLv3, 1 = TLSv1, 1.1 = TLSv1.1,"));
-  printf ("    %s\n", _("1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."));
+  printf ("    %s\n", _("1.2 = TLSv1.2, 1.3 = TLSv1.3). With a '+' suffix, newer versions are also accepted."));
   printf ("    %s\n", _("Note: SSLv2 and SSLv3 are deprecated and are usually disabled in libcurl"));
   printf (" %s\n", "--sni");
   printf ("    %s\n", _("Enable SSL/TLS hostname extension support (SNI)"));

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1041,7 +1041,7 @@ redir (curlhelp_write_curlbuf* header_buf)
     const UriPathSegmentA* p = uri.pathHead;
     for (; p; p = p->next) {
       strncat (new_url, "/", DEFAULT_BUFFER_SIZE);
-      strncat (new_url, uri_string (p->text, buf, DEFAULT_BUFFER_SIZE), DEFAULT_BUFFER_SIZE);
+      strncat (new_url, uri_string (p->text, buf, DEFAULT_BUFFER_SIZE), DEFAULT_BUFFER_SIZE-1);
     }
   }
 


### PR DESCRIPTION
- help messages fix: 1.3 in SSL version for TLSv1.3
- fixed URI buffer overflow
- fix #1665 (printing HTTP protocol version correctly as HTTP/2)