### PR TITLE
check_curl: Fix bug where headers beginning with HTTP_ cause the status line parsing to fail

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1995,7 +1995,7 @@ curlhelp_parse_statusline (const char *buf, curlhelp_statusline *status_line)
   char *first_line_buf;
 
   /* find last start of a new header */
-  start = strrstr2 (buf, "\r\nHTTP");
+  start = strrstr2 (buf, "\r\nHTTP/");
   if (start != NULL) {
     start += 2;
     buf = start;


### PR DESCRIPTION
### BEFORE
```
$ check_curl -H www.kupujemprodajem.com -S --no-body -v
> GET / HTTP/1.1
Host: www.kupujemprodajem.com
User-Agent: check_curl/v2.3.1 (monitoring-plugins 2.3.1, libcurl/7.58.0 OpenSSL/1.1.1 zlib/1.2.11 libidn2/2.0.4 libpsl/0.19.1 (+libidn2/2.0.4) nghttp2/1.30.0 librtmp/2.3)
Accept: */*
Connection: close

< HTTP/1.1 200 OK
< Server: nginx
< Date: Mon, 12 Apr 2021 16:11:24 GMT
< Content-Type: text/html; charset=UTF-8
< Connection: close
< Vary: Accept-Encoding
< HTTP_X_FORWARDED_PROTO: https
< HTTP_X_FORWARDED_FOR:
< Set-Cookie: KUPUJEMPRODAJEM=b94idrr7k9leldjp5gh23b9ugr; path=/; domain=.kupujemprodajem.com; HttpOnly
< Set-Cookie: machine_id=8f910d26570f22b0f9aad3422d86fddb; expires=Fri, 11-Jun-2021 16:11:24 GMT; Max-Age=5184000; path=/; domain=.kupujemprodajem.com
< Set-Cookie: KUPUJEMPRODAJEM=b94idrr7k9leldjp5gh23b9ugr; path=/; domain=.kupujemprodajem.com; HttpOnly
<
* Excess found in a non pipelined read: excess = 6707 url = / (zero-length body)
* Closing connection 0

HTTP CRITICAL HTTP/x.x 0 unknown - Unparsable status line in 0.571 seconds response time|time=0.571002s;;;0.000000;10.000000 size=564B;;;0
```

### AFTER
```
$ plugins/check_curl -H www.kupujemprodajem.com -S --no-body -v
> GET / HTTP/1.1
Host: www.kupujemprodajem.com
User-Agent: check_curl/v2.3.1.1.ga514 (monitoring-plugins 2.3.1, libcurl/7.58.0 OpenSSL/1.1.1 zlib/1.2.11 libidn2/2.0.4 libpsl/0.19.1 (+libidn2/2.0.4) nghttp2/1.30.0 librtmp/2.3)
Accept: */*
Connection: close

< HTTP/1.1 200 OK
< Server: nginx
< Date: Mon, 12 Apr 2021 16:12:47 GMT
< Content-Type: text/html; charset=UTF-8
< Connection: close
< Vary: Accept-Encoding
< HTTP_X_FORWARDED_PROTO: https
< HTTP_X_FORWARDED_FOR:
< Set-Cookie: KUPUJEMPRODAJEM=r1hq4ue5vr2t2ugsfs973psgpv; path=/; domain=.kupujemprodajem.com; HttpOnly
< Set-Cookie: machine_id=40e73b6fd7269c87159f1d0fe847538f; expires=Fri, 11-Jun-2021 16:12:47 GMT; Max-Age=5184000; path=/; domain=.kupujemprodajem.com
< Set-Cookie: KUPUJEMPRODAJEM=r1hq4ue5vr2t2ugsfs973psgpv; path=/; domain=.kupujemprodajem.com; HttpOnly
<
* Excess found in a non pipelined read: excess = 6707 url = / (zero-length body)
* Closing connection 0

HTTP OK: HTTP/1.1 200 OK - 564 bytes in 0.586 second response time |time=0.585537s;;;0.000000;10.000000 size=564B;;;0
```