### PR TITLE
Fix perfdata for check swap

### DIFF
--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -466,7 +466,7 @@ process_arguments (int argc, char **argv)
 				length = strlen(optarg);
 
 				if (optarg[length - 1] == '%') {
-					// It's percentage!
+					/* It's percentage */
 					warn.is_percentage = true;
 					optarg[length - 1] = '\0';
 					if (is_uint64(optarg, &warn.value)) {
@@ -477,7 +477,7 @@ process_arguments (int argc, char **argv)
 						}
 					}
 				} else {
-					// It's Bytes
+					/* It's Bytes */
 					warn.is_percentage = false;
 					if (is_uint64(optarg, &warn.value)) {
 						break;
@@ -497,7 +497,7 @@ process_arguments (int argc, char **argv)
 				length = strlen(optarg);
 
 				if (optarg[length - 1] == '%') {
-					// It's percentage!
+					/* It's percentage */
 					crit.is_percentage = true;
 					optarg[length - 1] = '\0';
 					if (is_uint64(optarg, &crit.value)) {
@@ -508,6 +508,7 @@ process_arguments (int argc, char **argv)
 						}
 					}
 				} else {
+					/* It's Bytes */
 					crit.is_percentage = false;
 					if (is_uint64(optarg, &crit.value)) {
 						break;

--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -37,7 +37,6 @@ const char *email = "devel@monitoring-plugins.org";
 #include <string.h>
 #include <math.h>
 #include <libintl.h>
-#include <stdbool.h>
 
 #ifdef HAVE_DECL_SWAPCTL
 # ifdef HAVE_SYS_PARAM_H
@@ -56,7 +55,7 @@ const char *email = "devel@monitoring-plugins.org";
 #endif
 
 typedef struct {
-	bool is_percentage;
+	int is_percentage;
 	uint64_t value;
 } threshold_t;
 
@@ -69,7 +68,7 @@ void print_help (void);
 threshold_t warn;
 threshold_t crit;
 int verbose;
-bool allswaps;
+int allswaps;
 int no_swap_state = STATE_CRITICAL;
 
 int
@@ -467,7 +466,7 @@ process_arguments (int argc, char **argv)
 
 				if (optarg[length - 1] == '%') {
 					/* It's percentage */
-					warn.is_percentage = true;
+					warn.is_percentage = 1;
 					optarg[length - 1] = '\0';
 					if (is_uint64(optarg, &warn.value)) {
 						if (warn.value > 100) {
@@ -478,7 +477,7 @@ process_arguments (int argc, char **argv)
 					}
 				} else {
 					/* It's Bytes */
-					warn.is_percentage = false;
+					warn.is_percentage = 0;
 					if (is_uint64(optarg, &warn.value)) {
 						break;
 					} else {
@@ -498,7 +497,7 @@ process_arguments (int argc, char **argv)
 
 				if (optarg[length - 1] == '%') {
 					/* It's percentage */
-					crit.is_percentage = true;
+					crit.is_percentage = 1;
 					optarg[length - 1] = '\0';
 					if (is_uint64(optarg, &crit.value)) {
 						if (crit.value> 100) {
@@ -509,7 +508,7 @@ process_arguments (int argc, char **argv)
 					}
 				} else {
 					/* It's Bytes */
-					crit.is_percentage = false;
+					crit.is_percentage = 0;
 					if (is_uint64(optarg, &crit.value)) {
 						break;
 					} else {

--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -400,8 +400,8 @@ check_swap(float free_swap_mb, float total_swap_mb)
 
 	uint64_t free_swap = free_swap_mb * (1024 * 1024);		/* Convert back to bytes as warn and crit specified in bytes */
 
-	if (!crit.is_percentage && crit.value <= free_swap) return STATE_CRITICAL;
-	if (!warn.is_percentage && warn.value <= free_swap) return STATE_WARNING;
+	if (!crit.is_percentage && crit.value >= free_swap) return STATE_CRITICAL;
+	if (!warn.is_percentage && warn.value >= free_swap) return STATE_WARNING;
 
 
 	uint64_t usage_percentage = ((total_swap_mb - free_swap_mb) / total_swap_mb) * 100;

--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -34,6 +34,10 @@ const char *email = "devel@monitoring-plugins.org";
 #include "common.h"
 #include "popen.h"
 #include "utils.h"
+#include <string.h>
+#include <math.h>
+#include <libintl.h>
+#include <stdbool.h>
 
 #ifdef HAVE_DECL_SWAPCTL
 # ifdef HAVE_SYS_PARAM_H
@@ -51,26 +55,30 @@ const char *email = "devel@monitoring-plugins.org";
 # define SWAP_CONVERSION 1
 #endif
 
-int check_swap (int usp, float free_swap_mb, float total_swap_mb);
+typedef struct {
+	bool is_percentage;
+	uint64_t value;
+} threshold_t;
+
+int check_swap (float free_swap_mb, float total_swap_mb);
 int process_arguments (int argc, char **argv);
 int validate_arguments (void);
 void print_usage (void);
 void print_help (void);
 
-int warn_percent = 0;
-int crit_percent = 0;
-float warn_size_bytes = 0;
-float crit_size_bytes = 0;
+threshold_t warn;
+threshold_t crit;
 int verbose;
-int allswaps;
+bool allswaps;
 int no_swap_state = STATE_CRITICAL;
 
 int
 main (int argc, char **argv)
 {
-	int percent_used, percent;
-	float total_swap_mb = 0, used_swap_mb = 0, free_swap_mb = 0;
-	float dsktotal_mb = 0, dskused_mb = 0, dskfree_mb = 0, tmp_mb = 0;
+	unsigned int percent_used, percent;
+	uint64_t total_swap_mb = 0, used_swap_mb = 0, free_swap_mb = 0;
+	uint64_t dsktotal_mb = 0, dskused_mb = 0, dskfree_mb = 0;
+	uint64_t tmp_KB = 0;
 	int result = STATE_UNKNOWN;
 	char input_buffer[MAX_INPUT_BUFFER];
 #ifdef HAVE_PROC_MEMINFO
@@ -116,10 +124,15 @@ main (int argc, char **argv)
 	}
 	fp = fopen (PROC_MEMINFO, "r");
 	while (fgets (input_buffer, MAX_INPUT_BUFFER - 1, fp)) {
-		if (sscanf (input_buffer, "%*[S]%*[w]%*[a]%*[p]%*[:] %f %f %f", &dsktotal_mb, &dskused_mb, &dskfree_mb) == 3) {
-			dsktotal_mb = dsktotal_mb / 1048576;	/* Apply conversion */
-			dskused_mb = dskused_mb / 1048576;
-			dskfree_mb = dskfree_mb / 1048576;
+		/*
+		 * The following sscanf call looks for a line looking like: "Swap: 123 123 123"
+		 * On which kind of system this format exists, I can not say, but I wanted to
+		 * document this for people who are not adapt with sscanf anymore, like me
+		 */
+		if (sscanf (input_buffer, "%*[S]%*[w]%*[a]%*[p]%*[:] %lu %lu %lu", &dsktotal_mb, &dskused_mb, &dskfree_mb) == 3) {
+			dsktotal_mb = dsktotal_mb / (1024 * 1024);	/* Apply conversion */
+			dskused_mb = dskused_mb / (1024 * 1024);
+			dskfree_mb = dskfree_mb / (1024 * 1024);
 			total_swap_mb += dsktotal_mb;
 			used_swap_mb += dskused_mb;
 			free_swap_mb += dskfree_mb;
@@ -128,21 +141,25 @@ main (int argc, char **argv)
 					percent=100.0;
 				else
 					percent = 100 * (((double) dskused_mb) / ((double) dsktotal_mb));
-				result = max_state (result, check_swap (percent, dskfree_mb, dsktotal_mb));
+				result = max_state (result, check_swap (dskfree_mb, dsktotal_mb));
 				if (verbose)
 					xasprintf (&status, "%s [%.0f (%d%%)]", status, dskfree_mb, 100 - percent);
 			}
 		}
-		else if (sscanf (input_buffer, "%*[S]%*[w]%*[a]%*[p]%[TotalFre]%*[:] %f %*[k]%*[B]", str, &tmp_mb)) {
+		/*
+		 * The following sscanf call looks for lines looking like: "SwapTotal: 123" and "SwapFree: 123"
+		 * This format exists at least on Debian Linux with a 5.* kernel
+		 */
+		else if (sscanf (input_buffer, "%*[S]%*[w]%*[a]%*[p]%[TotalFre]%*[:] %lu %*[k]%*[B]", str, &tmp_KB)) {
 			if (verbose >= 3) {
-				printf("Got %s with %f\n", str, tmp_mb);
+				printf("Got %s with %lu\n", str, tmp_KB);
 			}
 			/* I think this part is always in Kb, so convert to mb */
 			if (strcmp ("Total", str) == 0) {
-				dsktotal_mb = tmp_mb / 1024;
+				dsktotal_mb = tmp_KB / 1024;
 			}
 			else if (strcmp ("Free", str) == 0) {
-				dskfree_mb = tmp_mb / 1024;
+				dskfree_mb = tmp_KB / 1024;
 			}
 		}
 	}
@@ -227,7 +244,7 @@ main (int argc, char **argv)
 			free_swap_mb += dskfree_mb;
 			if (allswaps) {
 				percent = 100 * (((double) dskused_mb) / ((double) dsktotal_mb));
-				result = max_state (result, check_swap (percent, dskfree_mb, dsktotal_mb));
+				result = max_state (result, check_swap (dskfree_mb, dsktotal_mb));
 				if (verbose)
 					xasprintf (&status, "%s [%.0f (%d%%)]", status, dskfree_mb, 100 - percent);
 			}
@@ -289,7 +306,7 @@ main (int argc, char **argv)
 
 		if(allswaps && dsktotal_mb > 0){
 			percent = 100 * (((double) dskused_mb) / ((double) dsktotal_mb));
-			result = max_state (result, check_swap (percent, dskfree_mb, dsktotal_mb));
+			result = max_state (result, check_swap (dskfree_mb, dsktotal_mb));
 			if (verbose) {
 				xasprintf (&status, "%s [%.0f (%d%%)]", status, dskfree_mb, 100 - percent);
 			}
@@ -328,7 +345,7 @@ main (int argc, char **argv)
 
 		if(allswaps && dsktotal_mb > 0){
 			percent = 100 * (((double) dskused_mb) / ((double) dsktotal_mb));
-			result = max_state (result, check_swap (percent, dskfree_mb, dsktotal_mb));
+			result = max_state (result, check_swap(dskfree_mb, dsktotal_mb));
 			if (verbose) {
 				xasprintf (&status, "%s [%.0f (%d%%)]", status, dskfree_mb, 100 - percent);
 			}
@@ -355,14 +372,19 @@ main (int argc, char **argv)
 		status = "- Swap is either disabled, not present, or of zero size. ";
 	}
 
-	result = max_state (result, check_swap (percent_used, free_swap_mb, total_swap_mb));
-	printf (_("SWAP %s - %d%% free (%d MB out of %d MB) %s|"),
+	result = max_state (result, check_swap(free_swap_mb, total_swap_mb));
+	printf (_("SWAP %s - %d%% free (%dMB out of %dMB) %s|"),
 			state_text (result),
 			(100 - percent_used), (int) free_swap_mb, (int) total_swap_mb, status);
 
-	puts (perfdata ("swap", (long) free_swap_mb, "MB",
-	                TRUE, (long) max (warn_size_bytes/(1024 * 1024), warn_percent/100.0*total_swap_mb),
-	                TRUE, (long) max (crit_size_bytes/(1024 * 1024), crit_percent/100.0*total_swap_mb),
+	uint64_t warn_print = warn.value;
+	if (warn.is_percentage) warn_print = warn.value * (total_swap_mb *1024 *1024/100);
+	uint64_t crit_print = crit.value;
+	if (crit.is_percentage) crit_print = crit.value * (total_swap_mb *1024 *1024/100);
+
+	puts (perfdata_uint64 ("swap", free_swap_mb *1024 *1024, "B",
+	                TRUE, warn_print,
+	                TRUE, crit_print,
 	                TRUE, 0,
 	                TRUE, (long) total_swap_mb));
 
@@ -370,26 +392,37 @@ main (int argc, char **argv)
 }
 
 
-
 int
-check_swap (int usp, float free_swap_mb, float total_swap_mb)
+check_swap(float free_swap_mb, float total_swap_mb)
 {
 
 	if (!total_swap_mb) return no_swap_state;
 
-	int result = STATE_UNKNOWN;
-	float free_swap = free_swap_mb * (1024 * 1024);		/* Convert back to bytes as warn and crit specified in bytes */
-	if (usp >= 0 && crit_percent != 0 && usp >= (100.0 - crit_percent))
-		result = STATE_CRITICAL;
-	else if (crit_size_bytes > 0 && free_swap <= crit_size_bytes)
-		result = STATE_CRITICAL;
-	else if (usp >= 0 && warn_percent != 0 && usp >= (100.0 - warn_percent))
-		result = STATE_WARNING;
-	else if (warn_size_bytes > 0 && free_swap <= warn_size_bytes)
-		result = STATE_WARNING;
-	else if (usp >= 0.0)
-		result = STATE_OK;
-	return result;
+	uint64_t free_swap = free_swap_mb * (1024 * 1024);		/* Convert back to bytes as warn and crit specified in bytes */
+
+	if (!crit.is_percentage && crit.value <= free_swap) return STATE_CRITICAL;
+	if (!warn.is_percentage && warn.value <= free_swap) return STATE_WARNING;
+
+
+	uint64_t usage_percentage = ((total_swap_mb - free_swap_mb) / total_swap_mb) * 100;
+
+	if (crit.is_percentage &&
+			usage_percentage >= 0 &&
+			crit.value != 0 &&
+			usage_percentage >= (100 - crit.value))
+	{
+			return STATE_CRITICAL;
+	}
+
+	if (warn.is_percentage &&
+			usage_percentage >= 0 &&
+			warn.value != 0 &&
+			usage_percentage >= (100 - warn.value))
+	{
+			return STATE_WARNING;
+	}
+
+	return STATE_OK;
 }
 
 
@@ -422,42 +455,67 @@ process_arguments (int argc, char **argv)
 			break;
 
 		switch (c) {
-		case 'w':									/* warning size threshold */
-			if (is_intnonneg (optarg)) {
-				warn_size_bytes = (float) atoi (optarg);
-				break;
+		case 'w': /* warning size threshold */
+			{
+				/*
+				 * We expect either a positive integer value without a unit, which means
+				 * the unit is Bytes or a positive integer value and a percentage sign (%),
+				 * which means the value must be with 0 and 100 and is relative to the total swap
+				 */
+				size_t length;
+				length = strlen(optarg);
+
+				if (optarg[length - 1] == '%') {
+					// It's percentage!
+					warn.is_percentage = true;
+					optarg[length - 1] = '\0';
+					if (is_uint64(optarg, &warn.value)) {
+						if (warn.value > 100) {
+							usage4 (_("Warning threshold percentage must be <= 100!"));
+						} else {
+							break;
+						}
+					}
+				} else {
+					// It's Bytes
+					warn.is_percentage = false;
+					if (is_uint64(optarg, &warn.value)) {
+						break;
+					} else {
+						usage4 (_("Warning threshold be positive integer or percentage!"));
+					}
+				}
 			}
-			else if (strstr (optarg, ",") &&
-							 strstr (optarg, "%") &&
-							 sscanf (optarg, "%f,%d%%", &warn_size_bytes, &warn_percent) == 2) {
-				warn_size_bytes = floorf(warn_size_bytes);
-				break;
-			}
-			else if (strstr (optarg, "%") &&
-							 sscanf (optarg, "%d%%", &warn_percent) == 1) {
-				break;
-			}
-			else {
-				usage4 (_("Warning threshold must be integer or percentage!"));
-			}
-		case 'c':									/* critical size threshold */
-			if (is_intnonneg (optarg)) {
-				crit_size_bytes = (float) atoi (optarg);
-				break;
-			}
-			else if (strstr (optarg, ",") &&
-							 strstr (optarg, "%") &&
-							 sscanf (optarg, "%f,%d%%", &crit_size_bytes, &crit_percent) == 2) {
-				crit_size_bytes = floorf(crit_size_bytes);
-				break;
-			}
-			else if (strstr (optarg, "%") &&
-							 sscanf (optarg, "%d%%", &crit_percent) == 1) {
-				break;
-			}
-			else {
-				usage4 (_("Critical threshold must be integer or percentage!"));
-			}
+		case 'c': /* critical size threshold */
+			{
+				/*
+				 * We expect either a positive integer value without a unit, which means
+				 * the unit is Bytes or a positive integer value and a percentage sign (%),
+				 * which means the value must be with 0 and 100 and is relative to the total swap
+				 */
+				size_t length;
+				length = strlen(optarg);
+
+				if (optarg[length - 1] == '%') {
+					// It's percentage!
+					crit.is_percentage = true;
+					optarg[length - 1] = '\0';
+					if (is_uint64(optarg, &crit.value)) {
+						if (crit.value> 100) {
+							usage4 (_("Critical threshold percentage must be <= 100!"));
+						} else {
+							break;
+						}
+					}
+				} else {
+					crit.is_percentage = false;
+					if (is_uint64(optarg, &crit.value)) {
+						break;
+					} else {
+						usage4 (_("Critical threshold be positive integer or percentage!"));
+					}
+				}
+			  }
 		case 'a':									/* all swap */
 			allswaps = TRUE;
 			break;
@@ -482,23 +540,6 @@ process_arguments (int argc, char **argv)
 	c = optind;
 	if (c == argc)
 		return validate_arguments ();
-	if (warn_percent == 0 && is_intnonneg (argv[c]))
-		warn_percent = atoi (argv[c++]);
-
-	if (c == argc)
-		return validate_arguments ();
-	if (crit_percent == 0 && is_intnonneg (argv[c]))
-		crit_percent = atoi (argv[c++]);
-
-	if (c == argc)
-		return validate_arguments ();
-	if (warn_size_bytes == 0 && is_intnonneg (argv[c]))
-		warn_size_bytes = (float) atoi (argv[c++]);
-
-	if (c == argc)
-		return validate_arguments ();
-	if (crit_size_bytes == 0 && is_intnonneg (argv[c]))
-		crit_size_bytes = (float) atoi (argv[c++]);
 
 	return validate_arguments ();
 }
@@ -508,17 +549,12 @@ process_arguments (int argc, char **argv)
 int
 validate_arguments (void)
 {
-	if (warn_percent == 0 && crit_percent == 0 && warn_size_bytes == 0
-			&& crit_size_bytes == 0) {
+	if (warn.value == 0 && crit.value == 0) {
 		return ERROR;
 	}
-	else if (warn_percent < crit_percent) {
+	else if (warn.value < crit.value) {
 		usage4
-			(_("Warning percentage should be more than critical percentage"));
-	}
-	else if (warn_size_bytes < crit_size_bytes) {
-		usage4
-			(_("Warning free space should be more than critical free space"));
+			(_("Warning should be more than critical"));
 	}
 	return OK;
 }
@@ -562,7 +598,6 @@ print_help (void)
 
 	printf (UT_SUPPORT);
 }
-
 
 
 void

--- a/plugins/t/check_swap.t
+++ b/plugins/t/check_swap.t
@@ -8,9 +8,9 @@ use strict;
 use Test::More tests => 8;
 use NPTest;
 
-my $successOutput = '/^SWAP OK - [0-9]+\% free \([0-9]+ MB out of [0-9]+ MB\)/';
-my $failureOutput = '/^SWAP CRITICAL - [0-9]+\% free \([0-9]+ MB out of [0-9]+ MB\)/';
-my $warnOutput    = '/^SWAP WARNING - [0-9]+\% free \([0-9]+ MB out of [0-9]+ MB\)/';
+my $successOutput = '/^SWAP OK - [0-9]+\% free \([0-9]+MB out of [0-9]+MB\)/';
+my $failureOutput = '/^SWAP CRITICAL - [0-9]+\% free \([0-9]+MB out of [0-9]+MB\)/';
+my $warnOutput    = '/^SWAP WARNING - [0-9]+\% free \([0-9]+MB out of [0-9]+MB\)/';
 
 my $result;
 

--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -27,6 +27,8 @@
 #include "utils_base.h"
 #include <stdarg.h>
 #include <limits.h>
+#include <string.h>
+#include <errno.h>
 
 #include <arpa/inet.h>
 
@@ -237,6 +239,46 @@ is_intnonneg (char *number)
 		return TRUE;
 	else
 		return FALSE;
+}
+
+/*
+ * Checks whether the number in the string _number_ can be put inside a int64_t
+ * On success the number will be written to the _target_ address, if _target_ is not set
+ * to NULL.
+ */
+bool is_int64(char *number, int64_t *target) {
+	errno = 0;
+	uint64_t tmp = strtoll(number, NULL, 10);
+	if (errno != 0) {
+		return false;
+	}
+	if (tmp < INT64_MIN || tmp > INT64_MAX) {
+		return false;
+	}
+	if (target != NULL) {
+		*target = tmp;
+	}
+	return true;
+}
+
+/*
+ * Checks whether the number in the string _number_ can be put inside a uint64_t
+ * On success the number will be written to the _target_ address, if _target_ is not set
+ * to NULL.
+ */
+bool is_uint64(char *number, uint64_t *target) {
+	errno = 0;
+	uint64_t tmp = strtoll(number, NULL, 10);
+	if (errno != 0) {
+		return false;
+	}
+	if (tmp < 0 || tmp > UINT64_MAX) {
+		return false;
+	}
+	if (target != NULL) {
+		*target = tmp;
+	}
+	return true;
 }
 
 int
@@ -528,6 +570,84 @@ char *perfdata (const char *label,
  long int minv,
  int maxp,
  long int maxv)
+{
+	char *data = NULL;
+
+	if (strpbrk (label, "'= "))
+		xasprintf (&data, "'%s'=%ld%s;", label, val, uom);
+	else
+		xasprintf (&data, "%s=%ld%s;", label, val, uom);
+
+	if (warnp)
+		xasprintf (&data, "%s%ld;", data, warn);
+	else
+		xasprintf (&data, "%s;", data);
+
+	if (critp)
+		xasprintf (&data, "%s%ld;", data, crit);
+	else
+		xasprintf (&data, "%s;", data);
+
+	if (minp)
+		xasprintf (&data, "%s%ld", data, minv);
+
+	if (maxp)
+		xasprintf (&data, "%s;%ld", data, maxv);
+
+	return data;
+}
+
+
+char *perfdata_uint64 (const char *label,
+ uint64_t val,
+ const char *uom,
+ int warnp,
+ uint64_t warn,
+ int critp,
+ uint64_t crit,
+ int minp,
+ uint64_t minv,
+ int maxp,
+ uint64_t maxv)
+{
+	char *data = NULL;
+
+	if (strpbrk (label, "'= "))
+		xasprintf (&data, "'%s'=%ld%s;", label, val, uom);
+	else
+		xasprintf (&data, "%s=%ld%s;", label, val, uom);
+
+	if (warnp)
+		xasprintf (&data, "%s%ld;", data, warn);
+	else
+		xasprintf (&data, "%s;", data);
+
+	if (critp)
+		xasprintf (&data, "%s%ld;", data, crit);
+	else
+		xasprintf (&data, "%s;", data);
+
+	if (minp)
+		xasprintf (&data, "%s%ld", data, minv);
+
+	if (maxp)
+		xasprintf (&data, "%s;%ld", data, maxv);
+
+	return data;
+}
+
+
+char *perfdata_int64 (const char *label,
+ int64_t val,
+ const char *uom,
+ int warnp,
+ int64_t warn,
+ int critp,
+ int64_t crit,
+ int minp,
+ int64_t minv,
+ int maxp,
+ int64_t maxv)
 {
 	char *data = NULL;
 

--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -246,19 +246,19 @@ is_intnonneg (char *number)
  * On success the number will be written to the _target_ address, if _target_ is not set
  * to NULL.
  */
-bool is_int64(char *number, int64_t *target) {
+int is_int64(char *number, int64_t *target) {
 	errno = 0;
 	uint64_t tmp = strtoll(number, NULL, 10);
 	if (errno != 0) {
-		return false;
+		return 0;
 	}
 	if (tmp < INT64_MIN || tmp > INT64_MAX) {
-		return false;
+		return 0;
 	}
 	if (target != NULL) {
 		*target = tmp;
 	}
-	return true;
+	return 1;
 }
 
 /*
@@ -266,19 +266,19 @@ bool is_int64(char *number, int64_t *target) {
  * On success the number will be written to the _target_ address, if _target_ is not set
  * to NULL.
  */
-bool is_uint64(char *number, uint64_t *target) {
+int is_uint64(char *number, uint64_t *target) {
 	errno = 0;
 	uint64_t tmp = strtoll(number, NULL, 10);
 	if (errno != 0) {
-		return false;
+		return 0;
 	}
 	if (tmp < 0 || tmp > UINT64_MAX) {
-		return false;
+		return 0;
 	}
 	if (target != NULL) {
 		*target = tmp;
 	}
-	return true;
+	return 1;
 }
 
 int

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -16,6 +16,9 @@ suite of plugins. */
 /* now some functions etc are being defined in ../lib/utils_base.c */
 #include "utils_base.h"
 
+
+#include <stdbool.h>
+
 #ifdef NP_EXTRA_OPTS
 /* Include extra-opts functions if compiled in */
 #include "extra_opts.h"
@@ -38,6 +41,7 @@ int is_intpos (char *);
 int is_intneg (char *);
 int is_intnonneg (char *);
 int is_intpercent (char *);
+bool is_uint64(char *number, uint64_t *target);
 
 int is_numeric (char *);
 int is_positive (char *);
@@ -87,6 +91,12 @@ void usage_va(const char *fmt, ...) __attribute__((noreturn));
 
 char *perfdata (const char *, long int, const char *, int, long int,
                 int, long int, int, long int, int, long int);
+
+char *perfdata_uint64 (const char *, uint64_t , const char *, int, uint64_t,
+                int, uint64_t, int, uint64_t, int, uint64_t);
+
+char *perfdata_int64 (const char *, int64_t, const char *, int, int64_t,
+                int, int64_t, int, int64_t, int, int64_t);
 
 char *fperfdata (const char *, double, const char *, int, double,
                  int, double, int, double, int, double);

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -17,8 +17,6 @@ suite of plugins. */
 #include "utils_base.h"
 
 
-#include <stdbool.h>
-
 #ifdef NP_EXTRA_OPTS
 /* Include extra-opts functions if compiled in */
 #include "extra_opts.h"
@@ -41,7 +39,8 @@ int is_intpos (char *);
 int is_intneg (char *);
 int is_intnonneg (char *);
 int is_intpercent (char *);
-bool is_uint64(char *number, uint64_t *target);
+int is_uint64(char *number, uint64_t *target);
+int is_int64(char *number, int64_t *target);
 
 int is_numeric (char *);
 int is_positive (char *);


### PR DESCRIPTION
   The original problem was #1705 
    where the performance data output of check_swap did not conform to
    the parser logic of a monitoring system (which decided to go for
    "correct" SI or IEC units.
    The PR was accompanied by a change to byte values in the performance
    data which broke the _perfdata_ helper function which could not handle
    values of this size.
    The fix for this, was to use _fperfdata_ which could, but would
    use float values.

    I didn't like that (since all values here are discreet) and this
    is my proposal for a fix for the problem.

    It introduces some helper functions which do now explicitely work
    with (u)int64_t, including a special version of the _perfdata_ helper.

    In the process of introducing this to check_swap, I stumbled over
    several sections of the check_swap code which I found problematic.
    Therefore I tried to simplify the code and make it more readable
    and less redundant.

    I am kinda sorry about this, but sincerely hope my changes can
    be helpful.