### PR TITLE
check_curl.c: bugfix: verify certificates option should not force SSL to be used

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1346,7 +1346,7 @@ process_arguments (int argc, char **argv)
 #ifdef LIBCURL_FEATURE_SSL
     case 'D': /* verify peer certificate & host */
       verify_peer_and_host = TRUE;
-      goto enable_ssl;
+      break;
 #endif
     case 'S': /* use SSL */
 #ifdef LIBCURL_FEATURE_SSL

--- a/plugins/t/check_curl.t
+++ b/plugins/t/check_curl.t
@@ -95,7 +95,7 @@ SKIP: {
         $res = NPTest->testCmd("./$plugin -v -H $host_tls_http:443 -S -p 443");
         like( $res->output, '/^Host: '.$host_tls_http.'\s*$/ms', "Host Header OK" );
 
-        $res = NPTest->testCmd("./$plugin -v -H $host_tls_http -D -p 443");
+        $res = NPTest->testCmd("./$plugin -v -H $host_tls_http -D -S -p 443");
         like( $res->output, '/(^Host: '.$host_tls_http.'\s*$)|(cURL returned 60)/ms', "Host Header OK" );
 };
 


### PR DESCRIPTION
The original addition of the `-D` option to verify certificates is causing SSL to be forced into use whenever this switch is used. This fix allows the ability to toggle SSL separately from this switch (which will still verify certificates following a HTTP > HTTPS redirect).

### Before
```
$ check_curl -H neverssl.com -f curl --sni --no-body -D -t 40
HTTP CRITICAL - Invalid HTTP response received from host on port 443: cURL returned 51 - SSL: no alternative certificate subject name matches target host name 'neverssl.com'
```

### After
```
$ check_curl -H neverssl.com -f curl --sni --no-body -D -t 40
HTTP OK: HTTP/1.1 200 OK - 473 bytes in 1.125 second response time |time=1.124970s;;;0.000000;40.000000 size=473B;;;0

$ check_curl -H neverssl.com -f curl --sni --no-body -D -t 40 -S
HTTP CRITICAL - Invalid HTTP response received from host on port 443: cURL returned 51 - SSL: no alternative certificate subject name matches target host name 'neverssl.com'

$ check_curl -H expired.badssl.com -f curl --sni -D -t 40
HTTP CRITICAL - Invalid HTTP response received from host on port 80: cURL returned 60 - SSL certificate problem: certificate has expired
```