### PR TITLE
Fix check_icmp long options and check_http test plan

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -451,6 +451,14 @@ main(int argc, char **argv)
 		packets = 5;
 	}
 
+	/* support "--help" and "--version" */
+	if(argc == 2) {
+		if(!strcmp(argv[1], "--help"))
+			strcpy(argv[1], "-h");
+		if(!strcmp(argv[1], "--version"))
+			strcpy(argv[1], "-V");
+	}
+
 	/* Parse protocol arguments first */
 	for(i = 1; i < argc; i++) {
 		while((arg = getopt(argc, argv, opts_str)) != EOF) {
@@ -554,14 +562,6 @@ main(int argc, char **argv)
 
 	/* Parse extra opts if any */
 	argv=np_extra_opts(&argc, argv, progname);
-
-	/* support "--help" and "--version" */
-	if(argc == 2) {
-		if(!strcmp(argv[1], "--help"))
-			strcpy(argv[1], "-h");
-		if(!strcmp(argv[1], "--version"))
-			strcpy(argv[1], "-V");
-	}
 
 	argv = &argv[optind];
 	while(*argv) {

--- a/plugins/t/check_http.t
+++ b/plugins/t/check_http.t
@@ -103,7 +103,7 @@ SKIP: {
         cmp_ok( $res->return_code, "==", 0, "And also when not found");
 }
 SKIP: {
-        skip "No internet access", 23 if $internet_access eq "no";
+        skip "No internet access", 22 if $internet_access eq "no";
 
         $res = NPTest->testCmd(
                 "./$plugin --ssl $host_tls_http"


### PR DESCRIPTION
### check_icmp: fix parsing help/version long options

Fix parsing of the long options --help and --version. The special
handling must be done before calling getopt().
This fixes erroneous output like:

    ./check_icmp --version
    ./check_icmp: invalid option -- '-'
    ./check_icmp: invalid option -- 'e'
    ./check_icmp: invalid option -- 'r'
    ./check_icmp: invalid option -- '-'
    ./check_icmp: invalid option -- 'e'
    ./check_icmp: invalid option -- 'r'

### check_http: fix test plan

Fix test plan when run with NP_INTERNET_ACCESS=no, where the correct
number of steps must be skipped.
Caused by a removed test in 65fc7064295ac70d1388fa4db4d4d2cddd531e24
