### PR TITLE
check_http: changed 'STATE_CRITICAL' to 'STATE_WARNING' for infinite loop

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1453,8 +1453,8 @@ redir (char *pos, char *status_line)
       !strncmp(server_address, addr, MAX_IPV4_HOSTLENGTH) &&
       (host_name && !strncmp(host_name, addr, MAX_IPV4_HOSTLENGTH)) &&
       !strcmp(server_url, url))
-    die (STATE_WARNING,
-         _("HTTP WARNING - redirection creates an infinite loop - %s://%s:%d%s%s\n"),
+    die (STATE_CRITICAL,
+         _("HTTP CRITICAL - redirection creates an infinite loop - %s://%s:%d%s%s\n"),
          type, addr, i, url, (display_html ? "</A>" : ""));
 
   strcpy (server_type, type);


### PR DESCRIPTION
We use the check_http in our Icinga instance and once had the case that we got the message (HTTP WARNING - redirection creates an infinite loop) issued with the warning status. Since this is an infinite loop message I think the state should be rather 'critical', right?