### PR TITLE
check_curl: fix test plan

### DIFF
--- a/plugins/t/check_curl.t
+++ b/plugins/t/check_curl.t
@@ -13,7 +13,7 @@ use vars qw($tests $has_ipv6);
 BEGIN {
     use NPTest;
     $has_ipv6 = NPTest::has_ipv6();
-    $tests = $has_ipv6 ? 59 : 57;
+    $tests = $has_ipv6 ? 59 : 58;
     plan tests => $tests;
 }
 


### PR DESCRIPTION
Fix test plan when run with NPTest::has_ipv6 = false. 

Signed-off-by: Jerson Dumalaon <jdumalaon@itrsgroup.com>