### PR TITLE
Fix trailing whitespaces in C plugins

### DIFF
--- a/plugins/check_apt.c
+++ b/plugins/check_apt.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_apt plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2006-2008 Monitoring Plugins Development Team
-* 
+*
 * Original author: Sean Finney
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_apt plugin
-* 
+*
 * Check for available updates in apt package management systems
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
+*
 *****************************************************************************/
 
 const char *progname = "check_apt";
@@ -269,7 +269,7 @@ int run_upgrade(int *pkgcount, int *secpkgcount, char ***pkglist, char ***secpkg
 			die(STATE_UNKNOWN, _("%s: Error compiling regexp: %s"), progname, rerrbuf);
 		}
 	}
-   
+
 	if(do_exclude!=NULL){
 		regres=regcomp(&ereg, do_exclude, REG_EXTENDED);
 		if(regres!=0) {
@@ -278,7 +278,7 @@ int run_upgrade(int *pkgcount, int *secpkgcount, char ***pkglist, char ***secpkg
 			    progname, rerrbuf);
 		}
 	}
-   
+
 	const char *crit_ptr = (do_critical != NULL) ? do_critical : SECURITY_RE;
 	regres=regcomp(&sreg, crit_ptr, REG_EXTENDED);
 	if(regres!=0) {
@@ -295,7 +295,7 @@ int run_upgrade(int *pkgcount, int *secpkgcount, char ***pkglist, char ***secpkg
 		/* run the upgrade */
 		result = np_runcmd(cmdline, &chld_out, &chld_err, 0);
 	}
-   
+
 	/* apt-get upgrade only changes exit status if there is an
 	 * internal error when run in dry-run mode.  therefore we will
 	 * treat such an error as UNKNOWN */

--- a/plugins/check_by_ssh.c
+++ b/plugins/check_by_ssh.c
@@ -1,29 +1,29 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_by_ssh plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_by_ssh plugin
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_by_ssh";
@@ -157,7 +157,7 @@ main (int argc, char **argv)
 			         cresult, status_text);
 		}
 	}
-	
+
 	/* Multiple commands and passive checking should always return OK */
 	return result;
 }

--- a/plugins/check_cluster.c
+++ b/plugins/check_cluster.c
@@ -1,25 +1,25 @@
 /*****************************************************************************
-* 
+*
 * check_cluster.c - Host and Service Cluster Plugin for Monitoring
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2004 Ethan Galstad (nagios@nagios.org)
 * Copyright (c) 2007 Monitoring Plugins Development Team
-* 
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_cluster";

--- a/plugins/check_dbi.c
+++ b/plugins/check_dbi.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_dbi plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2011 Monitoring Plugins Development Team
 * Author: Sebastian 'tokkee' Harl <sh@teamix.net>
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_dbi plugin
-* 
+*
 * Runs an arbitrary (SQL) command and checks the result.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_dbi";

--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -1,29 +1,29 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_dig plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2002-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_dig plugin
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 /* Hackers note:

--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -1,29 +1,29 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_disk plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_disk plugin
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_disk";
@@ -255,7 +255,7 @@ main (int argc, char **argv)
     /* Remove filesystems already seen */
     if (np_seen_name(seen, me->me_mountdir)) {
       continue;
-    } 
+    }
     np_add_name(&seen, me->me_mountdir);
 
     if (path->group == NULL) {
@@ -1026,20 +1026,20 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
       if (p_list->group && ! (strcmp(p_list->group, p->group))) {
         stat_path(p_list);
         get_fs_usage (p_list->best_match->me_mountdir, p_list->best_match->me_devname, &tmpfsp);
-        get_path_stats(p_list, &tmpfsp); 
+        get_path_stats(p_list, &tmpfsp);
         if (verbose >= 3)
           printf("Group %s: adding %llu blocks sized %llu, (%s) used_units=%g free_units=%g total_units=%g fsu_blocksize=%llu mult=%llu\n",
                  p_list->group, tmpfsp.fsu_bavail, tmpfsp.fsu_blocksize, p_list->best_match->me_mountdir, p_list->dused_units, p_list->dfree_units,
                  p_list->dtotal_units, mult);
 
-        /* prevent counting the first FS of a group twice since its parameter_list entry 
+        /* prevent counting the first FS of a group twice since its parameter_list entry
          * is used to carry the information of all file systems of the entire group */
         if (! first) {
           p->total += p_list->total;
           p->available += p_list->available;
           p->available_to_root += p_list->available_to_root;
           p->used += p_list->used;
-            
+
           p->dused_units += p_list->dused_units;
           p->dfree_units += p_list->dfree_units;
           p->dtotal_units += p_list->dtotal_units;
@@ -1050,7 +1050,7 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
         }
         first = 0;
       }
-      if (verbose >= 3) 
+      if (verbose >= 3)
         printf("Group %s now has: used_units=%g free_units=%g total_units=%g fsu_blocksize=%llu mult=%llu\n",
                p->group, tmpfsp.fsu_bavail, tmpfsp.fsu_blocksize, p->best_match->me_mountdir, p->dused_units,
                p->dfree_units, p->dtotal_units, mult);
@@ -1063,7 +1063,7 @@ get_stats (struct parameter_list *p, struct fs_usage *fsp) {
   p->dfree_pct = 100 - p->dused_pct;
   p->dused_inodes_percent = calculate_percent(p->inodes_total - p->inodes_free, p->inodes_total);
   p->dfree_inodes_percent = 100 - p->dused_inodes_percent;
-  
+
 }
 
 void
@@ -1081,7 +1081,7 @@ get_path_stats (struct parameter_list *p, struct fs_usage *fsp) {
     /* default behaviour : take all the blocks into account */
     p->total = fsp->fsu_blocks;
   }
-  
+
   p->dused_units = p->used*fsp->fsu_blocksize/mult;
   p->dfree_units = p->available*fsp->fsu_blocksize/mult;
   p->dtotal_units = p->total*fsp->fsu_blocksize/mult;

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_dns plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_dns plugin
-* 
+*
 * LIMITATION: nslookup on Solaris 7 can return output over 2 lines, which
 * will not be picked up by this plugin
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_dns";
@@ -138,7 +138,7 @@ main (int argc, char **argv)
       }
     }
 
-    /* bug ID: 2946553 - Older versions of bind will use all available dns 
+    /* bug ID: 2946553 - Older versions of bind will use all available dns
                          servers, we have to match the one specified */
     if (strstr (chld_out.line[i], "Server:") && strlen(dns_server) > 0) {
       temp_buffer = strchr (chld_out.line[i], ':');
@@ -335,7 +335,7 @@ ip2long(const char* src) {
               ip[0] < 256 && ip[1] < 256 &&
               ip[2] < 256 && ip[3] < 256)
           ? ip[0] << 24 | ip[1] << 16 | ip[2] << 8 | ip[3]
-          : 0; 
+          : 0;
 }
 
 int

