### PR TITLE
remove duplicate W=i/C=i args in check_mailq.pl

### DIFF
--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -578,8 +578,6 @@ sub process_arguments(){
 		 "t=i" => \$opt_t, "timeout=i"  => \$opt_t,
 		 "s"   => \$opt_s, "sudo"       => \$opt_s,
 		 "d:s" => \$opt_d, "configdir:s" => \$opt_d,
-		 "W=i" => \$opt_W,                            # warning if above this number
-		 "C=i" => \$opt_C,                            # critical if above this number
 		 );
 
 	if ($opt_V) {


### PR DESCRIPTION
currently, check_mailq.pl defines the C/W arg twice (slipped in in a single commit in 2020, only adding those duplicates), leading to warnings on plugin execution.