### PR TITLE
check_curl.c: bugfix: in hostname lookup, use the first address returned by resolver

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -383,7 +383,7 @@ handle_curl_option_return_code (CURLcode res, const char* option)
 int
 lookup_host (const char *host, char *buf, size_t buflen)
 {
-  struct addrinfo hints, *res, *result;
+  struct addrinfo hints, *res;
   int errcode;
   void *ptr;
 
@@ -392,13 +392,10 @@ lookup_host (const char *host, char *buf, size_t buflen)
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_flags |= AI_CANONNAME;
 
-  errcode = getaddrinfo (host, NULL, &hints, &result);
+  errcode = getaddrinfo (host, NULL, &hints, &res);
   if (errcode != 0)
     return errcode;
-  
-  res = result;
 
-  while (res) {
   inet_ntop (res->ai_family, res->ai_addr->sa_data, buf, buflen);
   switch (res->ai_family) {
     case AF_INET:
@@ -406,16 +403,15 @@ lookup_host (const char *host, char *buf, size_t buflen)
       break;
     case AF_INET6:
       ptr = &((struct sockaddr_in6 *) res->ai_addr)->sin6_addr;
-    break;
-    }
-    inet_ntop (res->ai_family, ptr, buf, buflen);
-    if (verbose >= 1)
-      printf ("* getaddrinfo IPv%d address: %s\n",
-        res->ai_family == PF_INET6 ? 6 : 4, buf);
-    res = res->ai_next;
+      break;
   }
-  
-  freeaddrinfo(result);
+  inet_ntop (res->ai_family, ptr, buf, buflen);
+
+  if (verbose >= 1)
+    printf ("* getaddrinfo IPv%d address: %s\n",
+      res->ai_family == PF_INET6 ? 6 : 4, buf);
+
+  freeaddrinfo(res);
 
   return 0;
 }


### PR DESCRIPTION
Solves Issue: https://github.com/monitoring-plugins/monitoring-plugins/issues/1844

A previous commit fixed a bug by populating curl's DNS resolver cache with the IP address for the host being tested: https://github.com/monitoring-plugins/monitoring-plugins/commit/3f5c54c7830b0529030bb08e2c333497e70b6eb1

It's behaviour is to cycle through all IP matches for the hostname, saving the last one for use by the check. This violates the DNS>IP precedence rules defined in `/etc/gai.conf`, which specify which IPs are returned first when querying DNS (and should therefore be used for connections). For example, `/etc/gai.conf` can be configured to prefer IPv4 or IPv6 by default, if no specific protocol was requested.

This PR changes that behaviour to save the first IP address returned by the resolver, without cycling through all other IPs found.

### Before

```
# ./check_curl -H uptime.com -S -v
* getaddrinfo IPv6 address: 2600:9000:21a8:4000:15:e39f:8a40:93a1
* getaddrinfo IPv6 address: 2600:9000:21a8:5a00:15:e39f:8a40:93a1
* getaddrinfo IPv6 address: 2600:9000:21a8:7000:15:e39f:8a40:93a1
* getaddrinfo IPv6 address: 2600:9000:21a8:8c00:15:e39f:8a40:93a1
* getaddrinfo IPv6 address: 2600:9000:21a8:a200:15:e39f:8a40:93a1
* getaddrinfo IPv6 address: 2600:9000:21a8:ac00:15:e39f:8a40:93a1
* getaddrinfo IPv6 address: 2600:9000:21a8:3200:15:e39f:8a40:93a1
* getaddrinfo IPv6 address: 2600:9000:21a8:3e00:15:e39f:8a40:93a1
* getaddrinfo IPv4 address: 13.224.222.71
* getaddrinfo IPv4 address: 13.224.222.128
* getaddrinfo IPv4 address: 13.224.222.24
* getaddrinfo IPv4 address: 13.224.222.56
* curl CURLOPT_RESOLVE: uptime.com:443:13.224.222.56
* curl CURLOPT_URL: https://uptime.com:443/
* Added uptime.com:443:13.224.222.56 to DNS cache
* Hostname uptime.com was found in DNS cache
*   Trying 13.224.222.56:443...
```

### After

```
# ./check_curl -H uptime.com -S -v
* getaddrinfo IPv6 address: 2600:9000:21a8:1600:15:e39f:8a40:93a1
* curl CURLOPT_RESOLVE: uptime.com:443:2600:9000:21a8:1600:15:e39f:8a40:93a1
* curl CURLOPT_URL: https://uptime.com:443/
* Added uptime.com:443:2600:9000:21a8:1600:15:e39f:8a40:93a1 to DNS cache
* Hostname uptime.com was found in DNS cache
*   Trying 2600:9000:21a8:1600:15:e39f:8a40:93a1:443...
```