### PR TITLE
Let ssh decide if a host is valid, enables usage of ssh .config file

### DIFF
--- a/plugins/check_by_ssh.c
+++ b/plugins/check_by_ssh.c
@@ -230,7 +230,6 @@ process_arguments (int argc, char **argv)
 				timeout_interval = atoi (optarg);
 			break;
 		case 'H':									/* host */
-			host_or_die(optarg);
 			hostname = optarg;
 			break;
 		case 'p': /* port number */
@@ -329,7 +328,6 @@ process_arguments (int argc, char **argv)
 		if (c <= argc) {
 			die (STATE_UNKNOWN, _("%s: You must provide a host name\n"), progname);
 		}
-		host_or_die(argv[c]);
 		hostname = argv[c++];
 	}
 


### PR DESCRIPTION
Removes host check from the plugin and lets SSH decide if the hostname parameter is valid.
SSH will additionaly search the config file for the name and therefore allow some customization.
#1135 