### PR TITLE
add LOAD prefix to load plugin

### DIFF
--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -209,7 +209,7 @@ main (int argc, char **argv)
 		else if(la[i] > wload[i]) result = STATE_WARNING;
 	}
 
-	printf("%s - %s|", state_text(result), status_line);
+	printf("LOAD %s - %s|", state_text(result), status_line);
 	for(i = 0; i < 3; i++)
 		printf("load%d=%.3f;%.3f;%.3f;0; ", nums[i], la[i], wload[i], cload[i]);
 

--- a/plugins/t/check_load.t
+++ b/plugins/t/check_load.t
@@ -11,8 +11,8 @@ use NPTest;
 my $res;
 
 my $loadValue = "[0-9]+\.?[0-9]+";
-my $successOutput = "/^OK - load average: $loadValue, $loadValue, $loadValue/";
-my $failureOutput = "/^CRITICAL - load average: $loadValue, $loadValue, $loadValue/";
+my $successOutput = "/^LOAD OK - load average: $loadValue, $loadValue, $loadValue/";
+my $failureOutput = "/^LOAD CRITICAL - load average: $loadValue, $loadValue, $loadValue/";
 
 plan tests => 11;
 


### PR DESCRIPTION
just a cosmetic fix so the load plugin display a LOAD prefix before check results (this time hopefully correct and complete)