### PR TITLE
check_uptime: Add option to report uptime in days instead of seconds

### DIFF
--- a/plugins-scripts/check_uptime.pl
+++ b/plugins-scripts/check_uptime.pl
@@ -25,7 +25,7 @@ use POSIX;
 use strict;
 use Getopt::Long;
 use vars qw($opt_V $opt_h $opt_v $verbose $PROGNAME $opt_w $opt_c
-					$opt_f $opt_s
+					$opt_f $opt_s $opt_d
 					$lower_warn_threshold $upper_warn_threshold
 					$lower_crit_threshold $upper_crit_threshold
 					$status $state $msg);
@@ -137,9 +137,20 @@ if ( $uptime_seconds > $upper_crit_threshold ) {
 	$state_str = "OK";
 }
 
+# Prepare uptime value (seconds or days)
+my $uptime_text = "";
+my $uptime_unit = "";
+if ( $opt_d ) {
+	$uptime_text = floor($uptime_seconds / 60 / 60 / 24);
+	$uptime_unit = "days";
+} else {
+	$uptime_text = $uptime_seconds;
+	$uptime_unit = "seconds";
+}
+
 $msg = "$state_str: ";
 
-$msg .= "uptime is $uptime_seconds seconds. ";
+$msg .= "uptime is $uptime_text $uptime_unit. ";
 $msg .= "Exceeds $out_of_bounds_text threshold. "  if  $out_of_bounds_text;
 $msg .= "Running for $pretty_uptime. "  if  $opt_f;
 if ( $opt_s ) {
@@ -167,6 +178,7 @@ sub process_arguments(){
 		 "c=s" => \$opt_c, "critical=s" => \$opt_c,	  # critical if above this number
 		 "f"   => \$opt_f, "for"        => \$opt_f,	  # show "running for ..."
 		 "s"   => \$opt_s, "since"      => \$opt_s,	  # show "running since ..."
+		 "d"   => \$opt_d, "days"       => \$opt_d,	  # report uptime in days
 		 );
 
 	if ($opt_V) {
@@ -262,6 +274,7 @@ sub print_help () {
 	print "-c (--critical)  = Min. number of uptime to generate critical alert ( w < c )\n";
 	print "-f (--for)       = Show uptime in a pretty format (Running for x weeks, x days, ...)\n";
 	print "-s (--since)     = Show last boot in yyyy-mm-dd HH:MM:SS format (output from 'uptime -s')\n";
+	print "-d (--days)      = Show uptime in days\n";
 	print "-h (--help)\n";
 	print "-V (--version)\n";
 	print "-v (--verbose)   = debugging output\n";

--- a/plugins-scripts/t/check_uptime.t
+++ b/plugins-scripts/t/check_uptime.t
@@ -5,7 +5,7 @@
 #
 
 use strict;
-use Test::More tests => 40;
+use Test::More tests => 42;
 use NPTest;
 
 my $result;
@@ -44,6 +44,12 @@ $result = NPTest->testCmd(
 	);
 cmp_ok( $result->return_code, '==', 2, "Uptime higher than 2 seconds" );
 like  ( $result->output, '/Running since \d+/', "Output for the s parameter correct" );
+
+$result = NPTest->testCmd(
+	"./check_uptime -d -w 1 -c 2"
+	);
+cmp_ok( $result->return_code, '==', 2, "Uptime higher than 2 seconds" );
+like  ( $result->output, '/CRITICAL: uptime is \d+ days/', "Output for the d parameter correct" );
 
 $result = NPTest->testCmd(
 	"./check_uptime -w 1 -c 2"


### PR DESCRIPTION
Dear community. Dear @wopfel and @sni.

Firsts things first: Thanks a stack for conceiving and maintaining this excellent collection of monitoring plugins.

This is a humble patch for the `check_uptime.pl` sensor to make it report the system uptime in _days_ instead of _seconds_. It has been wired to a new `--days` option, in order not to change its default behavior.

The rationale is to reduce mental load for humans, when looking at the textual output of the sensor. While the _"pretty" format_ already implemented by `check_uptime.pl` has good intentions, it didn't quite nail it for us.

With kind regards,
Andreas.

---


### Previous situation

Currently, the baseline plugin output, with no way to change it, is:
```
CRITICAL: Uptime is 38829029 seconds.
```

We also tried using both options `--for` and `--since`. However, we still have not been happy with the corresponding output.

![image](https://user-images.githubusercontent.com/453543/153714423-fc1a9f3b-dee9-4ce9-8f37-e3f5406d58b2.png)


### New situation

When using the proposed `--days|-d` option, the output will be:
```
CRITICAL: Uptime is 449 days.
```

In our opinion, this is much more pleasant.

![image](https://user-images.githubusercontent.com/453543/153714480-3786ce6d-c677-4eb2-b5bc-743d8850d6e0.png)
