### PR TITLE
Update check_curl.c to display a specific human-readable error message where possible

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -313,8 +313,8 @@ static char *string_statuscode (int major, int minor)
       /* assuming here HTTP/N with N>=4 */
       snprintf (buf, sizeof (buf), "HTTP/%d", major);
       break;
-  }  
-  
+  }
+
   return buf;
 }
 
@@ -662,7 +662,7 @@ check_http (void)
   /* Curl errors, result in critical Nagios state */
   if (res != CURLE_OK) {
     snprintf (msg, DEFAULT_BUFFER_SIZE, _("Invalid HTTP response received from host on port %d: cURL returned %d - %s"),
-      server_port, res, curl_easy_strerror(res));
+      server_port, res, errbuf[0] ? errbuf : curl_easy_strerror(res));
     die (STATE_CRITICAL, "HTTP CRITICAL - %s\n", msg);
   }
 

--- a/plugins/t/check_curl.t
+++ b/plugins/t/check_curl.t
@@ -46,7 +46,7 @@ $res = NPTest->testCmd(
 	);
 cmp_ok( $res->return_code, '==', 2, "Webserver $host_nonresponsive not responding" );
 # was CRITICAL only, but both check_curl and check_http print HTTP CRITICAL (puzzle?!)
-cmp_ok( $res->output, 'eq', "HTTP CRITICAL - Invalid HTTP response received from host on port 80: cURL returned 28 - Timeout was reached", "Output OK");
+like( $res->output, "/HTTP CRITICAL - Invalid HTTP response received from host on port 80: cURL returned 28 - Connection timed out after/", "Output OK");
 
 $res = NPTest->testCmd(
 	"./$plugin $hostname_invalid -wt 1 -ct 2"
@@ -56,7 +56,7 @@ cmp_ok( $res->return_code, '==', 2, "Webserver $hostname_invalid not valid" );
 # On Debian, it is Name or service not known, on Darwin, it is No address associated with nodename
 # Is also possible to get a socket timeout if DNS is not responding fast enough
 # cURL gives us consistent strings from it's own 'lib/strerror.c'
-like( $res->output, "/cURL returned 6 - Couldn't resolve host name/", "Output OK");
+like( $res->output, "/cURL returned 6 - Could not resolve host:/", "Output OK");
 
 # host header checks
 $res = NPTest->testCmd("./$plugin -v -H $host_tcp_http");


### PR DESCRIPTION
Currently check_curl uses the libcurl function `curl_easy_strerror()` to convert from error codes to error messages. This function does not provide real context but rather returns a fixed string based on the error code. A much more accurate and user-friendly error code is available via the `CURLOPT_ERRORBUFFER` option. This PR tries to use the error message from that option where possible, falling back to the former in case it is not available.

For more details see:
https://curl.se/libcurl/c/curl_easy_strerror.html
https://curl.se/libcurl/c/CURLOPT_ERRORBUFFER.html

### Sample output - BEFORE:
```
$ check_curl -H expired.badssl.com -S --ca-cert=/etc/ssl/certs/ca-certificates.crt
HTTP CRITICAL - Invalid HTTP response received from host on port 443: cURL returned 60 - Peer certificate cannot be authenticated with given CA certificates
```

### Sample output - AFTER:
```
$ check_curl -H expired.badssl.com -S --ca-cert=/etc/ssl/certs/ca-certificates.crt
HTTP CRITICAL - Invalid HTTP response received from host on port 443: cURL returned 60 - SSL certificate problem: certificate has expired
```
