### PR TITLE
Feature check curl

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -55,6 +55,10 @@ const char *email = "devel@monitoring-plugins.org";
 
 #include <arpa/inet.h>
 
+#if defined(HAVE_SSL) && defined(USE_OPENSSL)
+#include <openssl/opensslv.h>
+#endif
+
 #define MAKE_LIBCURL_VERSION(major, minor, patch) ((major)*0x10000 + (minor)*0x100 + (patch))
 
 #define DEFAULT_BUFFER_SIZE 2048
@@ -286,7 +290,9 @@ int verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx)
    * TODO: is the last certificate always the server certificate?
    */
   cert = X509_STORE_CTX_get_current_cert(x509_ctx);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
   X509_up_ref(cert);
+#endif
   if (verbose>=2) {
     puts("* SSL verify callback with certificate:");
     X509_NAME *subject, *issuer;

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1033,8 +1033,8 @@ char*
 uri_string (const UriTextRangeA range, char* buf, size_t buflen)
 {
   if (!range.first) return "(null)";
-  strncpy (buf, range.first, max (buflen, range.afterLast - range.first));
-  buf[max (buflen, range.afterLast - range.first)] = '\0';
+  strncpy (buf, range.first, max (buflen-1, range.afterLast - range.first));
+  buf[max (buflen-1, range.afterLast - range.first)] = '\0';
   buf[range.afterLast - range.first] = '\0';
   return buf;
 }

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1106,8 +1106,8 @@ redir (curlhelp_write_curlbuf* header_buf)
       !strncmp(server_address, new_host, MAX_IPV4_HOSTLENGTH) &&
       (host_name && !strncmp(host_name, new_host, MAX_IPV4_HOSTLENGTH)) &&
       !strcmp(server_url, new_url))
-    die (STATE_WARNING,
-         _("HTTP WARNING - redirection creates an infinite loop - %s://%s:%d%s%s\n"),
+    die (STATE_CRITICAL,
+         _("HTTP CRITICAL - redirection creates an infinite loop - %s://%s:%d%s%s\n"),
          use_ssl ? "https" : "http", new_host, new_port, new_url, (display_html ? "</A>" : ""));
 
   /* set new values for redirected request */


### PR DESCRIPTION
- adds --automatic_decompression for automatically decompressing the body
- bugfixes:
  - certificate check with old OpenSSL versions (up_ref pining)
  - DNS cache with host:port:host is no longer allowed in newest curl version, must be host:port:ip (leads to an error
    in HTTPS virtual host cases)
  - the usual scoping and buffer overflow bugfixes
- backports from check_http:
  - infinitite redirection loops should be CRITICAL
 