### PR TITLE
Allows check_ldap to read password from environment variable

### DIFF
--- a/plugins/check_ldap.c
+++ b/plugins/check_ldap.c
@@ -432,6 +432,9 @@ validate_arguments ()
 		set_thresholds(&entries_thresholds,
 			warn_entries, crit_entries);
 	}
+	if (ld_passwd==NULL)
+		ld_passwd = getenv("LDAP_PASSWORD");
+
 	return OK;
 }
 
@@ -465,7 +468,7 @@ print_help (void)
   printf (" %s\n", "-D [--bind]");
   printf ("    %s\n", _("ldap bind DN (if required)"));
   printf (" %s\n", "-P [--pass]");
-  printf ("    %s\n", _("ldap password (if required)"));
+  printf ("    %s\n", _("ldap password (if required, or set the password through environment variable 'LDAP_PASSWORD')"));
   printf (" %s\n", "-T [--starttls]");
   printf ("    %s\n", _("use starttls mechanism introduced in protocol version 3"));
   printf (" %s\n", "-S [--ssl]");


### PR DESCRIPTION
It's not secure to provide LDAP password through command line option
because other users on the same host can see the password in
'ps' command output.

This change allows check_ldap to get password from environment variable.