### PR TITLE
check_mysql: handle ER_ACCESS_DENIED_NO_PASSWORD_ERROR if ignore_auth=1

### DIFF
--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -138,7 +138,10 @@ main (int argc, char **argv)
 		mysql_ssl_set(&mysql,key,cert,ca_cert,ca_dir,ciphers);
 	/* establish a connection to the server and error checking */
 	if (!mysql_real_connect(&mysql,db_host,db_user,db_pass,db,db_port,db_socket,0)) {
-		if (ignore_auth && mysql_errno (&mysql) == ER_ACCESS_DENIED_ERROR)
+		/* Depending on internally-selected auth plugin MySQL might return */
+		/* ER_ACCESS_DENIED_NO_PASSWORD_ERROR or ER_ACCESS_DENIED_ERROR. */
+		/* Semantically these errors are the same. */
+		if (ignore_auth && (mysql_errno (&mysql) == ER_ACCESS_DENIED_ERROR || mysql_errno (&mysql) == ER_ACCESS_DENIED_NO_PASSWORD_ERROR))
 		{
 			printf("MySQL OK - Version: %s (protocol %d)\n",
 				mysql_get_server_info(&mysql),


### PR DESCRIPTION
tl;dr - in some situations MySQL might return ER_ACCESS_DENIED_NO_PASSWORD_ERROR instead of ER_ACCESS_DENIED_ERROR, and that results in error being returned even when --ignore-auth option is provided.

This patch handles the second error code and returns OK as expected.

<hr>

Below is an explanation of why that other error code might be returned.

The error code to be returned is determined here: https://github.com/MariaDB/server/blob/11.1/sql/sql_acl.h#L65

In most cases, the `passwd_used` is not 2, and ER_ACCESS_DENIED_ERROR is returned. However if authentication happens via `unix_socket` plugin, passwd_used will be set to PASSWORD_USED_NO_MENTION (2).

If the check is done using some unknown username (`nagios` for example), [MySQL will select a random account](https://github.com/MariaDB/server/blob/11.1/sql/sql_acl.cc#L13490) and authenticate as if that random account username was used. Random account is selected using the incoming original username as a "random seed", thus most of the time the behavior will be stable. But the funny side effect of this implementation is that if unrelated MySQL user is added or deleted the selected random account will also change, and check_mysql might start receiving a different error code.