### PR TITLE
fix check_snmp regex matches

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -1165,17 +1165,36 @@ nextarg (char *str)
 char *
 multiply (char *str)
 {
-	double val = strtod (str, NULL);
-	val *= multiplier;
+	char *endptr;
+	double val;
 	char *conv = "%f";
+
+	if(verbose>2)
+		printf("    multiply input: %s\n", str);
+
+	val = strtod (str, &endptr);
+	if ((val == 0.0) && (endptr == str)) {
+		if(multiplier != 1) {
+			die(STATE_UNKNOWN, _("multiplier set (%.1f), but input is not a number: %s"), multiplier, str);
+		}
+		return str;
+	}
+
+	if(verbose>2)
+		printf("    multiply extracted double: %f\n", val);
+	val *= multiplier;
 	if (fmtstr != "") {
 		conv = fmtstr;
 	}
 	if (val == (int)val) {
 		sprintf(str, "%.0f", val);
 	} else {
+		if(verbose>2)
+			printf("    multiply using format: %s\n", conv);
 		sprintf(str, conv, val);
 	}
+	if(verbose>2)
+		printf("    multiply result: %s\n", str);
 	return str;
 }
 


### PR DESCRIPTION
the multiplier function always tried to extract a number, even if the result is a string because of using a mib.

before:
```
./check_snmp -H hostname -P2c -c public -o IF-MIB::ifAdminStatus.11466 -vvv -r 0
/usr/bin/snmpget -Le -t 10 -r 5 -m ALL -v 2c [context] [authpriv] 10.0.13.11:161 IF-MIB::ifAdminStatus.11466
IF-MIB::ifAdminStatus.11466 = INTEGER: up(1)
Processing oid 1 (line 1)
  oidname: IF-MIB::ifAdminStatus.11466
  response:  = INTEGER: up(1)
SNMP OK - 0 | IF-MIB::ifAdminStatus.11466=0;;
```

the regexp 0 matches, even if the actual result is "up(1)".

after this patch:
```
./check_snmp -H hostname -P2c -c public -o IF-MIB::ifAdminStatus.11466 -vvv -r 0
/usr/bin/snmpget -Le -t 10 -r 5 -m ALL -v 2c [context] [authpriv] 10.0.13.11:161 IF-MIB::ifAdminStatus.11466
IF-MIB::ifAdminStatus.11466 = INTEGER: up(1)
Processing oid 1 (line 1)
  oidname: IF-MIB::ifAdminStatus.11466
  response:  = INTEGER: up(1)
SNMP CRITICAL - *up(1)* |
```