### PR TITLE
check_disk: Find accessible mount path if multiple are available

### DIFF
--- a/lib/utils_disk.c
+++ b/lib/utils_disk.c
@@ -133,7 +133,7 @@ np_set_best_match(struct parameter_list *desired, struct mount_entry *mount_list
       /* set best match if path name exactly matches a mounted device name */
       for (me = mount_list; me; me = me->me_next) {
 	if (get_fs_usage(me->me_mountdir, me->me_devname, &fsp) < 0)
-	  continue;
+	  continue; /* skip if permissions do not suffice for accessing device */
         if (strcmp(me->me_devname, d->name)==0)
           best_match = me;
       }
@@ -142,7 +142,7 @@ np_set_best_match(struct parameter_list *desired, struct mount_entry *mount_list
       if (! best_match) {
         for (me = mount_list; me; me = me->me_next) {
 	  if (get_fs_usage(me->me_mountdir, me->me_devname, &fsp) < 0)
-	    continue;
+	    continue; /* skip if permissions do not suffice for accessing device */
           size_t len = strlen (me->me_mountdir);
           if ((exact == FALSE && (best_match_len <= len && len <= name_len &&
              (len == 1 || strncmp (me->me_mountdir, d->name, len) == 0)))

--- a/lib/utils_disk.c
+++ b/lib/utils_disk.c
@@ -28,6 +28,7 @@
 
 #include "common.h"
 #include "utils_disk.h"
+#include "gl/fsusage.h"
 
 void
 np_add_name (struct name_list **list, const char *name)
@@ -127,9 +128,12 @@ np_set_best_match(struct parameter_list *desired, struct mount_entry *mount_list
       size_t name_len = strlen(d->name);
       size_t best_match_len = 0;
       struct mount_entry *best_match = NULL;
+      struct fs_usage fsp;
 
       /* set best match if path name exactly matches a mounted device name */
       for (me = mount_list; me; me = me->me_next) {
+	if (get_fs_usage(me->me_mountdir, me->me_devname, &fsp) < 0)
+	  continue;
         if (strcmp(me->me_devname, d->name)==0)
           best_match = me;
       }
@@ -137,6 +141,8 @@ np_set_best_match(struct parameter_list *desired, struct mount_entry *mount_list
       /* set best match by directory name if no match was found by devname */
       if (! best_match) {
         for (me = mount_list; me; me = me->me_next) {
+	  if (get_fs_usage(me->me_mountdir, me->me_devname, &fsp) < 0)
+	    continue;
           size_t len = strlen (me->me_mountdir);
           if ((exact == FALSE && (best_match_len <= len && len <= name_len &&
              (len == 1 || strncmp (me->me_mountdir, d->name, len) == 0)))


### PR DESCRIPTION
* PR as discussed with @RincewindsHat; fixes #1819
* proximate cause was app. that errors returned from `get_fs_usage()` were ignored
* remediation of root cause consists of adding another condition in `np_set_best_match()`: besides constituting "best" matches, eligible mount entries also have to be accessible according to `get_fs_usage()`
* in consequence, no more such errors should occur
* I have confirmed that this PR makes the original issue (in a Kubernetes environment, as described in #1819) go away; the specific output from the check now reads as follows:

```
DISK OK - free space: /var 15388MiB (25% inode=65%);| /var=46552580096B;52372596326;58919170867;0;65465745408
```

* please let me know if you intend to merge this PR into `master`, then I will also add a corresponding change to `AUTHORS`