### PR TITLE
make check_http faster with larger files

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1095,9 +1095,14 @@ check_http (void)
       *pos = ' ';
     }
     buffer[i] = '\0';
-    xasprintf (&full_page_new, "%s%s", full_page, buffer);
-    free (full_page);
+
+    if ((full_page_new = realloc(full_page, pagesize + i + 1)) == NULL)
+        die (STATE_UNKNOWN, _("HTTP UNKNOWN - Could not allocate memory for full_page\n"));
+
+    memmove(&full_page_new[pagesize], buffer, i + 1);
+
     full_page = full_page_new;
+
     pagesize += i;
 
                 if (no_body && document_headers_done (full_page)) {


### PR DESCRIPTION
The current implementation becomes exponentially slower with growing response size.

See also:

https://github.com/nagios-plugins/nagios-plugins/blob/release-2.4.2/plugins/check_http.c#L1199-L1204

Test:

    $ mkdir web
    $ nohup python3 -m http.server -d web 5080 &
    $ perl -E 'say "0123456789" for (1..2_000_000)' >| web/file.txt
    $ ./check_http.orig  -t 200 -v  -I localhost -p 5080 -u /file.txt > test1.txt
    real    0m26.893s
    user    0m12.661s
    sys     0m14.221s
    $ time ./check_http -t 200 -v  -I localhost -p 5080 -u /file.txt > test2.txt
    real    0m0.038s
    user    0m0.011s
    sys     0m0.027s
    $ diff -u test[12].txt
    --- test1.txt   2022-12-21 14:58:28.720260811 +0100
    +++ test2.txt   2022-12-21 14:58:42.640008604 +0100
    @@ -7,7 +7,7 @@
     STATUS: HTTP/1.0 200 OK
     **** HEADER ****
     Server: SimpleHTTP/0.6 Python/3.9.2
    -Date: Wed, 21 Dec 2022 13:58:01 GMT
    +Date: Wed, 21 Dec 2022 13:58:42 GMT
     Content-type: text/plain
     Content-Length: 22000000
     Last-Modified: Wed, 21 Dec 2022 13:57:58 GMT
    @@ -2000013,4 +2000013,4 @@
     0123456789
     0123456789

    -HTTP OK: HTTP/1.0 200 OK - 22000191 bytes in 26.860 second response time |time=26.860182s;;;0.000000;200.000000 size=22000191B;;;0;
    +HTTP OK: HTTP/1.0 200 OK - 22000191 bytes in 0.016 second response time |time=0.016412s;;;0.000000;200.000000 size=22000191B;;;0;