### PR TITLE
check_ping: Do not show RTA if no connection was possible

### DIFF
--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -171,7 +171,7 @@ main (int argc, char **argv)
 									  crta>0?TRUE:FALSE, crta,
 									  TRUE, 0, FALSE, 0));
 		} else {
-			printf("| rta=U;;;;;");
+			printf("| rta=U;%f;%f;;", wrta, crta);
 		}
 		printf(" %s\n", perfdata ("pl", (long) pl, "%",
 		                          wpl>0?TRUE:FALSE, wpl,

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -37,6 +37,8 @@ const char *email = "devel@monitoring-plugins.org";
 #include "popen.h"
 #include "utils.h"
 
+#include <signal.h>
+
 #define WARN_DUPLICATES "DUPLICATES FOUND! "
 #define UNKNOWN_TRIP_TIME -1.0	/* -1 seconds */
 
@@ -163,10 +165,14 @@ main (int argc, char **argv)
 			printf ("</A>");
 
 		/* Print performance data */
-		printf("|%s", fperfdata ("rta", (double) rta, "ms",
-		                          wrta>0?TRUE:FALSE, wrta,
-		                          crta>0?TRUE:FALSE, crta,
-		                          TRUE, 0, FALSE, 0));
+		if (pl != 100) {
+			printf("|%s", fperfdata ("rta", (double) rta, "ms",
+									  wrta>0?TRUE:FALSE, wrta,
+									  crta>0?TRUE:FALSE, crta,
+									  TRUE, 0, FALSE, 0));
+		} else {
+			printf("|");
+		}
 		printf(" %s\n", perfdata ("pl", (long) pl, "%",
 		                          wpl>0?TRUE:FALSE, wpl,
 		                          cpl>0?TRUE:FALSE, cpl,

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -171,7 +171,7 @@ main (int argc, char **argv)
 									  crta>0?TRUE:FALSE, crta,
 									  TRUE, 0, FALSE, 0));
 		} else {
-			printf("|");
+			printf("| rta=U;;;;;");
 		}
 		printf(" %s\n", perfdata ("pl", (long) pl, "%",
 		                          wpl>0?TRUE:FALSE, wpl,

--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -589,10 +589,12 @@ char *perfdata (const char *label,
 		xasprintf (&data, "%s;", data);
 
 	if (minp)
-		xasprintf (&data, "%s%ld", data, minv);
+		xasprintf (&data, "%s%ld;", data, minv);
+	else
+		xasprintf (&data, "%s;", data);
 
 	if (maxp)
-		xasprintf (&data, "%s;%ld", data, maxv);
+		xasprintf (&data, "%s%ld", data, maxv);
 
 	return data;
 }


### PR DESCRIPTION
Displaying the RTA in perfdata will confuse the system using this data  and falsify averages.