### PR TITLE
Fix 'requres' typo

### DIFF
--- a/plugins/check_nwstat.c
+++ b/plugins/check_nwstat.c
@@ -1668,7 +1668,7 @@ void print_help(void)
 
   printf ("\n");
   printf ("%s\n", _("Notes:"));
-	printf (" %s\n", _("- This plugin requres that the MRTGEXT.NLM file from James Drews' MRTG"));
+	printf (" %s\n", _("- This plugin requires that the MRTGEXT.NLM file from James Drews' MRTG"));
   printf (" %s\n", _("  extension for NetWare be loaded on the Novell servers you wish to check."));
   printf (" %s\n", _("  (available from http://www.engr.wisc.edu/~drews/mrtg/)"));
   printf (" %s\n", _("- Values for critical thresholds should be lower than warning thresholds"));

--- a/po/de.po
+++ b/po/de.po
@@ -3315,7 +3315,7 @@ msgid "Include server version string in results"
 msgstr ""
 
 #: plugins/check_nwstat.c:1671
-msgid "- This plugin requres that the MRTGEXT.NLM file from James Drews' MRTG"
+msgid "- This plugin requires that the MRTGEXT.NLM file from James Drews' MRTG"
 msgstr ""
 
 #: plugins/check_nwstat.c:1672

--- a/po/fr.po
+++ b/po/fr.po
@@ -3372,7 +3372,7 @@ msgid "Include server version string in results"
 msgstr ""
 
 #: plugins/check_nwstat.c:1671
-msgid "- This plugin requres that the MRTGEXT.NLM file from James Drews' MRTG"
+msgid "- This plugin requires that the MRTGEXT.NLM file from James Drews' MRTG"
 msgstr ""
 
 #: plugins/check_nwstat.c:1672

--- a/po/monitoring-plugins.pot
+++ b/po/monitoring-plugins.pot
@@ -3225,7 +3225,7 @@ msgid "Include server version string in results"
 msgstr ""
 
 #: plugins/check_nwstat.c:1671
-msgid "- This plugin requres that the MRTGEXT.NLM file from James Drews' MRTG"
+msgid "- This plugin requires that the MRTGEXT.NLM file from James Drews' MRTG"
 msgstr ""
 
 #: plugins/check_nwstat.c:1672


### PR DESCRIPTION
There is just that one obvious typo that bothered me.  
Here's a fix I hope (I `grep`ed for every occurrence).