--- a/plugins/check_dummy.c
+++ b/plugins/check_dummy.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_dummy plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_dummy plugin
-* 
+*
 * This plugin will simply return the state corresponding to the numeric value
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_dummy";

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_fping plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_disk plugin
-* 
+*
 * This plugin will use the fping command to ping the specified host for a
 * fast check
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_fping";

--- a/plugins/check_game.c
+++ b/plugins/check_game.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_game plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2002-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_game plugin
-* 
+*
 * This plugin tests game server connections with the specified host.
 * using the qstat program
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
+*
 *
 *****************************************************************************/
 

--- a/plugins/check_hpjd.c
+++ b/plugins/check_hpjd.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_hpjd plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_hpjd plugin
-* 
+*
 * This plugin tests the STATUS of an HP printer with a JetDirect card.
 * Net-SNMP must be installed on the computer running the plugin.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_hpjd";
@@ -316,7 +316,7 @@ process_arguments (int argc, char **argv)
 		{"community", required_argument, 0, 'C'},
 /*  		{"critical",       required_argument,0,'c'}, */
 /*  		{"warning",        required_argument,0,'w'}, */
-  		{"port", required_argument,0,'p'}, 
+  		{"port", required_argument,0,'p'},
 		{"version", no_argument, 0, 'V'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}

--- a/plugins/check_ide_smart.c
+++ b/plugins/check_ide_smart.c
@@ -1,42 +1,42 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_ide_smart plugin
 * ide-smart 1.3 - IDE S.M.A.R.T. checking tool
-* 
+*
 * License: GPL
 * Copyright (C) 1998-1999 Ragnar Hojland Espinosa <ragnar@lightside.dhis.org>
 *               1998      Gadi Oxman <gadio@netvision.net.il>
 * Copyright (c) 2000 Robert Dale <rdale@digital-mission.com>
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_ide_smart plugin
-* 
+*
 * This plugin checks a local hard drive with the (Linux specific) SMART
 * interface
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_ide_smart";
 const char *copyright = "1998-2007";
 const char *email = "devel@monitoring-plugins.org";
-	
+
 #include "common.h"
 #include "utils.h"
 
@@ -70,13 +70,13 @@ void print_usage (void);
 #define OPEN_MODE O_RDWR
 #endif /* __NetBSD__ */
 #include <errno.h>
-	
+
 #define NR_ATTRIBUTES	30
-	
+
 #ifndef TRUE
 #define TRUE 1
 #endif	/*  */
-	
+
 #define PREFAILURE 2
 #define ADVISORY 1
 #define OPERATIONAL 0
@@ -156,12 +156,12 @@ smart_command[] =
 	};
 
 
-/* Index to smart_command table, keep in order */ 
-enum SmartCommand 
+/* Index to smart_command table, keep in order */
+enum SmartCommand
 	{ SMART_CMD_ENABLE,
 		SMART_CMD_DISABLE,
 		SMART_CMD_IMMEDIATE_OFFLINE,
-		SMART_CMD_AUTO_OFFLINE 
+		SMART_CMD_AUTO_OFFLINE
 	};
 
 char *get_offline_text (int);
@@ -174,7 +174,7 @@ int smart_read_thresholds (int, thresholds_t *);
 int verbose = FALSE;
 
 int
