### PR TITLE
Add an option to check_curl to verify the peer certificate & host using the system CA's

### DIFF
--- a/plugins/t/check_curl.t
+++ b/plugins/t/check_curl.t
@@ -9,7 +9,7 @@ use Test::More;
 use POSIX qw/mktime strftime/;
 use NPTest;
 
-plan tests => 57;
+plan tests => 58;
 
 my $successOutput = '/OK.*HTTP.*second/';
 
@@ -94,6 +94,9 @@ SKIP: {
 
         $res = NPTest->testCmd("./$plugin -v -H $host_tls_http:443 -S -p 443");
         like( $res->output, '/^Host: '.$host_tls_http.'\s*$/ms', "Host Header OK" );
+
+        $res = NPTest->testCmd("./$plugin -v -H $host_tls_http -D -p 443");
+        like( $res->output, '/(^Host: '.$host_tls_http.'\s*$)|(cURL returned 60)/ms', "Host Header OK" );
 };
 
 SKIP: {


### PR DESCRIPTION
One of the major considerations for moving to check_curl is the ability to verify peer certificates automatically, using the system CA settings (i.e. the default curl behaviour). While maintaining backwards compatibility is necessary for a drop-in replacement of check_http, it would be nice to have an option to reactivate certificate verification without having to specify a CA chain.

The new option is `-D` or `--verify-cert`
### Sample output :
```
$ check_curl -H expired.badssl.com -S
HTTP OK: HTTP/1.1 200 OK - 761 bytes in 0.767 second response time |time=0.766678s;;;0.000000;10.000000 size=761B;;;0

$ check_curl -H expired.badssl.com --ca-cert=/etc/ssl/certs/ca-certificates.crt
HTTP CRITICAL - Invalid HTTP response received from host on port 443: cURL returned 60 - SSL certificate problem: certificate has expired

$ check_curl -H expired.badssl.com -D
HTTP CRITICAL - Invalid HTTP response received from host on port 443: cURL returned 60 - SSL certificate problem: certificate has expired

$ check_curl -H expired.badssl.com --verify-cert
HTTP CRITICAL - Invalid HTTP response received from host on port 443: cURL returned 60 - SSL certificate problem: certificate has expired
```