### PR TITLE
check_snmp: fix performance thresholds when using multiple oids

### DIFF
--- a/lib/utils_base.c
+++ b/lib/utils_base.c
@@ -128,6 +128,7 @@ range
 	temp_range->end = 0;
 	temp_range->end_infinity = TRUE;
 	temp_range->alert_on = OUTSIDE;
+	temp_range->text = strdup(str);
 
 	if (str[0] == '@') {
 		temp_range->alert_on = INSIDE;
@@ -706,4 +707,3 @@ void np_state_write_string(time_t data_time, char *data_string) {
 
 	np_free(temp_file);
 }
-

--- a/lib/utils_base.h
+++ b/lib/utils_base.h
@@ -23,6 +23,7 @@ typedef struct range_struct {
 	double	end;
 	int	end_infinity;
 	int	alert_on;		/* OUTSIDE (default) or INSIDE */
+	char* text; /* original unparsed text input */
 	} range;
 
 typedef struct thresholds_struct {

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -468,6 +468,9 @@ main (int argc, char **argv)
 		/* Process this block for numeric comparisons */
 		/* Make some special values,like Timeticks numeric only if a threshold is defined */
 		if (thlds[i]->warning || thlds[i]->critical || calculate_rate) {
+			if (verbose > 2) {
+				print_thresholds("  thresholds", thlds[i]);
+			}
 			ptr = strpbrk (show, "-0123456789");
 			if (ptr == NULL)
 				die (STATE_UNKNOWN,_("No valid data returned (%s)\n"), show);
@@ -581,14 +584,16 @@ main (int argc, char **argv)
 
 			if (warning_thresholds) {
 				strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
-				strncat(perfstr, warning_thresholds, sizeof(perfstr)-strlen(perfstr)-1);
+				if(thlds[i]->warning && thlds[i]->warning->text)
+					strncat(perfstr, thlds[i]->warning->text, sizeof(perfstr)-strlen(perfstr)-1);
 			}
 
 			if (critical_thresholds) {
 				if (!warning_thresholds)
 					strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
 				strncat(perfstr, ";", sizeof(perfstr)-strlen(perfstr)-1);
-				strncat(perfstr, critical_thresholds, sizeof(perfstr)-strlen(perfstr)-1);
+				if(thlds[i]->critical && thlds[i]->critical->text)
+					strncat(perfstr, thlds[i]->critical->text, sizeof(perfstr)-strlen(perfstr)-1);
 			}
 
 			strncat(perfstr, " ", sizeof(perfstr)-strlen(perfstr)-1);


### PR DESCRIPTION
when using check_snmp with multiple oids it simply printed the unparsed content
from -w/-c into the thresholds for each oid. So each oid contained the hole -w
from all oids.

./check_snmp ... -o iso.3.6.1.2.1.25.1.3.0,iso.3.6.1.2.1.25.1.5.0 -w '1,2' -c '3,4'

before:
  SNMP ... | HOST-RESOURCES-MIB::hrSystemInitialLoadDevice.0=393216;1,2;3,4 HOST-RESOURCES-MIB::hrSystemNumUsers.0=24;1,2;3,4

after:
  SNMP ... | HOST-RESOURCES-MIB::hrSystemInitialLoadDevice.0=393216;1;3 HOST-RESOURCES-MIB::hrSystemNumUsers.0=24;2;4

This also applies to fixed thresholds since check_snmp translates negative infinities from: `~:-1` to `@-1:~`