### PR TITLE
Added --exclude, cleanup args, fix -a count bug

### DIFF
--- a/plugins-scripts/check_log.sh
+++ b/plugins-scripts/check_log.sh
@@ -18,7 +18,7 @@
 # On the first run of the plugin, it will return an OK state with a message
 # of "Log check data initialized".  On successive runs, it will return an OK
 # state if *no* pattern matches have been found in the *difference* between the
-# log file and the older copy of the log file.  If the plugin detects any 
+# log file and the older copy of the log file.  If the plugin detects any
 # pattern matches in the log diff, it will return a CRITICAL state and print
 # out a message is the following format: "(x) last_match", where "x" is the
 # total number of pattern matches found in the file and "last_match" is the
@@ -76,6 +76,7 @@ print_usage() {
 	echo ""
 	echo "Other parameters:"
 	echo "	-a|--all : Print all matching lines"
+	echo "  --exclude: Exclude a pattern (-p or -e also applies here when used)"
 	echo "	-p|--perl-regex : Use perl style regular expressions in the query"
 	echo "	-e|--extended-regex : Use extended style regular expressions in the query (not necessary for GNU grep)"
 }
@@ -99,82 +100,46 @@ if [ $# -lt 1 ]; then
 fi
 
 # Grab the command line arguments
-
-#logfile=$1
-#oldlog=$2
-#query=$3
 exitstatus=$STATE_WARNING #default
 while test -n "$1"; do
     case "$1" in
-        --help)
+        -h | --help)
             print_help
             exit "$STATE_OK"
             ;;
-        -h)
-            print_help
-            exit "$STATE_OK"
-            ;;
-        --version)
+        -V | --version)
             print_revision "$PROGNAME" "$REVISION"
             exit "$STATE_OK"
             ;;
-        -V)
-            print_revision "$PROGNAME" "$REVISION"
-            exit "$STATE_OK"
-            ;;
-        --filename)
+        -F | --filename)
             logfile=$2
             shift 2
             ;;
-        -F)
-            logfile=$2
-            shift 2
-            ;;
-        --oldlog)
+        -O | --oldlog)
             oldlog=$2
             shift 2
             ;;
-        -O)
-            oldlog=$2
-            shift 2
-            ;;
-        --query)
+        -q | --query)
             query=$2
             shift 2
             ;;
-        -q)
-            query=$2
+        --exclude)
+            exclude=$2
             shift 2
             ;;
-        -x)
+        -x | --exitstatus)
             exitstatus=$2
             shift 2
             ;;
-        --exitstatus)
-            exitstatus=$2
-            shift 2
-            ;;
-        --extended-regex)
+        -e | --extended-regex)
             ERE=1
             shift
             ;;
-        -e)
-            ERE=1
-            shift
-            ;;
-        --perl-regex)
+        -p | --perl-regex)
             PRE=1
             shift
             ;;
-        -p)
-            PRE=1
-            shift
-            ;;
-        --all)
-            ALL=1
-            shift
-            ;;
-        -a)
+        -a | --all)
             ALL=1
             shift
             ;;
@@ -213,8 +178,8 @@ elif [ ! -r "$logfile" ] ; then
 fi
 # If no oldlog was given this can not work properly, abort then
 if [ -z "$oldlog" ]; then
-       echo "Oldlog parameter is needed"
-       exit $STATE_UNKNOWN
+    echo "Oldlog parameter is needed"
+    exit $STATE_UNKNOWN
 fi
 
 # If the old log file doesn't exist, this must be the first time
@@ -245,18 +210,24 @@ diff "$logfile" "$oldlog" | grep -v "^>" > "$tempdiff"
 
 
 if [ $ALL ]; then
-	# Get the last matching entry in the diff file
-	entry=$($GREP "$query" "$tempdiff")
-
-	# Count the number of matching log entries we have
-	count=$(echo "$entry" | wc -l)
+    # Get all matching entries in the diff file
+    if [ -n "$exclude" ]; then
+        entry=$($GREP "$query" "$tempdiff" | $GREP -v "$exclude")
+        count=$($GREP "$query" "$tempdiff" | $GREP -vc "$exclude")
+    else
+        entry=$($GREP "$query" "$tempdiff")
+        count=$($GREP -c "$query" "$tempdiff")
+    fi
 
 else
-	# Count the number of matching log entries we have
-	count=$($GREP -c "$query" "$tempdiff")
-
-	# Get the last matching entry in the diff file
-	entry=$($GREP "$query" "$tempdiff" | tail -1)
+    # Get the last matching entry in the diff file
+    if [ -n "$exclude" ]; then
+        entry=$($GREP "$query" "$tempdiff" | $GREP -v "$exclude" | tail -1)
+        count=$($GREP "$query" "$tempdiff" | $GREP -vc "$exclude")
+    else
+        entry=$($GREP "$query" "$tempdiff" | tail -1)
+        count=$($GREP -c "$query" "$tempdiff")
+    fi
 fi
 
 rm -f "$tempdiff"

