### PR TITLE
check_by_ssh: Add random wait option -r

### DIFF
--- a/plugins/check_by_ssh.c
+++ b/plugins/check_by_ssh.c
@@ -94,12 +94,8 @@ main (int argc, char **argv)
 
 	/* Wait a random amount of time */
 	if (random_wait_max) {
-		uint8_t random = 0;
-		int fd = open("/dev/urandom", O_RDONLY);
-		read(fd, &random, sizeof(uint8_t));
-		close(fd);
-
-		sleep( (random_wait_max * random) / 255 );
+		srand(time(NULL));
+		sleep(random() % random_wait_max);
 	}
 
 	/* Set signal handling and alarm timeout */


### PR DESCRIPTION
Added option -r, --random-wait=MAXTIME to wait for a random amount of seconds between 0 and MAXTIME.

This should help with deployments which check multiple services over SSH. I found that adding a wrapper to wait randomly for up to 10s reduced the amount of failed SSH connections dramatically, and thus eliminated many false alarms.