-main (int argc, char *argv[]) 
+main (int argc, char *argv[])
 {
 	char *device = NULL;
 	int o, longindex;
@@ -184,14 +184,14 @@ main (int argc, char *argv[])
 	values_t values;
 	int fd;
 
-	static struct option longopts[] = { 
-		{"device", required_argument, 0, 'd'}, 
-		{"immediate", no_argument, 0, 'i'}, 
-		{"quiet-check", no_argument, 0, 'q'}, 
-		{"auto-on", no_argument, 0, '1'}, 
-		{"auto-off", no_argument, 0, '0'}, 
+	static struct option longopts[] = {
+		{"device", required_argument, 0, 'd'},
+		{"immediate", no_argument, 0, 'i'},
+		{"quiet-check", no_argument, 0, 'q'},
+		{"auto-on", no_argument, 0, '1'},
+		{"auto-off", no_argument, 0, '0'},
 		{"nagios", no_argument, 0, 'n'}, /* DEPRECATED, but we still accept it */
-		{"help", no_argument, 0, 'h'}, 
+		{"help", no_argument, 0, 'h'},
 		{"version", no_argument, 0, 'V'},
 		{0, 0, 0, 0}
 	};
@@ -204,7 +204,7 @@ main (int argc, char *argv[])
 	textdomain (PACKAGE);
 
 	while (1) {
-		
+
 		o = getopt_long (argc, argv, "+d:iq10nhVv", longopts, &longindex);
 
 		if (o == -1 || o == EOF || o == 1)
@@ -275,7 +275,7 @@ main (int argc, char *argv[])
 
 
 char *
-get_offline_text (int status) 
+get_offline_text (int status)
 {
 	int i;
 	for (i = 0; offline_status_text[i].text; i++) {
@@ -289,7 +289,7 @@ get_offline_text (int status)
 
 
 int
-smart_read_values (int fd, values_t * values) 
+smart_read_values (int fd, values_t * values)
 {
 #ifdef __linux__
 	int e;
@@ -339,7 +339,7 @@ smart_read_values (int fd, values_t * values)
 
 
 int
-nagios (values_t * p, thresholds_t * t) 
+nagios (values_t * p, thresholds_t * t)
 {
 	value_t * value = p->values;
 	threshold_t * threshold = t->thresholds;
@@ -404,7 +404,7 @@ nagios (values_t * p, thresholds_t * t)
 
 
 void
-print_value (value_t * p, threshold_t * t) 
+print_value (value_t * p, threshold_t * t)
 {
 	printf ("Id=%3d, Status=%2d {%s , %s}, Value=%3d, Threshold=%3d, %s\n",
 					p->id, p->status, p->status & 1 ? "PreFailure" : "Advisory   ",
@@ -448,7 +448,7 @@ print_values (values_t * p, thresholds_t * t)
 
 
 int
-smart_cmd_simple (int fd, enum SmartCommand command, __u8 val0, char show_error) 
+smart_cmd_simple (int fd, enum SmartCommand command, __u8 val0, char show_error)
 {
 	int e = STATE_UNKNOWN;
 #ifdef __linux__
@@ -503,7 +503,7 @@ smart_cmd_simple (int fd, enum SmartCommand command, __u8 val0, char show_error)
 
 
 int
-smart_read_thresholds (int fd, thresholds_t * thresholds) 
+smart_read_thresholds (int fd, thresholds_t * thresholds)
 {
 #ifdef __linux__
 	int e;

--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_load plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_load plugin
-* 
+*
 * This plugin tests the current system load average.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_load";

--- a/plugins/check_mrtg.c
+++ b/plugins/check_mrtg.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_mrtg plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_mrtg plugin
-* 
+*
 * This plugin will check either the average or maximum value of one of the
 * two variables recorded in an MRTG log file.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_mrtg";

--- a/plugins/check_mrtgtraf.c
+++ b/plugins/check_mrtgtraf.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_mrtgtraf plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_mtrgtraf plugin
-* 
+*
 * This plugin will check the incoming/outgoing transfer rates of a router
 * switch, etc recorded in an MRTG log.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 #include "common.h"
@@ -308,7 +308,7 @@ process_arguments (int argc, char **argv)
 	if (argc > c && outgoing_warning_threshold == 0) {
 		outgoing_warning_threshold = strtoul (argv[c++], NULL, 10);
 	}
-	
+
 	if (argc > c && outgoing_critical_threshold == 0) {
 		outgoing_critical_threshold = strtoul (argv[c++], NULL, 10);
 	}

--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -1,33 +1,33 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_mysql plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999 Didi Rieder (adrieder@sbox.tu-graz.ac.at)
 * Copyright (c) 2000 Karl DeBisschop (kdebisschop@users.sourceforge.net)
 * Copyright (c) 1999-2011 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_mysql plugin
-* 
+*
 * This program tests connections to a mysql server
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_mysql";
@@ -125,7 +125,7 @@ main (int argc, char **argv)
 
 	/* initialize mysql  */
 	mysql_init (&mysql);
-	
+
 	if (opt_file != NULL)
 		mysql_options(&mysql,MYSQL_READ_DEFAULT_FILE,opt_file);
 

--- a/plugins/check_mysql_query.c
+++ b/plugins/check_mysql_query.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_mysql_query plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2006-2009 Monitoring Plugins Development Team
 * Original code from check_mysql, copyright 1999 Didi Rieder
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_mysql_query plugin
-* 
+*
 * This plugin is for running arbitrary SQL and checking the results
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_mysql_query";
@@ -67,7 +67,7 @@ main (int argc, char **argv)
 	MYSQL mysql;
 	MYSQL_RES *res;
 	MYSQL_ROW row;
-	
+
 	double value;
 	char *error = NULL;
 	int status;
@@ -164,7 +164,7 @@ main (int argc, char **argv)
 		fperfdata("result", value, "",
 		my_thresholds->warning?TRUE:FALSE, my_thresholds->warning?my_thresholds->warning->end:0,
 		my_thresholds->critical?TRUE:FALSE, my_thresholds->critical?my_thresholds->critical->end:0,
-		FALSE, 0, 
+		FALSE, 0,
 		FALSE, 0)
 	);
 	printf("\n");

--- a/plugins/check_nagios.c
+++ b/plugins/check_nagios.c
@@ -1,35 +1,35 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_nagios plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_nagios plugin
-* 
+*
 * This plugin checks the status of the Nagios process on the local machine.
 * The plugin will check to make sure the Nagios status log is no older than
 * the number of minutes specified by the expires option.
 * It also checks the process table for a process matching the command
 * argument.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_nagios";

--- a/plugins/check_nt.c
+++ b/plugins/check_nt.c
@@ -1,35 +1,35 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_nt plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2002 Yves Rubin (rubiyz@yahoo.com)
 * Copyright (c) 2003-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_nt plugin
-* 
+*
 * This plugin collects data from the NSClient service running on a
 * Windows NT/2000/XP/2003 server.
 * This plugin requires NSClient software to run on NT
 * (http://nsclient.ready2run.nl/)
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_nt";

--- a/plugins/check_ntp.c
+++ b/plugins/check_ntp.c
@@ -1,33 +1,33 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_ntp plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2006 Sean Finney <seanius@seanius.net>
 * Copyright (c) 2006-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_ntp plugin
-* 
+*
 * This plugin to check ntp servers independant of any commandline
 * programs or external libraries.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_ntp";

--- a/plugins/check_ntp_peer.c
+++ b/plugins/check_ntp_peer.c
@@ -1,38 +1,38 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_ntp_peer plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2006 Sean Finney <seanius@seanius.net>
 * Copyright (c) 2006-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_ntp_peer plugin
-* 
+*
 * This plugin checks an NTP server independent of any commandline
 * programs or external libraries.
-* 
+*
 * Use this plugin to check the health of an NTP server. It supports
 * checking the offset with the sync peer, the jitter and stratum. This
 * plugin will not check the clock offset between the local host and NTP
 * server; please use check_ntp_time for that purpose.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_ntp_peer";
@@ -598,7 +598,7 @@ int main(int argc, char *argv[]){
 		result = max_state_alt(result, get_status(fabs(offset), offset_thresholds));
 	}
 	oresult = result;
-	
+
 	if(do_truechimers) {
 		tresult = get_status(num_truechimers, truechimer_thresholds);
 		result = max_state_alt(result, tresult);
@@ -642,9 +642,9 @@ int main(int argc, char *argv[]){
 		xasprintf(&result_line, "%s %s %.10g secs (CRITICAL)", result_line, _("Offset"), offset);
 	} else {
 		xasprintf(&result_line, "%s %s %.10g secs", result_line, _("Offset"), offset);
-	}	
+	}
 	xasprintf(&perfdata_line, "%s", perfd_offset(offset));
-	
+
 	if (do_jitter) {
 		if (jresult == STATE_WARNING) {
 			xasprintf(&result_line, "%s, jitter=%f (WARNING)", result_line, jitter);

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -1,37 +1,37 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_ntp_time plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2006 Sean Finney <seanius@seanius.net>
 * Copyright (c) 2006-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_ntp_time plugin
-* 
+*
 * This plugin checks the clock offset between the local host and a
 * remote NTP server. It is independent of any commandline programs or
 * external libraries.
-* 
+*
 * If you'd rather want to monitor an NTP server, please use
 * check_ntp_peer.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_ntp_time";

--- a/plugins/check_nwstat.c
+++ b/plugins/check_nwstat.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_nwstat plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_nwstat plugin
-* 
+*
 * This plugin attempts to contact the MRTGEXT NLM running on a
 * Novell server to gather the requested system information.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_nwstat";

--- a/plugins/check_overcr.c
+++ b/plugins/check_overcr.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_overcr plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_overcr plugin
-* 
+*
 * This plugin attempts to contact the Over-CR collector daemon running on the
 * remote UNIX server in order to gather the requested system information.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_overcr";
@@ -118,7 +118,7 @@ main (int argc, char **argv)
 	case LOAD1:
 	case LOAD5:
 	case LOAD15:
-	
+
 		if (result != STATE_OK)
 			die (result, _("Unknown error fetching load data\n"));
 

--- a/plugins/check_pgsql.c
+++ b/plugins/check_pgsql.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_pgsql plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2011 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_pgsql plugin
-* 
+*
 * Test whether a PostgreSQL Database is accepting connections.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_pgsql";

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_ping plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_ping plugin
-* 
+*
 * Use the ping program to check connection statistics for a remote host.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_ping";

--- a/plugins/check_procs.c
+++ b/plugins/check_procs.c
@@ -1,34 +1,34 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_procs plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_procs plugin
-* 
+*
 * Checks all processes and generates WARNING or CRITICAL states if the
 * specified metric is outside the required threshold ranges. The metric
 * defaults to number of processes.  Search filters can be applied to limit
 * the processes to check.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_procs";
@@ -50,7 +50,7 @@ const char *email = "devel@monitoring-plugins.org";
 
 int process_arguments (int, char **);
 int validate_arguments (void);
-int convert_to_seconds (char *); 
+int convert_to_seconds (char *);
 void print_help (void);
 void print_usage (void);
 
@@ -230,9 +230,9 @@ main (int argc, char **argv)
 			procseconds = convert_to_seconds(procetime);
 
 			if (verbose >= 3)
-				printf ("proc#=%d uid=%d vsz=%d rss=%d pid=%d ppid=%d pcpu=%.2f stat=%s etime=%s prog=%s args=%s\n", 
+				printf ("proc#=%d uid=%d vsz=%d rss=%d pid=%d ppid=%d pcpu=%.2f stat=%s etime=%s prog=%s args=%s\n",
 					procs, procuid, procvsz, procrss,
-					procpid, procppid, procpcpu, procstat, 
+					procpid, procppid, procpcpu, procstat,
 					procetime, procprog, procargs);
 
 			/* Ignore self */
@@ -292,9 +292,9 @@ main (int argc, char **argv)
 
 			procs++;
 			if (verbose >= 2) {
-				printf ("Matched: uid=%d vsz=%d rss=%d pid=%d ppid=%d pcpu=%.2f stat=%s etime=%s prog=%s args=%s\n", 
+				printf ("Matched: uid=%d vsz=%d rss=%d pid=%d ppid=%d pcpu=%.2f stat=%s etime=%s prog=%s args=%s\n",
 					procuid, procvsz, procrss,
-					procpid, procppid, procpcpu, procstat, 
+					procpid, procppid, procpcpu, procstat,
 					procetime, procprog, procargs);
 			}
 
@@ -320,7 +320,7 @@ main (int argc, char **argv)
 					result = max_state (result, i);
 				}
 			}
-		} 
+		}
 		/* This should not happen */
 		else if (verbose) {
 			printf(_("Not parseable: %s"), input_buffer);
@@ -332,7 +332,7 @@ main (int argc, char **argv)
 		return STATE_UNKNOWN;
 	}
 
-	if ( result == STATE_UNKNOWN ) 
+	if ( result == STATE_UNKNOWN )
 		result = STATE_OK;
 
 	/* Needed if procs found, but none match filter */
@@ -352,9 +352,9 @@ main (int argc, char **argv)
 		if (metric != METRIC_PROCS) {
 			printf (_("%d crit, %d warn out of "), crit, warn);
 		}
-	} 
+	}
 	printf (ngettext ("%d process", "%d processes", (unsigned long) procs), procs);
-	
+
 	if (strcmp(fmt,"") != 0) {
 		printf (_(" with %s"), fmt);
 	}
@@ -440,7 +440,7 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'c':									/* critical threshold */
 			critical_range = optarg;
-			break;							 
+			break;
 		case 'w':									/* warning threshold */
 			warning_range = optarg;
 			break;
@@ -542,11 +542,11 @@ process_arguments (int argc, char **argv)
 			if ( strcmp(optarg, "PROCS") == 0) {
 				metric = METRIC_PROCS;
 				break;
-			} 
+			}
 			else if ( strcmp(optarg, "VSZ") == 0) {
 				metric = METRIC_VSZ;
 				break;
-			} 
+			}
 			else if ( strcmp(optarg, "RSS") == 0 ) {
 				metric = METRIC_RSS;
 				break;
@@ -559,7 +559,7 @@ process_arguments (int argc, char **argv)
 				metric = METRIC_ELAPSED;
 				break;
 			}
-				
+
 			usage4 (_("Metric must be one of PROCS, VSZ, RSS, CPU, ELAPSED!"));
 		case 'k':	/* linux kernel thread filter */
 			kthread_filter = 1;
@@ -642,7 +642,7 @@ convert_to_seconds(char *etime) {
 	seconds = 0;
 
 	for (ptr = etime; *ptr != '\0'; ptr++) {
-	
+
 		if (*ptr == '-') {
 			hyphcnt++;
 			continue;

--- a/plugins/check_radius.c
+++ b/plugins/check_radius.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_radius plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_radius plugin
-* 
+*
 * Tests to see if a radius server is accepting connections.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_radius";

--- a/plugins/check_real.c
+++ b/plugins/check_real.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_real plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_real plugin
-* 
+*
 * This plugin tests the REAL service on the specified host.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_real";

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_smtp plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_smtp plugin
-* 
+*
 * This plugin will attempt to open an SMTP connection with the host.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_smtp";
@@ -826,7 +826,7 @@ print_help (void)
   printf ("    %s\n", _("SMTP AUTH password"));
   printf (" %s\n", "-q, --ignore-quit-failure");
   printf ("    %s\n", _("Ignore failure when sending QUIT command to server"));
-   
+
 	printf (UT_WARN_CRIT);
 
 	printf (UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_snmp plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_snmp plugin
-* 
+*
 * Check status of remote machines and obtain system information via SNMP
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_snmp";
@@ -315,7 +315,7 @@ main (int argc, char **argv)
 	for (i = 0; i < numcontext; i++) {
 		command_line[10 + i] = contextargs[i];
 	}
-	
+
 	for (i = 0; i < numauthpriv; i++) {
 		command_line[10 + numcontext + i] = authpriv[i];
 	}
@@ -329,7 +329,7 @@ main (int argc, char **argv)
 
 	for (i = 0; i < numoids; i++) {
 		command_line[10 + numcontext + numauthpriv + 1 + i] = oids[i];
-		xasprintf(&cl_hidden_auth, "%s %s", cl_hidden_auth, oids[i]);	
+		xasprintf(&cl_hidden_auth, "%s %s", cl_hidden_auth, oids[i]);
 	}
 
 	command_line[10 + numcontext + numauthpriv + 1 + numoids] = NULL;
@@ -398,14 +398,14 @@ main (int argc, char **argv)
 		/* We strip out the datatype indicator for PHBs */
 		if (strstr (response, "Gauge: ")) {
 			show = strstr (response, "Gauge: ") + 7;
-		} 
+		}
 		else if (strstr (response, "Gauge32: ")) {
 			show = strstr (response, "Gauge32: ") + 9;
-		} 
+		}
 		else if (strstr (response, "Counter32: ")) {
 			show = strstr (response, "Counter32: ") + 11;
 			is_counter=1;
-			if(!calculate_rate) 
+			if(!calculate_rate)
 				strcpy(type, "c");
 		}
 		else if (strstr (response, "Counter64: ")) {
@@ -602,7 +602,7 @@ main (int argc, char **argv)
 		state_string=malloc(string_length);
 		if(state_string==NULL)
 			die(STATE_UNKNOWN, _("Cannot malloc"));
-		
+
 		current_length=0;
 		for(i=0; i<total_oids; i++) {
 			xasprintf(&temp_string,"%.0f",response_value[i]);
@@ -624,7 +624,7 @@ main (int argc, char **argv)
 		state_string[--current_length]='\0';
 		if (verbose > 2)
 			printf("State string=%s\n",state_string);
-		
+
 		/* This is not strictly the same as time now, but any subtle variations will cancel out */
 		np_state_write_string(current_time, state_string );
 		if(previous_state==NULL) {
@@ -1001,7 +1001,7 @@ validate_arguments ()
 			contextargs[0] = strdup ("-n");
 			contextargs[1] = strdup (context);
 		}
-		
+
 		if (seclevel == NULL)
 			xasprintf(&seclevel, "noAuthNoPriv");
 

--- a/plugins/check_ssh.c
+++ b/plugins/check_ssh.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_ssh plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_ssh plugin
-* 
+*
 * Try to connect to an SSH server at specified server and port
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_ssh";

--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -1,30 +1,30 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_swap plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000 Karl DeBisschop (kdebisschop@users.sourceforge.net)
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_swap plugin
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_swap";

--- a/plugins/check_time.c
+++ b/plugins/check_time.c
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_time plugin
-* 
+*
 * License: GPL
 * Copyright (c) 1999-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_time plugin
-* 
+*
 * This plugin will check the time difference with the specified host.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_time";

--- a/plugins/check_ups.c
+++ b/plugins/check_ups.c
@@ -1,35 +1,35 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_ups plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000 Tom Shields
 *               2004 Alain Richard <alain.richard@equation.fr>
 *               2004 Arnaud Quette <arnaud.quette@mgeups.com>
 * Copyright (c) 2002-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains Network UPS Tools plugin for Monitoring
-* 
+*
 * This plugin tests the UPS service on the specified host. Network UPS Tools
 * from www.networkupstools.org must be running for this plugin to work.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_ups";

--- a/plugins/check_users.c
+++ b/plugins/check_users.c
@@ -1,33 +1,33 @@
 /*****************************************************************************
-* 
+*
 * Monitoring check_users plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2012 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the check_users plugin
-* 
+*
 * This plugin checks the number of users currently logged in on the local
 * system and generates an error if the number exceeds the thresholds
 * specified.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "check_users";
@@ -163,7 +163,7 @@ main (int argc, char **argv)
 	if (result == STATE_UNKNOWN)
 		printf ("%s\n", _("Unable to read output"));
 	else {
-		printf (_("USERS %s - %d users currently logged in |%s\n"), 
+		printf (_("USERS %s - %d users currently logged in |%s\n"),
 				state_text(result), users,
 				sperfdata_int("users", users, "", warning_range,
 							critical_range, TRUE, 0, FALSE, 0));

--- a/plugins/common.h
+++ b/plugins/common.h
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring Plugins common include file
-* 
+*
 * License: GPL
 * Copyright (c) 1999 Ethan Galstad (nagios@nagios.org)
 * Copyright (c) 2003-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains common include files and defines used in many of
 * the plugins.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 #ifndef _COMMON_H_
@@ -76,7 +76,7 @@
 #include <unistd.h>
 #endif
 
-/* GET_NUMBER_OF_CPUS is a macro to return 
+/* GET_NUMBER_OF_CPUS is a macro to return
    number of CPUs, if we can get that data.
    Use configure.in to test for various OS ways of
    getting that data

--- a/plugins/negate.c
+++ b/plugins/negate.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring negate plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2002-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the negate plugin
-* 
+*
 * Negates the status of a plugin (returns OK for CRITICAL, and vice-versa).
 * Can also perform custom state switching.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "negate";

--- a/plugins/netutils.c
+++ b/plugins/netutils.c
@@ -1,30 +1,30 @@
 /*****************************************************************************
-* 
+*
 * Monitoring Plugins network utilities
-* 
+*
 * License: GPL
 * Copyright (c) 1999 Ethan Galstad (nagios@nagios.org)
 * Copyright (c) 2003-2008 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains commons functions used in many of the plugins.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 #include "common.h"

--- a/plugins/netutils.h
+++ b/plugins/netutils.h
@@ -1,31 +1,31 @@
 /*****************************************************************************
-* 
+*
 * Monitoring Plugins net utilities include file
-* 
+*
 * License: GPL
 * Copyright (c) 1999 Ethan Galstad (nagios@nagios.org)
 * Copyright (c) 2003-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains common include files and function definitions
 * used in many of the plugins.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 #ifndef _NETUTILS_H_

--- a/plugins/popen.c
+++ b/plugins/popen.c
@@ -1,41 +1,41 @@
 /*****************************************************************************
-* 
+*
 * Monitoring Plugins popen
-* 
+*
 * License: GPL
 * Copyright (c) 2005-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * A safe alternative to popen
-* 
+*
 * Provides spopen and spclose
-* 
+*
 * FILE * spopen(const char *);
 * int spclose(FILE *);
-* 
+*
 * Code taken with liitle modification from "Advanced Programming for the Unix
 * Environment" by W. Richard Stevens
-* 
+*
 * This is considered safe in that no shell is spawned, and the environment
 * and path passed to the exec'd program are essentially empty. (popen create
 * a shell and passes the environment to it).
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 #include "common.h"

--- a/plugins/runcmd.c
+++ b/plugins/runcmd.c
@@ -1,39 +1,39 @@
 /*****************************************************************************
-* 
+*
 * Monitoring run command utilities
-* 
+*
 * License: GPL
 * Copyright (c) 2005-2006 Monitoring Plugins Development Team
-* 
+*
 * Description :
-* 
+*
 * A simple interface to executing programs from other programs, using an
 * optimized and safe popen()-like implementation. It is considered safe
 * in that no shell needs to be spawned and the environment passed to the
 * execve()'d program is essentially empty.
-* 
+*
 * The code in this file is a derivative of popen.c which in turn was taken
 * from "Advanced Programming for the Unix Environment" by W. Richard Stevens.
-* 
+*
 * Care has been taken to make sure the functions are async-safe. The one
 * function which isn't is np_runcmd_init() which it doesn't make sense to
 * call twice anyway, so the api as a whole should be considered async-safe.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 #define NAGIOSPLUG_API_C 1

--- a/plugins/runcmd.h
+++ b/plugins/runcmd.h
@@ -1,24 +1,24 @@
 /****************************************************************************
-* 
+*
 * License: GPL
 * Copyright (c) 2005 Monitoring Plugins Development Team
 * Author: Andreas Ericsson <ae@op5.se>
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 #ifndef NAGIOSPLUG_RUNCMD_H

--- a/plugins/t/check_apt_input/debian2
+++ b/plugins/t/check_apt_input/debian2
@@ -3,7 +3,7 @@ NOTE: This is only a simulation!
       Keep also in mind that locking is deactivated,
       so don't depend on the relevance to the real current situation!
 Reading package lists... Done
-Building dependency tree       
+Building dependency tree
 Reading state information... Done
 The following packages will be upgraded:
   base-files debian-archive-keyring dpkg firmware-linux-free libc-bin libc-dev-bin libc6 libc6-dev linux-base

--- a/plugins/t/check_disk.t
+++ b/plugins/t/check_disk.t
@@ -26,8 +26,8 @@ if ($mountpoint_valid eq "" or $mountpoint2_valid eq "") {
 	plan tests => 78;
 }
 
-$result = NPTest->testCmd( 
-	"./check_disk -w 1% -c 1% -p $mountpoint_valid -w 1% -c 1% -p $mountpoint2_valid" 
+$result = NPTest->testCmd(
+	"./check_disk -w 1% -c 1% -p $mountpoint_valid -w 1% -c 1% -p $mountpoint2_valid"
 	);
 cmp_ok( $result->return_code, "==", 0, "Checking two mountpoints (must have at least 1% free in space and inodes)");
 my $c = 0;
@@ -102,8 +102,8 @@ is ($crit_percth_data, int((1-10/100)*$total_percth_data), "Wrong critical in pe
 
 
 # Check when order of mount points are reversed, that perf data remains same
-$result = NPTest->testCmd( 
-	"./check_disk -w 1% -c 1% -p $mountpoint2_valid -w 1% -c 1% -p $mountpoint_valid" 
+$result = NPTest->testCmd(
+	"./check_disk -w 1% -c 1% -p $mountpoint2_valid -w 1% -c 1% -p $mountpoint_valid"
 	);
 @_ = sort(split(/ /, $result->perf_output));
 is_deeply( \@perf_data, \@_, "perf data for both filesystems same when reversed");
@@ -133,8 +133,8 @@ cmp_ok( $result->return_code, '==', 0, "Old syntax okay" );
 $result = NPTest->testCmd( "./check_disk -w 1% -c 1% -p $more_free" );
 cmp_ok( $result->return_code, "==", 0, "At least 1% free" );
 
-$result = NPTest->testCmd( 
-	"./check_disk -w 1% -c 1% -p $more_free -w 100% -c 100% -p $less_free" 
+$result = NPTest->testCmd(
+	"./check_disk -w 1% -c 1% -p $more_free -w 100% -c 100% -p $less_free"
 	);
 cmp_ok( $result->return_code, "==", 2, "Get critical on less_free mountpoint $less_free" );
 like( $result->output, $failureOutput, "Right output" );
@@ -150,14 +150,14 @@ $result = NPTest->testCmd(
 	);
 cmp_ok( $result->return_code, '==', 0, "Get ok on more_free mountpoint, when checking avg_free");
 
-$result = NPTest->testCmd( 
-	"./check_disk -w $avg_free% -c 0% -p $less_free -w $avg_free% -c $avg_free% -p $more_free" 
+$result = NPTest->testCmd(
+	"./check_disk -w $avg_free% -c 0% -p $less_free -w $avg_free% -c $avg_free% -p $more_free"
 	);
 cmp_ok( $result->return_code, "==", 1, "Combining above two tests, get warning");
 my $all_disks = $result->output;
 
 $result = NPTest->testCmd(
-	"./check_disk -e -w $avg_free% -c 0% -p $less_free -w $avg_free% -c $avg_free% -p $more_free" 
+	"./check_disk -e -w $avg_free% -c 0% -p $less_free -w $avg_free% -c $avg_free% -p $more_free"
 	);
 isnt( $result->output, $all_disks, "-e gives different output");
 
@@ -239,7 +239,7 @@ TODO: {
 	cmp_ok( $result->return_code, '==', 3, "Invalid command line options" );
 }
 
-$result = NPTest->testCmd( 
+$result = NPTest->testCmd(
 	"./check_disk -p $mountpoint_valid -w 10% -c 15%"
 	);
 cmp_ok( $result->return_code, "==", 3, "Invalid options: -p must come after thresholds" );
@@ -321,7 +321,7 @@ cmp_ok( $result->return_code, '==', 1, "grouping: exit warning if the sum of fre
 $result = NPTest->testCmd( "./check_disk -w ". ($free_mb_on_all - 1) ." -c ". ($free_mb_on_all - 1) ." -g group -p $mountpoint_valid -p $mountpoint2_valid" );
 cmp_ok( $result->return_code, '==', 0, "grouping: exit ok if the sum of free megs on mp1+mp2 is more than warn/crit");
 
-# grouping: exit unknown if group name is given after -p 
+# grouping: exit unknown if group name is given after -p
 $result = NPTest->testCmd( "./check_disk -w ". ($free_mb_on_all - 1) ." -c ". ($free_mb_on_all - 1) ." -p $mountpoint_valid -g group -p $mountpoint2_valid" );
 cmp_ok( $result->return_code, '==', 3, "Invalid options: -p must come after groupname");
 

--- a/plugins/t/check_dns.t
+++ b/plugins/t/check_dns.t
@@ -14,7 +14,7 @@ plan tests => 19;
 
 my $successOutput = '/DNS OK: [\.0-9]+ seconds? response time/';
 
-my $hostname_valid = getTestParameter( 
+my $hostname_valid = getTestParameter(
 			"NP_HOSTNAME_VALID",
 			"A valid (known to DNS) hostname",
 			"monitoring-plugins.org",
@@ -44,8 +44,8 @@ my $hostname_valid_reverse = getTestParameter(
 			"orwell.monitoring-plugins.org.",
 			);
 
-my $hostname_invalid = getTestParameter( 
-			"NP_HOSTNAME_INVALID", 
+my $hostname_invalid = getTestParameter(
+			"NP_HOSTNAME_INVALID",
 			"An invalid (not known to DNS) hostname",
 			"nosuchhost.altinity.com",
 			);

--- a/plugins/t/check_hpjd.t
+++ b/plugins/t/check_hpjd.t
@@ -14,30 +14,30 @@ plan skip_all => "check_hpjd not compiled" unless (-x "check_hpjd");
 my $successOutput = '/^Printer ok - /';
 my $failureOutput = '/Timeout: No [Rr]esponse from /';
 
-my $host_tcp_hpjd = getTestParameter( 
+my $host_tcp_hpjd = getTestParameter(
 			"NP_HOST_TCP_HPJD",
 			"A host (usually a printer) providing the HP-JetDirect Services"
 			);
 
-my $host_hpjd_port_invalid = getTestParameter( 
+my $host_hpjd_port_invalid = getTestParameter(
 			"NP_HOST_HPJD_PORT_INVALID",
 			"A port that HP-JetDirect Services is not listening on",
 			"162"
 			);
 
-my $host_hpjd_port_valid = getTestParameter( 
+my $host_hpjd_port_valid = getTestParameter(
 			"NP_HOST_HPJD_PORT_VALID",
 			"The port that HP-JetDirect Services is currently listening on",
 			"161"
 			);
 
-my $host_nonresponsive = getTestParameter( 
+my $host_nonresponsive = getTestParameter(
 			"NP_HOST_NONRESPONSIVE",
 			"The hostname of system not responsive to network requests",
 			"10.0.0.1"
 			);
 
-my $hostname_invalid = getTestParameter( 
+my $hostname_invalid = getTestParameter(
 			"NP_HOSTNAME_INVALID",
 			"An invalid (not known to DNS) hostname",
 			"nosuchhost"

--- a/plugins/t/check_jabber.t
+++ b/plugins/t/check_jabber.t
@@ -33,7 +33,7 @@ SKIP: {
 	$r = NPTest->testCmd( "./check_jabber -H $host_tcp_jabber -w 9 -c 9 -t 10" );
 	is( $r->return_code, 0, "Connected okay, within limits" );
 	like( $r->output, $jabberOK, "Output as expected" );
-	
+
 	$r = NPTest->testCmd( "./check_jabber -H $host_tcp_jabber -wt 9 -ct 9 -to 10" );
 	is( $r->return_code, 0, "Old syntax okay" );
 	like( $r->output, $jabberOK, "Output as expected" );

--- a/plugins/t/check_nagios.t
+++ b/plugins/t/check_nagios.t
@@ -25,7 +25,7 @@ my $result;
 
 # Did use init, but MacOSX 10.4 replaces init with launchd
 # Alternative is to insist that nagios is running to run this test
-# Reasonable to expect cron because build servers will 
+# Reasonable to expect cron because build servers will
 # invoke cron to run a build
 my $procname = "cron";
 

--- a/plugins/t/check_ping.t
+++ b/plugins/t/check_ping.t
@@ -58,12 +58,12 @@ is( $res->return_code, 2, "Old syntax, with forced critical" );
 like( $res->output, $failureOutput, "Output OK" );
 
 
-# check_ping results will depend on whether the ping command discovered by 
+# check_ping results will depend on whether the ping command discovered by
 # ./configure has a timeout option. If it does, then the timeout will
 # be set, so check_ping will always get a response. If it doesn't
 # then check_ping will timeout. We do 2 tests for check_ping's timeout
 #  - 1 second
-#  - 15 seconds 
+#  - 15 seconds
 # The latter should be higher than normal ping timeouts, so should always give a packet loss result
 open(F, "../config.h") or die "Cannot open ../config.h";
 @_ = grep /define PING_HAS_TIMEOUT 1|define PING_PACKETS_FIRST 1/, <F>;

--- a/plugins/t/check_pop.t
+++ b/plugins/t/check_pop.t
@@ -10,7 +10,7 @@ use NPTest;
 
 plan tests => 5;
 
-my $host_tcp_smtp = getTestParameter( 
+my $host_tcp_smtp = getTestParameter(
 			"NP_HOST_TCP_SMTP",
 			"A host providing an STMP Service (a mail server)",
 			"mailhost"
@@ -23,12 +23,12 @@ my $host_tcp_pop = getTestParameter(
 			);
 
 my $host_nonresponsive = getTestParameter(
-			"NP_HOST_NONRESPONSIVE", 
+			"NP_HOST_NONRESPONSIVE",
 			"The hostname of system not responsive to network requests",
 			"10.0.0.1",
 			);
 
-my $hostname_invalid   = getTestParameter( 
+my $hostname_invalid   = getTestParameter(
 			"NP_HOSTNAME_INVALID",
 			"An invalid (not known to DNS) hostname",
 			"nosuchhost",

--- a/plugins/t/check_smtp.t
+++ b/plugins/t/check_smtp.t
@@ -8,17 +8,17 @@ use strict;
 use Test::More;
 use NPTest;
 
-my $host_tcp_smtp      = getTestParameter( "NP_HOST_TCP_SMTP", 
+my $host_tcp_smtp      = getTestParameter( "NP_HOST_TCP_SMTP",
 					   "A host providing an SMTP Service (a mail server)", "mailhost");
 my $host_tcp_smtp_tls  = getTestParameter( "NP_HOST_TCP_SMTP_TLS",
 					   "A host providing SMTP with TLS", $host_tcp_smtp);
 my $host_tcp_smtp_notls = getTestParameter( "NP_HOST_TCP_SMTP_NOTLS",
 					   "A host providing SMTP without TLS", "");
 
-my $host_nonresponsive = getTestParameter( "NP_HOST_NONRESPONSIVE", 
+my $host_nonresponsive = getTestParameter( "NP_HOST_NONRESPONSIVE",
 					   "The hostname of system not responsive to network requests", "10.0.0.1" );
 
-my $hostname_invalid   = getTestParameter( "NP_HOSTNAME_INVALID",   
+my $hostname_invalid   = getTestParameter( "NP_HOSTNAME_INVALID",
                                            "An invalid (not known to DNS) hostname", "nosuchhost" );
 my $res;
 
@@ -28,7 +28,7 @@ SKIP: {
 	skip "No SMTP server defined", 4 unless $host_tcp_smtp;
 	$res = NPTest->testCmd( "./check_smtp $host_tcp_smtp" );
 	is ($res->return_code, 0, "OK");
-	
+
 	$res = NPTest->testCmd( "./check_smtp -H $host_tcp_smtp -p 25 -w 9 -c 9 -t 10 -e 220" );
 	is ($res->return_code, 0, "OK, within 9 second response");
 

--- a/plugins/tests/check_nt.t
+++ b/plugins/tests/check_nt.t
@@ -40,7 +40,7 @@ if ($pid) {
 		my $rv = $client->recv($data, POSIX::BUFSIZ, 0);
 
 		my ($password, $command, $arg) = split('&', $data);
-		
+
 		if ($command eq "4") {
 			if ($arg eq "c") {
 				print $client "930000000&1000000000";

--- a/plugins/tests/check_snmp.t
+++ b/plugins/tests/check_snmp.t
@@ -57,9 +57,9 @@ if ($pid) {
 	exec("snmpd -c tests/conf/snmpd.conf -C -f -r udp:$port_snmp");
 }
 
-END { 
+END {
 	foreach my $pid (@pids) {
-		if ($pid) { print "Killing $pid\n"; kill "INT", $pid } 
+		if ($pid) { print "Killing $pid\n"; kill "INT", $pid }
 	}
 };
 
@@ -77,7 +77,7 @@ my $res;
 $res = NPTest->testCmd( "./check_snmp -H 127.0.0.1 -C public -p $port_snmp -o .1.3.6.1.4.1.8072.3.2.67.0");
 cmp_ok( $res->return_code, '==', 0, "Exit OK when querying a multi-line string" );
 like($res->output, '/^SNMP OK - /', "String contains SNMP OK");
-like($res->output, '/'.quotemeta('SNMP OK - Cisco Internetwork Operating System Software | 
+like($res->output, '/'.quotemeta('SNMP OK - Cisco Internetwork Operating System Software |
 .1.3.6.1.4.1.8072.3.2.67.0:
 "Cisco Internetwork Operating System Software
 IOS (tm) Catalyst 4000 \"L3\" Switch Software (cat4000-I9K91S-M), Version
@@ -90,7 +90,7 @@ Copyright (c) 1986-2004 by cisco Systems, Inc.
 $res = NPTest->testCmd( "./check_snmp -H 127.0.0.1 -C public -p $port_snmp -o .1.3.6.1.4.1.8072.3.2.67.0 -o sysContact.0 -o .1.3.6.1.4.1.8072.3.2.67.1");
 cmp_ok( $res->return_code, '==', 0, "Exit OK when querying multi-line OIDs" );
 like($res->output, '/^SNMP OK - /', "String contains SNMP OK");
-like($res->output, '/'.quotemeta('SNMP OK - Cisco Internetwork Operating System Software ').'"?Alice"?'.quotemeta(' Kisco Outernetwork Oserating Gystem Totware | 
+like($res->output, '/'.quotemeta('SNMP OK - Cisco Internetwork Operating System Software ').'"?Alice"?'.quotemeta(' Kisco Outernetwork Oserating Gystem Totware |
 .1.3.6.1.4.1.8072.3.2.67.0:
 "Cisco Internetwork Operating System Software
 IOS (tm) Catalyst 4000 \"L3\" Switch Software (cat4000-I9K91S-M), Version
@@ -103,19 +103,19 @@ Copyright (c) 1986-2004 by cisco Systems, Inc.
 Copyleft (c) 2400-2689 by kisco Systrems, Inc."').'/m', "String contains all lines with multiple OIDs");
 
 $res = NPTest->testCmd( "./check_snmp -H 127.0.0.1 -C public -p $port_snmp -o .1.3.6.1.4.1.8072.3.2.67.2");
-like($res->output, '/'.quotemeta('SNMP OK - This should not confuse check_snmp \"parser\" | 
+like($res->output, '/'.quotemeta('SNMP OK - This should not confuse check_snmp \"parser\" |
 .1.3.6.1.4.1.8072.3.2.67.2:
 "This should not confuse check_snmp \"parser\"
 into thinking there is no 2nd line"').'/m', "Attempt to confuse parser No.1");
 
 $res = NPTest->testCmd( "./check_snmp -H 127.0.0.1 -C public -p $port_snmp -o .1.3.6.1.4.1.8072.3.2.67.3");
-like($res->output, '/'.quotemeta('SNMP OK - It\'s getting even harder if the line | 
+like($res->output, '/'.quotemeta('SNMP OK - It\'s getting even harder if the line |
 .1.3.6.1.4.1.8072.3.2.67.3:
 "It\'s getting even harder if the line
 ends with with this: C:\\\\"').'/m', "Attempt to confuse parser No.2");
 
 $res = NPTest->testCmd( "./check_snmp -H 127.0.0.1 -C public -p $port_snmp -o .1.3.6.1.4.1.8072.3.2.67.4");
-like($res->output, '/'.quotemeta('SNMP OK - And now have fun with with this: \"C:\\\\\" | 
+like($res->output, '/'.quotemeta('SNMP OK - And now have fun with with this: \"C:\\\\\" |
 .1.3.6.1.4.1.8072.3.2.67.4:
 "And now have fun with with this: \"C:\\\\\"
 because we\'re not done yet!"').'/m', "Attempt to confuse parser No.3");

--- a/plugins/tests/check_snmp_agent.pl
+++ b/plugins/tests/check_snmp_agent.pl
@@ -50,7 +50,7 @@ $agent->register('check_snmp_agent', $regoid, \&my_snmp_handler);
 
 sub my_snmp_handler {
 	my ($handler, $registration_info, $request_info, $requests) = @_;
-	
+
 	for (my $request = $requests; $request; $request = $request->next) {
 		my $oid = $request->getOID();
 		my $index;

--- a/plugins/tests/var/ps_axwo.debian
+++ b/plugins/tests/var/ps_axwo.debian
@@ -1,5 +1,5 @@
 STAT   UID   PID  PPID   VSZ  RSS %CPU COMMAND          COMMAND
-S        0     1     0  1504  428  0.0 init             init [2]          
+S        0     1     0  1504  428  0.0 init             init [2]
 SN       0     2     1     0    0  0.0 ksoftirqd/0      [ksoftirqd/0]
 S<       0     3     1     0    0  0.0 events/0         [events/0]
 S<       0     4     3     0    0  0.0 khelper          [khelper]

--- a/plugins/urlize.c
+++ b/plugins/urlize.c
@@ -1,32 +1,32 @@
 /*****************************************************************************
-* 
+*
 * Monitoring urlize plugin
-* 
+*
 * License: GPL
 * Copyright (c) 2000-2007 Monitoring Plugins Development Team
-* 
+*
 * Description:
-* 
+*
 * This file contains the urlize plugin
-* 
+*
 * This plugin wraps the text output of another command (plugin) in HTML <A>
 * tags.  This plugin returns the status of the invoked plugin.
-* 
-* 
+*
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 const char *progname = "urlize";

--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -1,25 +1,25 @@
 /*****************************************************************************
-* 
+*
 * Library of useful functions for plugins
-* 
+*
 * License: GPL
 * Copyright (c) 2000 Karl DeBisschop (karl@debisschop.net)
 * Copyright (c) 2002-2007 Monitoring Plugins Development Team
-* 
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-* 
-* 
+*
+*
 *****************************************************************************/
 
 #include "common.h"
@@ -352,7 +352,7 @@ strscpy (char *dest, const char *src)
  * This
  * is
  * a
- * 
+ *
  * multiline string buffer
  * ==============================
  *
@@ -365,7 +365,7 @@ strscpy (char *dest, const char *src)
  *   printf("%d %s",i++,firstword(ptr));
  *   ptr = strnl(ptr);
  * }
- * 
+ *
  * Produces the following:
  *
  * 1 This
@@ -452,7 +452,7 @@ strpcpy (char *dest, const char *src, const char *str)
  * str = strpcpy(str,"This is a line of text with no trailing newline","x");
  * str = strpcat(str,"This is a line of text with no trailing newline","x");
  * printf("%s\n",str);
- * 
+ *
  *This is a line of texThis is a line of tex
  *
  *****************************************************************************/

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -99,8 +99,8 @@ char *sperfdata_int (const char *, int, const char *, char *, char *,
 
 int open_max (void);
 
-/* The idea here is that, although not every plugin will use all of these, 
-   most will or should.  Therefore, for consistency, these very common 
+/* The idea here is that, although not every plugin will use all of these,
+   most will or should.  Therefore, for consistency, these very common
    options should have only these meanings throughout the overall suite */
 
 #define STD_LONG_OPTS \


### PR DESCRIPTION
I am kinda sorry about this, but I am highlighting trailing whitespaces in my editor and this annoys me.
So I executed `find . -type f -exec sed -i 's/\s\+$//' {} \;` in the plugins directory.
It would be nice if that could be made a permanent state.