### PR TITLE
Restrict the nickname length of the test user for check_ircd

### DIFF
--- a/plugins-scripts/check_ircd.pl
+++ b/plugins-scripts/check_ircd.pl
@@ -69,6 +69,8 @@ $ENV{'ENV'}='';
 # -----------------------------------------------------------------[ Global ]--
 
 $PROGNAME = "check_ircd";
+# nickname shouldn't be longer than 9 chars, this might happen with large PIDs
+# To prevent this, we cut of the part over 10000
 my $NICK="ircd" . $$ % 10000;
 my $USER_INFO="monitor localhost localhost : ";
 	


### PR DESCRIPTION
check_ircd was using the string `ircd` plus the PID as a nickname
for connecting to a IRC network by default.
This caused errors, when the PID was too high and the network
restricted the length of the nickname to 9 characters.
This patch "fixes" this by just cutting it of, if it gets too big.

Fixes #1709