### PR TITLE
Update CodeQL and update runner before installing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,6 +53,7 @@ jobs:
 
     - name: Install packages
       run: |
+        sudo apt update
         sudo apt-get install -y --no-install-recommends m4 gettext automake autoconf make build-essential
         sudo apt-get install -y --no-install-recommends perl autotools-dev libdbi-dev libldap2-dev libpq-dev \
                                                         libmysqlclient-dev libradcli-dev libkrb5-dev libdbi0-dev \
@@ -62,10 +63,10 @@ jobs:
       run: |
         ./tools/setup
         ./configure --enable-libtap
-    
+
     - name: Build
       run: |
         make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
* Update QuodeQl test to version 2 to fix the complaining in the test runs ( https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/ )
* Update test machine package cache before installing stuff to avoid trying to fetch old ( and not available ) packages