### PR TITLE
Make tests run with custom settings

### DIFF
--- a/plugins-root/Makefile.am
+++ b/plugins-root/Makefile.am
@@ -37,6 +37,9 @@ TESTS = @PLUGIN_TEST@
 test:
 	perl -I $(top_builddir) -I $(top_srcdir) ../test.pl
 
+test-debug:
+	NPTEST_DEBUG=1 HARNESS_VERBOSE=1 perl -I $(top_builddir) -I $(top_srcdir) ../test.pl
+
 setuid_root_mode = ug=rx,u+s
 
 # /* Author Coreutils team - see ACKNOWLEDGEMENTS */

--- a/plugins-root/t/check_dhcp.t
+++ b/plugins-root/t/check_dhcp.t
@@ -19,7 +19,7 @@ if ($allow_sudo eq "yes" or $> == 0) {
 my $sudo = $> == 0 ? '' : 'sudo';
 
 my $successOutput = '/OK: Received \d+ DHCPOFFER\(s\), \d+ of 1 requested servers responded, max lease time = \d+ sec\./';
-my $failureOutput = '/CRITICAL: No DHCPOFFERs were received/';
+my $failureOutput = '/CRITICAL: (No DHCPOFFERs were received|Received \d+ DHCPOFFER\(s\), 0 of 1 requested servers responded, max lease time = \d+ sec\.)/';
 my $invalidOutput = '/Invalid hostname/';
 
 my $host_responsive    = getTestParameter( "NP_HOST_DHCP_RESPONSIVE",
@@ -36,7 +36,12 @@ my $hostname_invalid   = getTestParameter( "NP_HOSTNAME_INVALID",
 
 # try to determince interface
 my $interface = '';
-if(`ifconfig -a 2>/dev/null` =~ m/^(e\w*\d+)/mx and $1 ne 'eth0') {
+
+# find interface used for default route
+if (-x '/usr/sbin/ip' and `/usr/sbin/ip route get 1.1.1.1 2>/dev/null` =~ m/\sdev\s(\S+)/) {
+    $interface = "-i $1";
+}
+elsif (`ifconfig -a 2>/dev/null` =~ m/^(e\w*\d+)/mx and $1 ne 'eth0') {
     $interface = ' -i '.$1;
 }
 

--- a/plugins/t/check_curl.t
+++ b/plugins/t/check_curl.t
@@ -84,7 +84,7 @@ like( $res->output, '/^Host: testhost:8001\s*$/ms', "Host Header OK" );
 like( $res->output, '/CURLOPT_URL: http:\/\/'.$host_tcp_http.':80\//ms', "Url OK" );
 
 SKIP: {
-        skip "No internet access", 3 if $internet_access eq "no";
+        skip "No internet access", 4 if $internet_access eq "no";
 
         $res = NPTest->testCmd("./$plugin -v -H $host_tls_http -S");
         like( $res->output, '/^Host: '.$host_tls_http.'\s*$/ms', "Host Header OK" );
@@ -120,7 +120,7 @@ SKIP: {
         cmp_ok( $res->return_code, "==", 0, "And also when not found");
 }
 SKIP: {
-        skip "No internet access", 16 if $internet_access eq "no";
+        skip "No internet access", 28 if $internet_access eq "no";
 
         $res = NPTest->testCmd(
                 "./$plugin --ssl $host_tls_http"

--- a/plugins/t/check_http.t
+++ b/plugins/t/check_http.t
@@ -103,7 +103,7 @@ SKIP: {
         cmp_ok( $res->return_code, "==", 0, "And also when not found");
 }
 SKIP: {
-        skip "No internet access", 16 if $internet_access eq "no";
+        skip "No internet access", 23 if $internet_access eq "no";
 
         $res = NPTest->testCmd(
                 "./$plugin --ssl $host_tls_http"
@@ -135,7 +135,7 @@ SKIP: {
 
         # run some certificate checks with faketime
         SKIP: {
-                skip "No faketime binary found", 12 if !$faketime;
+                skip "No faketime binary found", 7 if !$faketime;
                 $res = NPTest->testCmd("LC_TIME=C TZ=UTC ./$plugin -C 1 $host_tls_http");
                 like($res->output, qr/OK - Certificate '$host_tls_cert' will expire on/, "Catch cert output");
                 is( $res->return_code, 0, "Catch cert output exit code" );


### PR DESCRIPTION
This PR has the patches I needed to make to run the test suite with different settings (`NP_*` vars), on a different host than what Travis CI uses.