--- a/plugins-scripts/check_log.sh
+++ b/plugins-scripts/check_log.sh
@@ -153,18 +153,18 @@ done
 
 # Parameter sanity check
 if [ $ERE ] && [ $PRE ] ; then
-	echo "Can not use extended and perl regex at the same time"
-	exit "$STATE_UNKNOWN"
+    echo "Can not use extended and perl regex at the same time"
+    exit "$STATE_UNKNOWN"
 fi
 
 GREP="grep"
 
 if [ $ERE ]; then
-	GREP="grep -E"
+    GREP="grep -E"
 fi
 
 if [ $PRE ]; then
-	GREP="grep -P"
+    GREP="grep -P"
 fi
 
 # If the source log file doesn't exist, exit

--- a/plugins-scripts/t/check_log.t
+++ b/plugins-scripts/t/check_log.t
@@ -1,0 +1,82 @@
+#!/usr/bin/perl -w -I ..
+#
+# check_log tests
+#
+#
+
+use strict;
+use Test::More;
+use NPTest;
+
+my $tests = 18;
+plan tests => $tests;
+
+my $firstTimeOutput ='/^Log check data initialized/';
+my $okOutput = '/^Log check ok - 0 pattern matches found/';
+my $criticalOutput = '/^\(\d+\) < /';
+my $multilineOutput = '/\(3\) <.*\n.*\n.*$/';
+my $unknownOutput = '/^Usage: /';
+my $unknownArgOutput = '/^Unknown argument: /';
+my $bothRegexOutput = '/^Can not use extended and perl regex/';
+
+my $result;
+my $temp_file = "/tmp/check_log.tmp";
+my $oldlog = "/tmp/oldlog.tmp";
+
+open(FH, '>', $temp_file) or die $!;
+close(FH);
+
+$result = NPTest->testCmd("./check_log");
+cmp_ok( $result->return_code, '==', 3, "Missing parameters" );
+like  ( $result->output, $unknownOutput, "Output for unknown correct" );
+
+$result = NPTest->testCmd("./check_log -f");
+cmp_ok( $result->return_code, '==', 3, "Wrong parameters" );
+like  ( $result->output, $unknownArgOutput, "Output for unknown correct" );
+
+$result = NPTest->testCmd("./check_log -F ".$temp_file." -O ".$oldlog." -q 'Simple match' -e -p");
+cmp_ok( $result->return_code, '==', 3, "Both regex parameters" );
+like  ( $result->output, $bothRegexOutput, "Output for unknown correct" );
+
+$result = NPTest->testCmd("./check_log -F ".$temp_file." -O ".$oldlog." -q 'Simple match'");
+cmp_ok( $result->return_code, '==', 0, "First time executing" );
+like  ( $result->output, $firstTimeOutput, "Output for first time executing correct" );
+
+open(FH, '>>', $temp_file) or die $!;
+print FH "This is some text, that should not match\n";
+close(FH);
+
+$result = NPTest->testCmd("./check_log -F ".$temp_file." -O ".$oldlog." -q 'No match'");
+cmp_ok( $result->return_code, '==', 0, "No match" );
+like  ( $result->output, $okOutput, "Output for no match correct" );
+
+open(FH, '>>', $temp_file) or die $!;
+print FH "This text should match\n";
+close(FH);
+
+$result = NPTest->testCmd("./check_log -F ".$temp_file." -O ".$oldlog." -q 'should match'");
+cmp_ok( $result->return_code, '==', 2, "Pattern match" );
+like  ( $result->output, $criticalOutput, "Output for match correct" );
+
+open(FH, '>>', $temp_file) or die $!;
+print FH "This text should not match, because it is excluded\n";
+close(FH);
+
+$result = NPTest->testCmd("./check_log -F ".$temp_file." -O ".$oldlog." -q 'match' --exclude 'because'");
+cmp_ok( $result->return_code, '==', 0, "Exclude a pattern" );
+like  ( $result->output, $okOutput, "Output for no match correct" );
+
+open(FH, '>>', $temp_file) or die $!;
+print FH "Trying\nwith\nmultiline\nignore me\n";
+close(FH);
+
+$result = NPTest->testCmd("./check_log -F ".$temp_file." -O ".$oldlog." -q 'Trying\\|with\\|multiline\\|ignore' --exclude 'me' --all");
+cmp_ok( $result->return_code, '==', 2, "Multiline pattern match with --all" );
+like  ( $result->output, $multilineOutput, "Output for multiline match correct" );
+
+$result = NPTest->testCmd("./check_log -F ".$temp_file." -O ".$oldlog." -q 'match' -a");
+cmp_ok( $result->return_code, '==', 0, "Non matching --all" );
+like  ( $result->output, $okOutput, "Output for no match correct" );
+
+unlink($oldlog);
+unlink($temp_file);


### PR DESCRIPTION
Added --exclude to exclude patterns
Cleaned up duplicated code in the args
Fixed a bug when using --all because the count always returned "1" even when nothing matched

entry=$($GREP "$query" "$tempdiff")
count=$(echo "$entry" | wc -l)

Example:

$ touch testfile
$ TEST123=$(grep 'test' testfile)
$ echo "$TEST123" | wc -l
1