### PR TITLE
check_smtp: Add option to prefix PROXY header

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -52,6 +52,7 @@ int days_till_exp_warn, days_till_exp_crit;
 enum {
 	SMTP_PORT	= 25
 };
+#define PROXY_PREFIX "PROXY TCP4 0.0.0.0 0.0.0.0 25 25\r\n"
 #define SMTP_EXPECT "220"
 #define SMTP_HELO "HELO "
 #define SMTP_EHLO "EHLO "
@@ -102,6 +103,7 @@ double critical_time = 0;
 int check_critical_time = FALSE;
 int verbose = 0;
 int use_ssl = FALSE;
+short use_proxy_prefix = FALSE;
 short use_ehlo = FALSE;
 short use_lhlo = FALSE;
 short ssl_established = 0;
@@ -183,6 +185,13 @@ main (int argc, char **argv)
 	result = my_tcp_connect (server_address, server_port, &sd);
 
 	if (result == STATE_OK) { /* we connected */
+
+		/* If requested, send PROXY header */
+		if (use_proxy_prefix) {
+			if (verbose)
+				printf ("Sending header %s\n", PROXY_PREFIX);
+			send(sd, PROXY_PREFIX, strlen(PROXY_PREFIX), 0);
+		}
 
 		/* watch for the SMTP connection string and */
 		/* return a WARNING status if we couldn't read any data */
@@ -478,6 +487,7 @@ process_arguments (int argc, char **argv)
 		{"starttls",no_argument,0,'S'},
 		{"certificate",required_argument,0,'D'},
 		{"ignore-quit-failure",no_argument,0,'q'},
+		{"proxy",no_argument,0,'r'},
 		{0, 0, 0, 0}
 	};
 
@@ -494,7 +504,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	while (1) {
-		c = getopt_long (argc, argv, "+hVv46Lt:p:f:e:c:w:H:C:R:SD:F:A:U:P:q",
+		c = getopt_long (argc, argv, "+hVv46Lrt:p:f:e:c:w:H:C:R:SD:F:A:U:P:q",
 		                 longopts, &option);
 
 		if (c == -1 || c == EOF)
@@ -620,6 +630,9 @@ process_arguments (int argc, char **argv)
 		/* starttls */
 			use_ssl = TRUE;
 			use_ehlo = TRUE;
+			break;
+		case 'r':
+			use_proxy_prefix = TRUE;
 			break;
 		case 'L':
 			use_lhlo = TRUE;
@@ -819,6 +832,8 @@ print_help (void)
   printf ("    %s\n", _("FROM-address to include in MAIL command, required by Exchange 2000")),
   printf (" %s\n", "-F, --fqdn=STRING");
   printf ("    %s\n", _("FQDN used for HELO"));
+  printf (" %s\n", "-r, --proxy");
+  printf ("    %s\n", _("Use PROXY protocol prefix for the connection."));
 #ifdef HAVE_SSL
   printf (" %s\n", "-D, --certificate=INTEGER[,INTEGER]");
   printf ("    %s\n", _("Minimum number of days a certificate has to be valid."));

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -3,7 +3,7 @@
 * Monitoring check_smtp plugin
 * 
 * License: GPL
-* Copyright (c) 2000-2007 Monitoring Plugins Development Team
+* Copyright (c) 2000-2023 Monitoring Plugins Development Team
 * 
 * Description:
 * 

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -875,6 +875,6 @@ print_usage (void)
   printf ("%s\n", _("Usage:"));
   printf ("%s -H host [-p port] [-4|-6] [-e expect] [-C command] [-R response] [-f from addr]\n", progname);
   printf ("[-A authtype -U authuser -P authpass] [-w warn] [-c crit] [-t timeout] [-q]\n");
-  printf ("[-F fqdn] [-S] [-L] [-D warn days cert expire[,crit days cert expire]] [-v] \n");
+  printf ("[-F fqdn] [-S] [-L] [-D warn days cert expire[,crit days cert expire]] [-r] [-v] \n");
 }
 

--- a/po/de.po
+++ b/po/de.po
@@ -4768,7 +4768,7 @@ msgstr ""
 
 #: plugins/check_smtp.c:836
 msgid "Use PROXY protocol prefix for the connection."
-msgstr ""
+msgstr "Benutze PROXY-Protokoll-Präfix für die Verbindung."
 
 #: plugins/check_smtp.c:839 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."

--- a/po/de.po
+++ b/po/de.po
@@ -9,111 +9,114 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nagiosplug\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2014-01-19 16:30-0500\n"
+"POT-Creation-Date: 2023-06-12 16:29+0200\n"
 "PO-Revision-Date: 2004-12-23 17:46+0100\n"
 "Last-Translator:  <>\n"
 "Language-Team: English <en@li.org>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=iso-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms:  nplurals=2; plural=(n > 1);X-Generator: KBabel 1.3.1\n"
 
-#: plugins/check_by_ssh.c:86 plugins/check_cluster.c:76 plugins/check_dig.c:88
-#: plugins/check_disk.c:194 plugins/check_dns.c:102 plugins/check_dummy.c:52
-#: plugins/check_fping.c:93 plugins/check_game.c:82 plugins/check_hpjd.c:103
-#: plugins/check_http.c:167 plugins/check_ldap.c:109 plugins/check_load.c:122
-#: plugins/check_mrtgtraf.c:83 plugins/check_mysql.c:122
-#: plugins/check_nagios.c:91 plugins/check_nt.c:127 plugins/check_ntp.c:770
-#: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:552
+#: plugins/check_by_ssh.c:88 plugins/check_cluster.c:76 plugins/check_dig.c:91
+#: plugins/check_disk.c:206 plugins/check_dns.c:106 plugins/check_dummy.c:52
+#: plugins/check_fping.c:95 plugins/check_game.c:82 plugins/check_hpjd.c:105
+#: plugins/check_http.c:174 plugins/check_ldap.c:118 plugins/check_load.c:128
+#: plugins/check_mrtgtraf.c:83 plugins/check_mysql.c:124
+#: plugins/check_nagios.c:91 plugins/check_nt.c:127 plugins/check_ntp.c:780
+#: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:557
 #: plugins/check_nwstat.c:173 plugins/check_overcr.c:102
-#: plugins/check_pgsql.c:172 plugins/check_ping.c:95 plugins/check_procs.c:172
-#: plugins/check_radius.c:160 plugins/check_real.c:80 plugins/check_smtp.c:144
-#: plugins/check_snmp.c:240 plugins/check_ssh.c:73 plugins/check_swap.c:110
-#: plugins/check_tcp.c:218 plugins/check_time.c:78 plugins/check_ups.c:122
-#: plugins/check_users.c:77 plugins/negate.c:214 plugins-root/check_dhcp.c:270
+#: plugins/check_pgsql.c:174 plugins/check_ping.c:97 plugins/check_procs.c:176
+#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:145
+#: plugins/check_snmp.c:248 plugins/check_ssh.c:74 plugins/check_swap.c:115
+#: plugins/check_tcp.c:222 plugins/check_time.c:78 plugins/check_ups.c:122
+#: plugins/check_users.c:84 plugins/negate.c:210 plugins-root/check_dhcp.c:270
 msgid "Could not parse arguments"
 msgstr "Argumente konnten nicht ausgewertet werden"
 
-#: plugins/check_by_ssh.c:90 plugins/check_dig.c:82 plugins/check_dns.c:95
-#: plugins/check_nagios.c:95 plugins/check_pgsql.c:178 plugins/check_ping.c:99
-#: plugins/check_procs.c:188 plugins/check_snmp.c:336 plugins/negate.c:79
+#: plugins/check_by_ssh.c:92 plugins/check_dig.c:85 plugins/check_dns.c:99
+#: plugins/check_nagios.c:95 plugins/check_pgsql.c:180 plugins/check_ping.c:101
+#: plugins/check_procs.c:192 plugins/check_snmp.c:348 plugins/negate.c:78
 msgid "Cannot catch SIGALRM"
 msgstr "Konnte SIGALRM nicht erhalten"
 
-#: plugins/check_by_ssh.c:110
+#: plugins/check_by_ssh.c:107
+#, c-format
+msgid "SSH connection failed: %s\n"
+msgstr ""
+
+#: plugins/check_by_ssh.c:126
 #, c-format
 msgid "Remote command execution failed: %s\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:122
+#: plugins/check_by_ssh.c:141
 #, c-format
 msgid "%s - check_by_ssh: Remote command '%s' returned status %d\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:134
+#: plugins/check_by_ssh.c:153
 #, c-format
 msgid "SSH WARNING: could not open %s\n"
 msgstr "SSH WARNING: Konnte %s nicht öffnen\n"
 
-#: plugins/check_by_ssh.c:143
+#: plugins/check_by_ssh.c:162
 #, c-format
 msgid "%s: Error parsing output\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:220 plugins/check_disk.c:476
-#: plugins/check_http.c:278 plugins/check_ldap.c:293 plugins/check_pgsql.c:311
-#: plugins/check_procs.c:437 plugins/check_radius.c:308
-#: plugins/check_real.c:356 plugins/check_smtp.c:581 plugins/check_snmp.c:736
-#: plugins/check_ssh.c:138 plugins/check_tcp.c:505 plugins/check_time.c:302
-#: plugins/check_ups.c:556 plugins/negate.c:164
+#: plugins/check_by_ssh.c:242 plugins/check_disk.c:568 plugins/check_http.c:292
+#: plugins/check_ldap.c:334 plugins/check_pgsql.c:314 plugins/check_procs.c:461
+#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:601
+#: plugins/check_snmp.c:789 plugins/check_ssh.c:140 plugins/check_tcp.c:519
+#: plugins/check_time.c:302 plugins/check_ups.c:559 plugins/negate.c:160
 msgid "Timeout interval must be a positive integer"
 msgstr "Timeout interval muss ein positiver Integer sein"
 
-#: plugins/check_by_ssh.c:230 plugins/check_pgsql.c:341
-#: plugins/check_radius.c:272 plugins/check_real.c:327
-#: plugins/check_smtp.c:506 plugins/check_tcp.c:511 plugins/check_time.c:296
-#: plugins/check_ups.c:518
+#: plugins/check_by_ssh.c:254 plugins/check_pgsql.c:344
+#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:526
+#: plugins/check_tcp.c:525 plugins/check_time.c:296 plugins/check_ups.c:521
 msgid "Port must be a positive integer"
 msgstr "Port muss ein positiver Integer sein"
 
-#: plugins/check_by_ssh.c:291
+#: plugins/check_by_ssh.c:315
 #, fuzzy
 msgid "skip-stdout argument must be an integer"
 msgstr "skip-stdout argument muss ein Integer sein"
 
-#: plugins/check_by_ssh.c:299
+#: plugins/check_by_ssh.c:323
 #, fuzzy
 msgid "skip-stderr argument must be an integer"
 msgstr "skip-stderr argument muss ein Integer sein"
 
-#: plugins/check_by_ssh.c:322
+#: plugins/check_by_ssh.c:349
 #, c-format
 msgid "%s: You must provide a host name\n"
 msgstr "%s: Hostname muss angegeben werden\n"
 
-#: plugins/check_by_ssh.c:340
+#: plugins/check_by_ssh.c:366
 msgid "No remotecmd"
 msgstr "Kein remotecm"
 
-#: plugins/check_by_ssh.c:354
+#: plugins/check_by_ssh.c:380
 #, c-format
 msgid "%s: Argument limit of %d exceeded\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:357
+#: plugins/check_by_ssh.c:383
 #, fuzzy
 msgid "Can not (re)allocate 'commargv' buffer\n"
 msgstr "Konnte·url·nicht·zuweisen\n"
 
-#: plugins/check_by_ssh.c:371
+#: plugins/check_by_ssh.c:397
 #, c-format
 msgid ""
 "%s: In passive mode, you must provide a service name for each command.\n"
 msgstr ""
 "%s: Im passive mode muss ein Servicename für jeden Befehl angegeben werden.\n"
 
-#: plugins/check_by_ssh.c:374
+#: plugins/check_by_ssh.c:400
 #, fuzzy, c-format
 msgid ""
 "%s: In passive mode, you must provide the host short name from the "
@@ -122,262 +125,270 @@ msgstr ""
 "%s: Im passive mode muss der \"host short name\" aus der Nagios "
 "Konfiguration angegeben werden\n"
 
-#: plugins/check_by_ssh.c:388
+#: plugins/check_by_ssh.c:414
 #, fuzzy, c-format
 msgid "This plugin uses SSH to execute commands on a remote host"
 msgstr ""
 "Dieses Plugin nutzt SSH um Befehle auf dem entfernten Rechner auszuführen\n"
 "\n"
 
-#: plugins/check_by_ssh.c:403
+#: plugins/check_by_ssh.c:429
 msgid "tell ssh to use Protocol 1 [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:405
+#: plugins/check_by_ssh.c:431
 msgid "tell ssh to use Protocol 2 [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:407
+#: plugins/check_by_ssh.c:433
 msgid "Ignore all or (if specified) first n lines on STDOUT [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:409
+#: plugins/check_by_ssh.c:435
 msgid "Ignore all or (if specified) first n lines on STDERR [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:411
+#: plugins/check_by_ssh.c:437
+msgid "Exit with an warning, if there is an output on STDERR"
+msgstr ""
+
+#: plugins/check_by_ssh.c:439
 msgid ""
 "tells ssh to fork rather than create a tty [optional]. This will always "
 "return OK if ssh is executed"
 msgstr ""
 
-#: plugins/check_by_ssh.c:413
+#: plugins/check_by_ssh.c:441
 msgid "command to execute on the remote machine"
 msgstr ""
 
-#: plugins/check_by_ssh.c:415
+#: plugins/check_by_ssh.c:443
 msgid "SSH user name on remote host [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:417
+#: plugins/check_by_ssh.c:445
 msgid "identity of an authorized key [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:419
+#: plugins/check_by_ssh.c:447
 msgid "external command file for monitoring [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:421
+#: plugins/check_by_ssh.c:449
 msgid "list of monitoring service names, separated by ':' [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:423
+#: plugins/check_by_ssh.c:451
 msgid "short name of host in the monitoring configuration [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:425
+#: plugins/check_by_ssh.c:453
 msgid "Call ssh with '-o OPTION' (may be used multiple times) [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:427
+#: plugins/check_by_ssh.c:455
 msgid "Tell ssh to use this configfile [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:429
+#: plugins/check_by_ssh.c:457
 msgid "Tell ssh to suppress warning and diagnostic messages [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:434
+#: plugins/check_by_ssh.c:461
+msgid "Make connection problems return UNKNOWN instead of CRITICAL"
+msgstr ""
+
+#: plugins/check_by_ssh.c:464
 msgid "The most common mode of use is to refer to a local identity file with"
 msgstr ""
 
-#: plugins/check_by_ssh.c:435
+#: plugins/check_by_ssh.c:465
 msgid "the '-i' option. In this mode, the identity pair should have a null"
 msgstr ""
 
-#: plugins/check_by_ssh.c:436
+#: plugins/check_by_ssh.c:466
 msgid "passphrase and the public key should be listed in the authorized_keys"
 msgstr ""
 
-#: plugins/check_by_ssh.c:437
+#: plugins/check_by_ssh.c:467
 msgid "file of the remote host. Usually the key will be restricted to running"
 msgstr ""
 
-#: plugins/check_by_ssh.c:438
+#: plugins/check_by_ssh.c:468
 msgid "only one command on the remote server. If the remote SSH server tracks"
 msgstr ""
 
-#: plugins/check_by_ssh.c:439
+#: plugins/check_by_ssh.c:469
 msgid "invocation arguments, the one remote program may be an agent that can"
 msgstr ""
 
-#: plugins/check_by_ssh.c:440
+#: plugins/check_by_ssh.c:470
 msgid "execute additional commands as proxy"
 msgstr ""
 
-#: plugins/check_by_ssh.c:442
+#: plugins/check_by_ssh.c:472
 msgid "To use passive mode, provide multiple '-C' options, and provide"
 msgstr ""
 
-#: plugins/check_by_ssh.c:443
+#: plugins/check_by_ssh.c:473
 msgid ""
 "all of -O, -s, and -n options (servicelist order must match '-C'options)"
 msgstr ""
 
-#: plugins/check_by_ssh.c:445 plugins/check_cluster.c:261
-#: plugins/check_dig.c:355 plugins/check_disk.c:924 plugins/check_http.c:1560
-#: plugins/check_nagios.c:312 plugins/check_ntp.c:869
-#: plugins/check_ntp_peer.c:705 plugins/check_ntp_time.c:633
-#: plugins/check_procs.c:763 plugins/negate.c:271 plugins/urlize.c:180
+#: plugins/check_by_ssh.c:475 plugins/check_cluster.c:271
+#: plugins/check_dig.c:364 plugins/check_disk.c:1000 plugins/check_http.c:1845
+#: plugins/check_nagios.c:312 plugins/check_ntp.c:879
+#: plugins/check_ntp_peer.c:733 plugins/check_ntp_time.c:642
+#: plugins/check_procs.c:806 plugins/negate.c:249 plugins/urlize.c:179
 msgid "Examples:"
 msgstr ""
 
-#: plugins/check_by_ssh.c:460 plugins/check_cluster.c:274
-#: plugins/check_dig.c:367 plugins/check_disk.c:941 plugins/check_dns.c:486
-#: plugins/check_dummy.c:122 plugins/check_fping.c:505
-#: plugins/check_game.c:331 plugins/check_hpjd.c:414 plugins/check_http.c:1590
-#: plugins/check_ldap.c:451 plugins/check_load.c:334 plugins/check_mrtg.c:382
-#: plugins/check_mysql.c:569 plugins/check_nagios.c:323 plugins/check_nt.c:774
-#: plugins/check_ntp.c:888 plugins/check_ntp_peer.c:725
-#: plugins/check_ntp_time.c:642 plugins/check_nwstat.c:1685
-#: plugins/check_overcr.c:467 plugins/check_pgsql.c:578
-#: plugins/check_ping.c:603 plugins/check_procs.c:781
-#: plugins/check_radius.c:385 plugins/check_real.c:451
-#: plugins/check_smtp.c:843 plugins/check_snmp.c:1207 plugins/check_ssh.c:309
-#: plugins/check_swap.c:558 plugins/check_tcp.c:684 plugins/check_time.c:371
-#: plugins/check_ups.c:660 plugins/check_users.c:240
-#: plugins/check_ide_smart.c:640 plugins/negate.c:295 plugins/urlize.c:197
-#: plugins-root/check_dhcp.c:1422 plugins-root/check_icmp.c:1354
+#: plugins/check_by_ssh.c:490 plugins/check_cluster.c:284
+#: plugins/check_dig.c:376 plugins/check_disk.c:1017 plugins/check_dns.c:617
+#: plugins/check_dummy.c:122 plugins/check_fping.c:524 plugins/check_game.c:331
+#: plugins/check_hpjd.c:439 plugins/check_http.c:1883 plugins/check_ldap.c:511
+#: plugins/check_load.c:372 plugins/check_mrtg.c:382 plugins/check_mysql.c:587
+#: plugins/check_nagios.c:323 plugins/check_nt.c:797 plugins/check_ntp.c:898
+#: plugins/check_ntp_peer.c:753 plugins/check_ntp_time.c:651
+#: plugins/check_nwstat.c:1685 plugins/check_overcr.c:467
+#: plugins/check_pgsql.c:551 plugins/check_ping.c:617 plugins/check_procs.c:829
+#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:875
+#: plugins/check_snmp.c:1346 plugins/check_ssh.c:325 plugins/check_swap.c:607
+#: plugins/check_tcp.c:710 plugins/check_time.c:371 plugins/check_ups.c:663
+#: plugins/check_users.c:262 plugins/check_ide_smart.c:606 plugins/negate.c:273
+#: plugins/urlize.c:196 plugins-root/check_dhcp.c:1390
+#: plugins-root/check_icmp.c:1628
 msgid "Usage:"
 msgstr ""
 
-#: plugins/check_cluster.c:230
+#: plugins/check_cluster.c:240
 #, c-format
 msgid "Host/Service Cluster Plugin for Monitoring"
 msgstr ""
 
-#: plugins/check_cluster.c:236 plugins/check_nt.c:676
+#: plugins/check_cluster.c:246 plugins/check_nt.c:697
 msgid "Options:"
 msgstr ""
 
-#: plugins/check_cluster.c:239
+#: plugins/check_cluster.c:249
 msgid "Check service cluster status"
 msgstr ""
 
-#: plugins/check_cluster.c:241
+#: plugins/check_cluster.c:251
 msgid "Check host cluster status"
 msgstr ""
 
-#: plugins/check_cluster.c:243
+#: plugins/check_cluster.c:253
 msgid "Optional prepended text output (i.e. \"Host cluster\")"
 msgstr ""
 
-#: plugins/check_cluster.c:245 plugins/check_cluster.c:248
+#: plugins/check_cluster.c:255 plugins/check_cluster.c:258
 msgid "Specifies the range of hosts or services in cluster that must be in a"
 msgstr ""
 
-#: plugins/check_cluster.c:246
+#: plugins/check_cluster.c:256
 msgid "non-OK state in order to return a WARNING status level"
 msgstr ""
 
-#: plugins/check_cluster.c:249
+#: plugins/check_cluster.c:259
 msgid "non-OK state in order to return a CRITICAL status level"
 msgstr ""
 
-#: plugins/check_cluster.c:251
+#: plugins/check_cluster.c:261
 msgid "The status codes of the hosts or services in the cluster, separated by"
 msgstr ""
 
-#: plugins/check_cluster.c:252
+#: plugins/check_cluster.c:262
 msgid "commas"
 msgstr ""
 
-#: plugins/check_cluster.c:257 plugins/check_game.c:318
-#: plugins/check_http.c:1542 plugins/check_ldap.c:438 plugins/check_mrtg.c:363
-#: plugins/check_mrtgtraf.c:361 plugins/check_mysql.c:558
-#: plugins/check_nt.c:758 plugins/check_ntp.c:865 plugins/check_ntp_peer.c:696
-#: plugins/check_ntp_time.c:626 plugins/check_nwstat.c:1670
-#: plugins/check_overcr.c:456 plugins/check_snmp.c:1178
-#: plugins/check_swap.c:547 plugins/check_ups.c:642 plugins/negate.c:277
-#: plugins-root/check_icmp.c:1329
+#: plugins/check_cluster.c:267 plugins/check_game.c:318
+#: plugins/check_http.c:1827 plugins/check_ldap.c:497 plugins/check_mrtg.c:363
+#: plugins/check_mrtgtraf.c:361 plugins/check_mysql.c:576
+#: plugins/check_nt.c:781 plugins/check_ntp.c:875 plugins/check_ntp_peer.c:724
+#: plugins/check_ntp_time.c:633 plugins/check_nwstat.c:1670
+#: plugins/check_overcr.c:456 plugins/check_snmp.c:1317
+#: plugins/check_swap.c:596 plugins/check_ups.c:645
+#: plugins/check_ide_smart.c:580 plugins/negate.c:255
+#: plugins-root/check_icmp.c:1603
 msgid "Notes:"
 msgstr ""
 
-#: plugins/check_cluster.c:263
+#: plugins/check_cluster.c:273
 msgid ""
 "Will alert critical if there are 3 or more service data points in a non-OK"
 msgstr ""
 
-#: plugins/check_cluster.c:264 plugins/check_ups.c:639
+#: plugins/check_cluster.c:274 plugins/check_ups.c:642
 msgid "state."
 msgstr ""
 
-#: plugins/check_dig.c:100 plugins/check_dig.c:102
+#: plugins/check_dig.c:106 plugins/check_dig.c:108
 #, c-format
 msgid "Looking for: '%s'\n"
 msgstr ""
 
-#: plugins/check_dig.c:109
+#: plugins/check_dig.c:115
 msgid "dig returned an error status"
 msgstr "dig hat einen Fehler zurückgegeben"
 
-#: plugins/check_dig.c:134
+#: plugins/check_dig.c:140
 msgid "Server not found in ANSWER SECTION"
 msgstr "Server nicht gefunden in ANSWER SECTION"
 
-#: plugins/check_dig.c:144
+#: plugins/check_dig.c:150
 msgid "No ANSWER SECTION found"
 msgstr "Keine ANSWER SECTION gefunden"
 
-#: plugins/check_dig.c:171
+#: plugins/check_dig.c:177
 #, fuzzy
 msgid "Probably a non-existent host/domain"
 msgstr "nicht existierender Host/Domain"
 
-#: plugins/check_dig.c:233
+#: plugins/check_dig.c:239
 #, fuzzy, c-format
 msgid "Port must be a positive integer - %s"
 msgstr "Port muss ein positiver Integer sein - %s"
 
-#: plugins/check_dig.c:244
+#: plugins/check_dig.c:250
 #, fuzzy, c-format
 msgid "Warning interval must be a positive integer - %s"
 msgstr "Warning interval muss ein positiver Integer sein - %s"
 
-#: plugins/check_dig.c:252
+#: plugins/check_dig.c:258
 #, fuzzy, c-format
 msgid "Critical interval must be a positive integer - %s"
 msgstr "Critical interval muss ein positiver Integer sein - %s"
 
-#: plugins/check_dig.c:260
+#: plugins/check_dig.c:266
 #, fuzzy, c-format
 msgid "Timeout interval must be a positive integer - %s"
 msgstr "Timeout interval muss ein positiver Integer sein - %s"
 
-#: plugins/check_dig.c:325
+#: plugins/check_dig.c:334
 #, fuzzy, c-format
-msgid "This plugin test the DNS service on the specified host using dig"
+msgid "This plugin tests the DNS service on the specified host using dig"
 msgstr "Testet den DNS Dienst auf dem angegebenen Host mit dig"
 
-#: plugins/check_dig.c:338
+#: plugins/check_dig.c:347
 msgid "Force dig to only use IPv4 query transport"
 msgstr ""
 
-#: plugins/check_dig.c:340
+#: plugins/check_dig.c:349
 msgid "Force dig to only use IPv6 query transport"
 msgstr ""
 
-#: plugins/check_dig.c:342
+#: plugins/check_dig.c:351
 #, fuzzy
 msgid "Machine name to lookup"
 msgstr "zu prüfender Hostname"
 
-#: plugins/check_dig.c:344
+#: plugins/check_dig.c:353
 #, fuzzy
 msgid "Record type to lookup (default: A)"
 msgstr "abzufragender Datensatztyp (Default: A)"
 
-#: plugins/check_dig.c:346
+#: plugins/check_dig.c:355
 #, fuzzy
 msgid ""
 "An address expected to be in the answer section. If not set, uses whatever"
@@ -385,96 +396,95 @@ msgstr ""
 "Adresse die in der ANSWER SECTION erwartet wird.wenn nicht gesetzt, "
 "ubernommen aus -l"
 
-#: plugins/check_dig.c:347
+#: plugins/check_dig.c:356
 msgid "was in -l"
 msgstr ""
 
-#: plugins/check_dig.c:349
+#: plugins/check_dig.c:358
 msgid "Pass STRING as argument(s) to dig"
 msgstr ""
 
-#: plugins/check_disk.c:216
+#: plugins/check_disk.c:241
 #, fuzzy, c-format
 msgid "DISK %s: %s not found\n"
 msgstr "%s [%s nicht gefunden]"
 
-#: plugins/check_disk.c:216 plugins/check_disk.c:956 plugins/check_dns.c:241
-#: plugins/check_dummy.c:74 plugins/check_mysql.c:299
+#: plugins/check_disk.c:241 plugins/check_disk.c:1035 plugins/check_dns.c:295
+#: plugins/check_dummy.c:74 plugins/check_mysql.c:313
 #: plugins/check_nagios.c:104 plugins/check_nagios.c:168
-#: plugins/check_nagios.c:172 plugins/check_pgsql.c:601
-#: plugins/check_pgsql.c:618 plugins/check_pgsql.c:627
-#: plugins/check_pgsql.c:642 plugins/check_procs.c:351
+#: plugins/check_nagios.c:172 plugins/check_pgsql.c:575
+#: plugins/check_pgsql.c:592 plugins/check_pgsql.c:601
+#: plugins/check_pgsql.c:616 plugins/check_procs.c:374
 #, c-format
 msgid "CRITICAL"
 msgstr "CRITICAL"
 
-#: plugins/check_disk.c:550
+#: plugins/check_disk.c:645
 #, c-format
 msgid "unit type %s not known\n"
 msgstr "unbekannter unit type: %s\n"
 
-#: plugins/check_disk.c:553
+#: plugins/check_disk.c:648
 #, c-format
 msgid "failed allocating storage for '%s'\n"
 msgstr "konnte keinen Speicher für '%s' reservieren\n"
 
-#: plugins/check_disk.c:577 plugins/check_disk.c:618 plugins/check_disk.c:626
-#: plugins/check_disk.c:633 plugins/check_disk.c:637 plugins/check_disk.c:677
-#: plugins/check_disk.c:683 plugins/check_disk.c:702 plugins/check_dummy.c:77
-#: plugins/check_dummy.c:80 plugins/check_pgsql.c:643
-#: plugins/check_procs.c:506
+#: plugins/check_disk.c:676 plugins/check_disk.c:724 plugins/check_disk.c:732
+#: plugins/check_disk.c:740 plugins/check_disk.c:744 plugins/check_disk.c:789
+#: plugins/check_disk.c:795 plugins/check_disk.c:818 plugins/check_dummy.c:77
+#: plugins/check_dummy.c:80 plugins/check_pgsql.c:617 plugins/check_procs.c:547
 #, c-format
 msgid "UNKNOWN"
 msgstr "UNKNOWN"
 
-#: plugins/check_disk.c:577
+#: plugins/check_disk.c:676
 msgid "Must set a threshold value before using -p\n"
 msgstr ""
 
-#: plugins/check_disk.c:618
+#: plugins/check_disk.c:724
 msgid "Must set -E before selecting paths\n"
 msgstr ""
 
-#: plugins/check_disk.c:626
+#: plugins/check_disk.c:732
 msgid "Must set group value before selecting paths\n"
 msgstr ""
 
-#: plugins/check_disk.c:633
+#: plugins/check_disk.c:740
 msgid ""
 "Paths need to be selected before using -i/-I. Use -A to select all paths "
 "explicitly"
 msgstr ""
 
-#: plugins/check_disk.c:637 plugins/check_disk.c:683 plugins/check_procs.c:506
+#: plugins/check_disk.c:744 plugins/check_disk.c:795 plugins/check_procs.c:547
 msgid "Could not compile regular expression"
 msgstr ""
 
-#: plugins/check_disk.c:677
+#: plugins/check_disk.c:789
 msgid "Must set a threshold value before using -r/-R\n"
 msgstr ""
 
-#: plugins/check_disk.c:703
+#: plugins/check_disk.c:819
 msgid "Regular expression did not match any path or disk"
 msgstr ""
 
-#: plugins/check_disk.c:749
+#: plugins/check_disk.c:865
 #, fuzzy
 msgid "Unknown argument"
 msgstr "Unbekanntes Argument"
 
-#: plugins/check_disk.c:783
+#: plugins/check_disk.c:899
 #, c-format
 msgid " for %s\n"
 msgstr ""
 
-#: plugins/check_disk.c:857
+#: plugins/check_disk.c:928
 #, fuzzy
 msgid ""
 "This plugin checks the amount of used disk space on a mounted file system"
 msgstr ""
 "Dieses Plugin prüft den freien Speicher auf einem gemounteten Filesystem"
 
-#: plugins/check_disk.c:858
+#: plugins/check_disk.c:929
 #, fuzzy
 msgid ""
 "and generates an alert if free space is less than one of the threshold values"
@@ -482,341 +492,385 @@ msgstr ""
 "und erzeugt einen Alarm wenn einer der angegebenen Schwellwerte "
 "unterschritten wird."
 
-#: plugins/check_disk.c:868
+#: plugins/check_disk.c:939
 msgid "Exit with WARNING status if less than INTEGER units of disk are free"
 msgstr ""
 
-#: plugins/check_disk.c:870
+#: plugins/check_disk.c:941
 msgid "Exit with WARNING status if less than PERCENT of disk space is free"
 msgstr ""
 
-#: plugins/check_disk.c:872
+#: plugins/check_disk.c:943
 msgid "Exit with CRITICAL status if less than INTEGER units of disk are free"
 msgstr ""
 
-#: plugins/check_disk.c:874
+#: plugins/check_disk.c:945
 msgid "Exit with CRITICAL status if less than PERCENT of disk space is free"
 msgstr ""
 
-#: plugins/check_disk.c:876
+#: plugins/check_disk.c:947
 msgid "Exit with WARNING status if less than PERCENT of inode space is free"
 msgstr ""
 
-#: plugins/check_disk.c:878
+#: plugins/check_disk.c:949
 msgid "Exit with CRITICAL status if less than PERCENT of inode space is free"
 msgstr ""
 
-#: plugins/check_disk.c:880
-msgid "Path or partition (may be repeated)"
+#: plugins/check_disk.c:951
+msgid ""
+"Mount point or block device as emitted by the mount(8) command (may be "
+"repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:882
+#: plugins/check_disk.c:953
 msgid "Ignore device (only works if -p unspecified)"
 msgstr ""
 
-#: plugins/check_disk.c:884
+#: plugins/check_disk.c:955
 msgid "Clear thresholds"
 msgstr ""
 
-#: plugins/check_disk.c:886
+#: plugins/check_disk.c:957
 msgid "For paths or partitions specified with -p, only check for exact paths"
 msgstr ""
 
-#: plugins/check_disk.c:888
+#: plugins/check_disk.c:959
 msgid "Display only devices/mountpoints with errors"
 msgstr ""
 
-#: plugins/check_disk.c:890
+#: plugins/check_disk.c:961
 msgid "Don't account root-reserved blocks into freespace in perfdata"
 msgstr ""
 
-#: plugins/check_disk.c:892
+#: plugins/check_disk.c:963
+msgid "Display inode usage in perfdata"
+msgstr ""
+
+#: plugins/check_disk.c:965
 msgid ""
 "Group paths. Thresholds apply to (free-)space of all partitions together"
 msgstr ""
 
-#: plugins/check_disk.c:894
+#: plugins/check_disk.c:967
 msgid "Same as '--units kB'"
 msgstr ""
 
-#: plugins/check_disk.c:896
+#: plugins/check_disk.c:969
 msgid "Only check local filesystems"
 msgstr ""
 
-#: plugins/check_disk.c:898
+#: plugins/check_disk.c:971
 msgid ""
 "Only check local filesystems against thresholds. Yet call stat on remote "
 "filesystems"
 msgstr ""
 
-#: plugins/check_disk.c:899
+#: plugins/check_disk.c:972
 msgid "to test if they are accessible (e.g. to detect Stale NFS Handles)"
 msgstr ""
 
-#: plugins/check_disk.c:901
-msgid "Display the mountpoint instead of the partition"
+#: plugins/check_disk.c:974
+msgid "Display the (block) device instead of the mount point"
 msgstr ""
 
-#: plugins/check_disk.c:903
+#: plugins/check_disk.c:976
 msgid "Same as '--units MB'"
 msgstr ""
 
-#: plugins/check_disk.c:905
+#: plugins/check_disk.c:978
 msgid "Explicitly select all paths. This is equivalent to -R '.*'"
 msgstr ""
 
-#: plugins/check_disk.c:907
+#: plugins/check_disk.c:980
 msgid ""
 "Case insensitive regular expression for path/partition (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:909
+#: plugins/check_disk.c:982
 msgid "Regular expression for path or partition (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:911
+#: plugins/check_disk.c:984
 msgid ""
 "Regular expression to ignore selected path/partition (case insensitive) (may "
 "be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:913
+#: plugins/check_disk.c:986
 msgid ""
 "Regular expression to ignore selected path or partition (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:916
+#: plugins/check_disk.c:988
+msgid ""
+"Return OK if no filesystem matches, filesystem does not exist or is "
+"inaccessible."
+msgstr ""
+
+#: plugins/check_disk.c:989
+msgid "(Provide this option before -p / -r / --ereg-path if used)"
+msgstr ""
+
+#: plugins/check_disk.c:992
 msgid "Choose bytes, kB, MB, GB, TB (default: MB)"
 msgstr ""
 
-#: plugins/check_disk.c:919
+#: plugins/check_disk.c:995
 msgid "Ignore all filesystems of indicated type (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:921
+#: plugins/check_disk.c:997
 msgid "Check only filesystems of indicated type (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:926
+#: plugins/check_disk.c:1002
 msgid "Checks /tmp and /var at 10% and 5%, and / at 100MB and 50MB"
 msgstr ""
 
-#: plugins/check_disk.c:928
+#: plugins/check_disk.c:1004
 msgid ""
 "Checks all filesystems not matching -r at 100M and 50M. The fs matching the -"
 "r regex"
 msgstr ""
 
-#: plugins/check_disk.c:929
+#: plugins/check_disk.c:1005
 msgid ""
 "are grouped which means the freespace thresholds are applied to all disks "
 "together"
 msgstr ""
 
-#: plugins/check_disk.c:931
+#: plugins/check_disk.c:1007
 msgid ""
 "Checks /foo for 1000M/500M and /bar for 5/3%. All remaining volumes use "
 "100M/50M"
 msgstr ""
 
-#: plugins/check_disk.c:957
+#: plugins/check_disk.c:1036
 #, c-format
 msgid "%s %s: %s\n"
 msgstr ""
 
-#: plugins/check_disk.c:957
+#: plugins/check_disk.c:1036
 msgid "is not accessible"
 msgstr ""
 
-#: plugins/check_dns.c:116
+#: plugins/check_dns.c:120
 #, fuzzy
 msgid "nslookup returned an error status"
 msgstr "nslookup hat einen Fehler zurückgegeben"
 
-#: plugins/check_dns.c:134
+#: plugins/check_dns.c:138
 msgid "Warning plugin error"
 msgstr "Warnung Plugin Fehler"
 
-#: plugins/check_dns.c:154
+#: plugins/check_dns.c:156
+#, fuzzy, c-format
+msgid "DNS CRITICAL - '%s' returned empty server string\n"
+msgstr "DNS CRITICAL - '%s'  hat einen leeren Hostnamen zurückgegeben\n"
+
+#: plugins/check_dns.c:161
+#, fuzzy, c-format
+msgid "DNS CRITICAL - No response from DNS %s\n"
+msgstr "Keine Antwort von DNS %s\n"
+
+#: plugins/check_dns.c:180
 #, c-format
 msgid "DNS CRITICAL - '%s' returned empty host name string\n"
 msgstr "DNS CRITICAL - '%s'  hat einen leeren Hostnamen zurückgegeben\n"
 
-#: plugins/check_dns.c:160
+#: plugins/check_dns.c:186
 msgid "Non-authoritative answer:"
 msgstr ""
 
-#: plugins/check_dns.c:201
+#: plugins/check_dns.c:215
+#, fuzzy, c-format
+msgid "Domain '%s' was not found by the server\n"
+msgstr "Domäne %s wurde vom Server nicht gefunden\n"
+
+#: plugins/check_dns.c:234
 #, fuzzy, c-format
 msgid "DNS CRITICAL - '%s' msg parsing exited with no address\n"
 msgstr "DNS CRITICAL - '%s' Ausgabeverarbeitung hat keine Adresse ergeben\n"
 
-#: plugins/check_dns.c:216
+#: plugins/check_dns.c:265
 #, fuzzy, c-format
 msgid "expected '%s' but got '%s'"
 msgstr "Erwartet: %s aber: %s erhalten"
 
-#: plugins/check_dns.c:223
+#: plugins/check_dns.c:272
+#, fuzzy, c-format
+msgid "Domain '%s' was found by the server: '%s'\n"
+msgstr "Domäne %s wurde vom Server nicht gefunden\n"
+
+#: plugins/check_dns.c:282
 #, c-format
 msgid "server %s is not authoritative for %s"
 msgstr "Server %s ist nicht autoritativ für %s"
 
-#: plugins/check_dns.c:237 plugins/check_dummy.c:68 plugins/check_nagios.c:182
-#: plugins/check_pgsql.c:638 plugins/check_procs.c:344
+#: plugins/check_dns.c:291 plugins/check_dummy.c:68 plugins/check_nagios.c:182
+#: plugins/check_pgsql.c:612 plugins/check_procs.c:367
 #, c-format
 msgid "OK"
 msgstr "OK"
 
-#: plugins/check_dns.c:239 plugins/check_dummy.c:71 plugins/check_mysql.c:296
-#: plugins/check_nagios.c:182 plugins/check_pgsql.c:607
-#: plugins/check_pgsql.c:612 plugins/check_pgsql.c:640
-#: plugins/check_procs.c:346
+#: plugins/check_dns.c:293 plugins/check_dummy.c:71 plugins/check_mysql.c:310
+#: plugins/check_nagios.c:182 plugins/check_pgsql.c:581
+#: plugins/check_pgsql.c:586 plugins/check_pgsql.c:614
+#: plugins/check_procs.c:369
 #, c-format
 msgid "WARNING"
 msgstr "WARNING"
 
-#: plugins/check_dns.c:243
+#: plugins/check_dns.c:297
 #, fuzzy, c-format
 msgid "%.3f second response time"
 msgid_plural "%.3f seconds response time"
 msgstr[0] "%.3f Sekunden Antwortzeit "
 msgstr[1] "%.3f Sekunden Antwortzeit "
 
-#: plugins/check_dns.c:244
+#: plugins/check_dns.c:298
 #, fuzzy, c-format
 msgid ". %s returns %s"
 msgstr "%s hat %s zurückgegeben"
 
-#: plugins/check_dns.c:248
+#: plugins/check_dns.c:318
 #, c-format
 msgid "DNS WARNING - %s\n"
 msgstr "DNS WARNING - %s\n"
 
-#: plugins/check_dns.c:249 plugins/check_dns.c:252 plugins/check_dns.c:255
+#: plugins/check_dns.c:319 plugins/check_dns.c:322 plugins/check_dns.c:325
 msgid " Probably a non-existent host/domain"
 msgstr "nicht existierender Host/Domain"
 
-#: plugins/check_dns.c:251
+#: plugins/check_dns.c:321
 #, c-format
 msgid "DNS CRITICAL - %s\n"
 msgstr "DNS CRITICAL - %s\n"
 
-#: plugins/check_dns.c:254
+#: plugins/check_dns.c:324
 #, fuzzy, c-format
 msgid "DNS UNKNOWN - %s\n"
 msgstr "DNS UNKNOWN - %s\n"
 
-#: plugins/check_dns.c:267
+#: plugins/check_dns.c:368
 msgid "Note: nslookup is deprecated and may be removed from future releases."
 msgstr ""
 
-#: plugins/check_dns.c:268
+#: plugins/check_dns.c:369
 msgid "Consider using the `dig' or `host' programs instead.  Run nslookup with"
 msgstr ""
 
-#: plugins/check_dns.c:269
+#: plugins/check_dns.c:370
 msgid "the `-sil[ent]' option to prevent this message from appearing."
 msgstr ""
 
-#: plugins/check_dns.c:274
+#: plugins/check_dns.c:375 plugins/check_dns.c:377
 #, c-format
 msgid "No response from DNS %s\n"
 msgstr "Keine Antwort von DNS %s\n"
 
-#: plugins/check_dns.c:278
+#: plugins/check_dns.c:381
 #, c-format
 msgid "DNS %s has no records\n"
 msgstr "Nameserver %s hat keine Datensätze\n"
 
-#: plugins/check_dns.c:286
+#: plugins/check_dns.c:389
 #, c-format
 msgid "Connection to DNS %s was refused\n"
 msgstr "Verbindung zum Nameserver %s wurde verweigert\n"
 
-#: plugins/check_dns.c:290
+#: plugins/check_dns.c:393
 #, c-format
 msgid "Query was refused by DNS server at %s\n"
 msgstr ""
 
-#: plugins/check_dns.c:294
+#: plugins/check_dns.c:397
 #, c-format
 msgid "No information returned by DNS server at %s\n"
 msgstr ""
 
-#: plugins/check_dns.c:300
-#, c-format
-msgid "Domain %s was not found by the server\n"
-msgstr "Domäne %s wurde vom Server nicht gefunden\n"
-
-#: plugins/check_dns.c:304
+#: plugins/check_dns.c:401
 msgid "Network is unreachable\n"
 msgstr "Netzwerk nicht erreichbar\n"
 
-#: plugins/check_dns.c:308
+#: plugins/check_dns.c:405
 #, c-format
 msgid "DNS failure for %s\n"
 msgstr "DNS Fehler für %s\n"
 
-#: plugins/check_dns.c:372 plugins/check_dns.c:380 plugins/check_dns.c:387
-#: plugins/check_dns.c:392 plugins/check_dns.c:414 plugins/check_dns.c:422
+#: plugins/check_dns.c:471 plugins/check_dns.c:479 plugins/check_dns.c:486
+#: plugins/check_dns.c:491 plugins/check_dns.c:533 plugins/check_dns.c:541
 #: plugins/check_game.c:211 plugins/check_game.c:219
 msgid "Input buffer overflow\n"
 msgstr "Eingabe-Pufferüberlauf\n"
 
-#: plugins/check_dns.c:450
+#: plugins/check_dns.c:576
 msgid ""
 "This plugin uses the nslookup program to obtain the IP address for the given "
 "host/domain query."
 msgstr ""
 
-#: plugins/check_dns.c:451
+#: plugins/check_dns.c:577
 msgid "An optional DNS server to use may be specified."
 msgstr ""
 
-#: plugins/check_dns.c:452
+#: plugins/check_dns.c:578
 msgid ""
 "If no DNS server is specified, the default server(s) specified in /etc/"
 "resolv.conf will be used."
 msgstr ""
 
-#: plugins/check_dns.c:462
+#: plugins/check_dns.c:588
 msgid "The name or address you want to query"
 msgstr ""
 
-#: plugins/check_dns.c:464
+#: plugins/check_dns.c:590
 msgid "Optional DNS server you want to use for the lookup"
 msgstr ""
 
-#: plugins/check_dns.c:466
+#: plugins/check_dns.c:592
 msgid ""
-"Optional IP-ADDRESS you expect the DNS server to return. HOST must end with"
+"Optional IP-ADDRESS/CIDR you expect the DNS server to return. HOST must end"
 msgstr ""
 
-#: plugins/check_dns.c:467
+#: plugins/check_dns.c:593
 msgid ""
-"a dot (.). This option can be repeated multiple times (Returns OK if any"
+"with a dot (.). This option can be repeated multiple times (Returns OK if any"
 msgstr ""
 
-#: plugins/check_dns.c:468
-msgid ""
-"value match). If multiple addresses are returned at once, you have to match"
+#: plugins/check_dns.c:594
+msgid "value matches)."
 msgstr ""
 
-#: plugins/check_dns.c:469
+#: plugins/check_dns.c:596
 msgid ""
-"the whole string of addresses separated with commas (sorted alphabetically)."
+"Expect the DNS server to return NXDOMAIN (i.e. the domain was not found)"
 msgstr ""
 
-#: plugins/check_dns.c:471
+#: plugins/check_dns.c:597
+msgid "Cannot be used together with -a"
+msgstr ""
+
+#: plugins/check_dns.c:599
 msgid "Optionally expect the DNS server to be authoritative for the lookup"
 msgstr ""
 
-#: plugins/check_dns.c:473
+#: plugins/check_dns.c:601
 msgid "Return warning if elapsed time exceeds value. Default off"
 msgstr ""
 
-#: plugins/check_dns.c:475
+#: plugins/check_dns.c:603
 msgid "Return critical if elapsed time exceeds value. Default off"
+msgstr ""
+
+#: plugins/check_dns.c:605
+msgid ""
+"Return critical if the list of expected addresses does not match all "
+"addresses"
+msgstr ""
+
+#: plugins/check_dns.c:606
+msgid "returned. Default off"
 msgstr ""
 
 #: plugins/check_dummy.c:62
@@ -837,179 +891,188 @@ msgstr ""
 msgid "of the <state> argument with optional text"
 msgstr ""
 
-#: plugins/check_fping.c:125 plugins/check_hpjd.c:128 plugins/check_ping.c:438
-#: plugins/check_swap.c:175 plugins/check_users.c:94 plugins/urlize.c:110
+#: plugins/check_fping.c:127 plugins/check_hpjd.c:134 plugins/check_ping.c:444
+#: plugins/check_swap.c:193 plugins/check_users.c:130 plugins/urlize.c:109
 #, c-format
 msgid "Could not open pipe: %s\n"
 msgstr "Pipe: %s konnte nicht geöffnet werden\n"
 
-#: plugins/check_fping.c:131 plugins/check_hpjd.c:134 plugins/check_load.c:153
-#: plugins/check_swap.c:181 plugins/check_users.c:100 plugins/urlize.c:116
+#: plugins/check_fping.c:133 plugins/check_hpjd.c:140 plugins/check_load.c:159
+#: plugins/check_swap.c:199 plugins/check_users.c:136 plugins/urlize.c:115
 #, c-format
 msgid "Could not open stderr for %s\n"
 msgstr "Konnte stderr nicht öffnen für: %s\n"
 
-#: plugins/check_fping.c:157
+#: plugins/check_fping.c:161
 #, fuzzy
 msgid "FPING UNKNOWN - IP address not found\n"
 msgstr "FPING UNKNOWN - %s nicht gefunden\n"
 
-#: plugins/check_fping.c:160
+#: plugins/check_fping.c:164
 msgid "FPING UNKNOWN - invalid commandline argument\n"
 msgstr ""
 
-#: plugins/check_fping.c:163
+#: plugins/check_fping.c:167
 #, fuzzy
 msgid "FPING UNKNOWN - failed system call\n"
 msgstr "FPING UNKNOWN - %s nicht gefunden\n"
 
-#: plugins/check_fping.c:187
+#: plugins/check_fping.c:194
+#, fuzzy, c-format
+msgid "FPING %s - %s (rta=%f ms)|%s\n"
+msgstr "FPING %s - %s (verloren=%.0f%% )|%s\n"
+
+#: plugins/check_fping.c:202
 #, c-format
 msgid "FPING UNKNOWN - %s not found\n"
 msgstr "FPING UNKNOWN - %s nicht gefunden\n"
 
-#: plugins/check_fping.c:191
+#: plugins/check_fping.c:206
 #, c-format
 msgid "FPING CRITICAL - %s is unreachable\n"
 msgstr "FPING CRITICAL - %s ist nicht erreichbar\n"
 
-#: plugins/check_fping.c:196
+#: plugins/check_fping.c:211
 #, fuzzy, c-format
 msgid "FPING UNKNOWN - %s parameter error\n"
 msgstr "FPING UNKNOWN - %s nicht gefunden\n"
 
-#: plugins/check_fping.c:200 plugins/check_fping.c:240
+#: plugins/check_fping.c:215 plugins/check_fping.c:255
 #, c-format
 msgid "FPING CRITICAL - %s is down\n"
 msgstr "FPING CRITICAL - %s ist down\n"
 
-#: plugins/check_fping.c:227
+#: plugins/check_fping.c:242
 #, c-format
 msgid "FPING %s - %s (loss=%.0f%%, rta=%f ms)|%s %s\n"
 msgstr "FPING %s - %s (verloren=%.0f%%, rta=%f ms)|%s %s\n"
 
-#: plugins/check_fping.c:253
+#: plugins/check_fping.c:268
 #, c-format
 msgid "FPING %s - %s (loss=%.0f%% )|%s\n"
 msgstr "FPING %s - %s (verloren=%.0f%% )|%s\n"
 
-#: plugins/check_fping.c:326 plugins/check_fping.c:332
-#: plugins/check_hpjd.c:338 plugins/check_hpjd.c:361 plugins/check_mysql.c:371
-#: plugins/check_mysql.c:455 plugins/check_ntp.c:709
-#: plugins/check_ntp_peer.c:497 plugins/check_ntp_time.c:496
-#: plugins/check_pgsql.c:335 plugins/check_ping.c:295 plugins/check_ping.c:418
-#: plugins/check_radius.c:264 plugins/check_real.c:314
-#: plugins/check_real.c:376 plugins/check_smtp.c:499 plugins/check_smtp.c:641
-#: plugins/check_ssh.c:157 plugins/check_time.c:240 plugins/check_time.c:315
-#: plugins/check_ups.c:504 plugins/check_ups.c:573
+#: plugins/check_fping.c:345 plugins/check_fping.c:351 plugins/check_hpjd.c:345
+#: plugins/check_hpjd.c:376 plugins/check_mysql.c:389 plugins/check_mysql.c:476
+#: plugins/check_ntp.c:719 plugins/check_ntp_peer.c:497
+#: plugins/check_ntp_time.c:498 plugins/check_pgsql.c:338
+#: plugins/check_ping.c:301 plugins/check_ping.c:424 plugins/check_radius.c:279
+#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:519
+#: plugins/check_smtp.c:667 plugins/check_ssh.c:162 plugins/check_time.c:240
+#: plugins/check_time.c:315 plugins/check_ups.c:507 plugins/check_ups.c:576
 msgid "Invalid hostname/address"
 msgstr "Ungültige(r) Hostname/Adresse"
 
-#: plugins/check_fping.c:345 plugins/check_ldap.c:353 plugins/check_ping.c:246
+#: plugins/check_fping.c:364 plugins/check_ldap.c:400 plugins/check_ping.c:252
+#: plugins-root/check_icmp.c:474
 msgid "IPv6 support not available\n"
 msgstr ""
 
-#: plugins/check_fping.c:378
+#: plugins/check_fping.c:397
 msgid "Packet size must be a positive integer"
 msgstr "Paketgröße muss ein positiver Integer sein"
 
-#: plugins/check_fping.c:384
+#: plugins/check_fping.c:403
 msgid "Packet count must be a positive integer"
 msgstr "Paketanzahl muss ein positiver Integer sein"
 
-#: plugins/check_fping.c:390
+#: plugins/check_fping.c:409
 #, fuzzy
 msgid "Target timeout must be a positive integer"
 msgstr "Warnung time muss ein positiver Integer sein"
 
-#: plugins/check_fping.c:396
+#: plugins/check_fping.c:415
 #, fuzzy
 msgid "Interval must be a positive integer"
 msgstr "Timeout interval muss ein positiver Integer sein"
 
-#: plugins/check_fping.c:402 plugins/check_ntp.c:733
-#: plugins/check_ntp_peer.c:524 plugins/check_ntp_time.c:523
-#: plugins/check_radius.c:314 plugins/check_time.c:319
+#: plugins/check_fping.c:421 plugins/check_ntp.c:743
+#: plugins/check_ntp_peer.c:524 plugins/check_ntp_time.c:528
+#: plugins/check_radius.c:329 plugins/check_time.c:319
 msgid "Hostname was not supplied"
 msgstr ""
 
-#: plugins/check_fping.c:422
+#: plugins/check_fping.c:441
 #, c-format
 msgid "%s: Only one threshold may be packet loss (%s)\n"
 msgstr "%s: Nur ein Wert darf für packet loss angegeben werden (%s)\n"
 
-#: plugins/check_fping.c:426
+#: plugins/check_fping.c:445
 #, c-format
 msgid "%s: Only one threshold must be packet loss (%s)\n"
 msgstr "%s: Nur ein Wert darf für packet loss angegeben werden (%s)\n"
 
-#: plugins/check_fping.c:458
+#: plugins/check_fping.c:475
 msgid ""
 "This plugin will use the fping command to ping the specified host for a fast "
 "check"
 msgstr ""
 
-#: plugins/check_fping.c:460
+#: plugins/check_fping.c:477
 msgid "Note that it is necessary to set the suid flag on fping."
 msgstr ""
 
-#: plugins/check_fping.c:472
+#: plugins/check_fping.c:489
 msgid ""
 "name or IP Address of host to ping (IP Address bypasses name lookup, "
 "reducing system load)"
 msgstr ""
 
-#: plugins/check_fping.c:474 plugins/check_ping.c:575
+#: plugins/check_fping.c:491 plugins/check_ping.c:589
 #, fuzzy
 msgid "warning threshold pair"
 msgstr "Warning threshold  Integer sein"
 
-#: plugins/check_fping.c:476 plugins/check_ping.c:577
+#: plugins/check_fping.c:493 plugins/check_ping.c:591
 #, fuzzy
 msgid "critical threshold pair"
 msgstr "Critical threshold muss ein Integer sein"
 
-#: plugins/check_fping.c:478
+#: plugins/check_fping.c:495
+msgid "Return OK after first successful reply"
+msgstr ""
+
+#: plugins/check_fping.c:497
 msgid "size of ICMP packet"
 msgstr ""
 
-#: plugins/check_fping.c:480
+#: plugins/check_fping.c:499
 msgid "number of ICMP packets to send"
 msgstr ""
 
-#: plugins/check_fping.c:482
+#: plugins/check_fping.c:501
 msgid "Target timeout (ms)"
 msgstr ""
 
-#: plugins/check_fping.c:484
+#: plugins/check_fping.c:503
 msgid "Interval (ms) between sending packets"
 msgstr ""
 
-#: plugins/check_fping.c:486
+#: plugins/check_fping.c:505
 msgid "name or IP Address of sourceip"
 msgstr ""
 
-#: plugins/check_fping.c:488
+#: plugins/check_fping.c:507
 msgid "source interface name"
 msgstr ""
 
-#: plugins/check_fping.c:491
+#: plugins/check_fping.c:510
 #, c-format
 msgid ""
 "THRESHOLD is <rta>,<pl>%% where <rta> is the round trip average travel time "
 "(ms)"
 msgstr ""
 
-#: plugins/check_fping.c:492
+#: plugins/check_fping.c:511
 msgid ""
 "which triggers a WARNING or CRITICAL state, and <pl> is the percentage of"
 msgstr ""
 
-#: plugins/check_fping.c:493
+#: plugins/check_fping.c:512
 msgid "packet loss to trigger an alarm state."
 msgstr ""
 
-#: plugins/check_fping.c:496
+#: plugins/check_fping.c:515
 msgid "IPv4 is used by default. Specify -6 to use IPv6."
 msgstr ""
 
@@ -1067,61 +1130,64 @@ msgid ""
 msgstr ""
 
 #: plugins/check_game.c:321
-msgid ""
-"http://www.activesw.com/people/steve/qstat.html before you can use this "
-"plugin."
+msgid "https://github.com/multiplay/qstat before you can use this plugin."
 msgstr ""
 
-#: plugins/check_hpjd.c:239
+#: plugins/check_hpjd.c:245
 msgid "Paper Jam"
 msgstr "Papierstau"
 
-#: plugins/check_hpjd.c:243
+#: plugins/check_hpjd.c:250
 msgid "Out of Paper"
 msgstr "Kein Papier"
 
-#: plugins/check_hpjd.c:248
+#: plugins/check_hpjd.c:255
 msgid "Printer Offline"
 msgstr "Drucker ausgeschaltet"
 
-#: plugins/check_hpjd.c:253
+#: plugins/check_hpjd.c:260
 msgid "Peripheral Error"
 msgstr "Peripheriefehler"
 
-#: plugins/check_hpjd.c:257
+#: plugins/check_hpjd.c:264
 msgid "Intervention Required"
 msgstr "Eingriff benötigt"
 
-#: plugins/check_hpjd.c:261
+#: plugins/check_hpjd.c:268
 msgid "Toner Low"
 msgstr "Wenig Toner"
 
-#: plugins/check_hpjd.c:265
+#: plugins/check_hpjd.c:272
 msgid "Insufficient Memory"
 msgstr "Nicht genügend Speicher"
 
-#: plugins/check_hpjd.c:269
+#: plugins/check_hpjd.c:276
 msgid "A Door is Open"
 msgstr "Eine Abdeckung ist offen"
 
-#: plugins/check_hpjd.c:273
+#: plugins/check_hpjd.c:280
 msgid "Output Tray is Full"
 msgstr "Ausgabeschacht ist voll"
 
-#: plugins/check_hpjd.c:277
+#: plugins/check_hpjd.c:284
 msgid "Data too Slow for Engine"
 msgstr ""
 
-#: plugins/check_hpjd.c:281
+#: plugins/check_hpjd.c:288
 msgid "Unknown Paper Error"
 msgstr "Papierfehler"
 
-#: plugins/check_hpjd.c:286
+#: plugins/check_hpjd.c:293
 #, c-format
 msgid "Printer ok - (%s)\n"
 msgstr "Printer ok - (%s)\n"
 
-#: plugins/check_hpjd.c:391
+#: plugins/check_hpjd.c:353
+#, fuzzy
+msgid "Port must be a positive short integer"
+msgstr "Port muss ein positiver Integer sein"
+
+#: plugins/check_hpjd.c:410
 #, fuzzy
 msgid "This plugin tests the STATUS of an HP printer with a JetDirect card."
 msgstr ""
@@ -1130,7 +1196,7 @@ msgstr ""
 "Net-snmp muss auf dem ausführenden Computer installiert sein.\n"
 "\n"
 
-#: plugins/check_hpjd.c:392
+#: plugins/check_hpjd.c:411
 #, fuzzy
 msgid "Net-snmp must be installed on the computer running the plugin."
 msgstr ""
@@ -1139,733 +1205,854 @@ msgstr ""
 "Net-snmp muss auf dem ausführenden Computer installiert sein.\n"
 "\n"
 
-#: plugins/check_hpjd.c:402
+#: plugins/check_hpjd.c:421
 msgid "The SNMP community name "
 msgstr ""
 
-#: plugins/check_hpjd.c:403
+#: plugins/check_hpjd.c:422 plugins/check_hpjd.c:426
 #, c-format
 msgid "(default=%s)"
 msgstr ""
 
-#: plugins/check_http.c:189
+#: plugins/check_hpjd.c:425
+msgid "Specify the port to check "
+msgstr ""
+
+#: plugins/check_hpjd.c:429
+msgid "Disable paper check "
+msgstr ""
+
+#: plugins/check_http.c:196
 msgid "file does not exist or is not readable"
 msgstr ""
 
-#: plugins/check_http.c:310 plugins/check_http.c:315 plugins/check_http.c:321
-#: plugins/check_smtp.c:600 plugins/check_tcp.c:576 plugins/check_tcp.c:580
-#: plugins/check_tcp.c:586
+#: plugins/check_http.c:324 plugins/check_http.c:329 plugins/check_http.c:335
+#: plugins/check_smtp.c:615 plugins/check_tcp.c:590 plugins/check_tcp.c:595
+#: plugins/check_tcp.c:601
 msgid "Invalid certificate expiration period"
 msgstr "Ungültiger Zertifikatsablauftermin"
 
-#: plugins/check_http.c:348
+#: plugins/check_http.c:378
 msgid ""
-"Invalid option - Valid values for SSL Version are 1 (TLSv1), 2 (SSLv2) or 3 "
-"(SSLv3)"
+"Invalid option - Valid SSL/TLS versions: 2, 3, 1, 1.1, 1.2 (with optional "
+"'+' suffix)"
 msgstr ""
 
-#: plugins/check_http.c:354 plugins/check_tcp.c:599
+#: plugins/check_http.c:384 plugins/check_tcp.c:614 plugins/check_tcp.c:623
 #, fuzzy
 msgid "Invalid option - SSL is not available"
 msgstr "Ungültige Option - SSL ist nicht verfügbar\n"
 
-#: plugins/check_http.c:375
+#: plugins/check_http.c:392
+msgid "Invalid max_redirs count"
+msgstr ""
+
+#: plugins/check_http.c:412
 msgid "Invalid onredirect option"
 msgstr ""
 
-#: plugins/check_http.c:377
+#: plugins/check_http.c:414
 #, c-format
 msgid "option f:%d \n"
 msgstr "Option f:%d \n"
 
-#: plugins/check_http.c:398
+#: plugins/check_http.c:449
 msgid "Invalid port number"
 msgstr "Ungültige Portnummer"
 
-#: plugins/check_http.c:450
+#: plugins/check_http.c:507
 #, c-format
 msgid "Could Not Compile Regular Expression: %s"
 msgstr ""
 
-#: plugins/check_http.c:464 plugins/check_ntp.c:722
-#: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:512
-#: plugins/check_smtp.c:621 plugins/check_ssh.c:149 plugins/check_tcp.c:477
+#: plugins/check_http.c:521 plugins/check_ntp.c:732
+#: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:517
+#: plugins/check_smtp.c:647 plugins/check_ssh.c:151 plugins/check_tcp.c:491
 msgid "IPv6 support not available"
 msgstr "IPv6 Unterstützung nicht vorhanden"
 
-#: plugins/check_http.c:529 plugins/check_ping.c:422
+#: plugins/check_http.c:589 plugins/check_ping.c:428
 msgid "You must specify a server address or host name"
 msgstr "Hostname oder Serveradresse muss angegeben werden"
 
-#: plugins/check_http.c:543
+#: plugins/check_http.c:606
 msgid ""
 "If you use a client certificate you must also specify a private key file"
 msgstr ""
 
-#: plugins/check_http.c:667 plugins/check_http.c:835
+#: plugins/check_http.c:733 plugins/check_http.c:901
 #, fuzzy
 msgid "HTTP UNKNOWN - Memory allocation error\n"
 msgstr "HTTP UNKNOWN - Konnte·url·nicht·zuweisen\n"
 
-#: plugins/check_http.c:739
+#: plugins/check_http.c:805
 #, fuzzy, c-format
 msgid "%sServer date unknown, "
 msgstr "HTTP UNKNOWN - Serverdatum unbekannt\n"
 
-#: plugins/check_http.c:742
+#: plugins/check_http.c:808
 #, fuzzy, c-format
 msgid "%sDocument modification date unknown, "
 msgstr "HTTP CRITICAL - Datum der letzten Änderung unbekannt\n"
 
-#: plugins/check_http.c:749
+#: plugins/check_http.c:815
 #, fuzzy, c-format
 msgid "%sServer date \"%100s\" unparsable, "
 msgstr "HTTP CRITICAL - Serverdatum \"%100s\" konnte nicht verarbeitet werden"
 
-#: plugins/check_http.c:752
+#: plugins/check_http.c:818
 #, fuzzy, c-format
 msgid "%sDocument date \"%100s\" unparsable, "
 msgstr ""
 "HTTP CRITICAL - Dokumentendatum \"%100s\" konnte nicht verarbeitet werden"
 
-#: plugins/check_http.c:755
+#: plugins/check_http.c:821
 #, fuzzy, c-format
 msgid "%sDocument is %d seconds in the future, "
 msgstr "HTTP CRITICAL - Dokumentendatum ist %d Sekunden in der Zukunft\n"
 
-#: plugins/check_http.c:760
+#: plugins/check_http.c:826
 #, fuzzy, c-format
 msgid "%sLast modified %.1f days ago, "
 msgstr "HTTP CRITICAL - Letzte Änderung vor %.1f Tagen\n"
 
-#: plugins/check_http.c:763
+#: plugins/check_http.c:829
 #, fuzzy, c-format
 msgid "%sLast modified %d:%02d:%02d ago, "
 msgstr "HTTP CRITICAL - Letzte Änderung vor %d:%02d:%02d \n"
 
-#: plugins/check_http.c:876
+#: plugins/check_http.c:943
 msgid "HTTP CRITICAL - Unable to open TCP socket\n"
 msgstr "HTTP CRITICAL - Konnte TCP socket nicht öffnen\n"
 
-#: plugins/check_http.c:995
+#: plugins/check_http.c:1103
+#, fuzzy
+msgid "HTTP UNKNOWN - Could not allocate memory for full_page\n"
+msgstr "HTTP UNKNOWN - Konnte·url·nicht·zuweisen\n"
+
+#: plugins/check_http.c:1120
 msgid "HTTP CRITICAL - Error on receive\n"
 msgstr "HTTP CRITICAL - Fehler beim Empfangen\n"
 
-#: plugins/check_http.c:1005
+#: plugins/check_http.c:1125
 #, fuzzy
 msgid "HTTP CRITICAL - No data received from host\n"
 msgstr "HTTP CRITICAL - Keine Daten empfangen\n"
 
-#: plugins/check_http.c:1056
+#: plugins/check_http.c:1176
 #, fuzzy, c-format
 msgid "Invalid HTTP response received from host: %s\n"
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_http.c:1060
+#: plugins/check_http.c:1180
 #, fuzzy, c-format
 msgid "Invalid HTTP response received from host on port %d: %s\n"
 msgstr "Ungültige HTTP Antwort von Host erhalten auf Port %d\n"
 
-#: plugins/check_http.c:1069
+#: plugins/check_http.c:1183 plugins/check_http.c:1376
+#, c-format
+msgid ""
+"%s\n"
+"%s"
+msgstr ""
+
+#: plugins/check_http.c:1191
 #, fuzzy, c-format
 msgid "Status line output matched \"%s\" - "
 msgstr "HTTP OK: Statusausgabe passt auf \"%s\"\n"
 
-#: plugins/check_http.c:1080
+#: plugins/check_http.c:1202
 #, c-format
 msgid "HTTP CRITICAL: Invalid Status Line (%s)\n"
 msgstr "HTTP CRITICAL: Ungültige Statusmeldung (%s)\n"
 
-#: plugins/check_http.c:1087
+#: plugins/check_http.c:1209
 #, c-format
 msgid "HTTP CRITICAL: Invalid Status (%s)\n"
 msgstr "HTTP CRITICAL: Ungültiger Status (%s)\n"
 
-#: plugins/check_http.c:1091 plugins/check_http.c:1096
-#: plugins/check_http.c:1106 plugins/check_http.c:1110
+#: plugins/check_http.c:1213 plugins/check_http.c:1218
+#: plugins/check_http.c:1228 plugins/check_http.c:1232
 #, c-format
 msgid "%s - "
 msgstr ""
 
-#: plugins/check_http.c:1129
+#: plugins/check_http.c:1260
 #, fuzzy, c-format
 msgid "%sheader '%s' not found on '%s://%s:%d%s', "
 msgstr "CRITICAL - Muster nicht gefunden%s|%s %s\n"
 
-#: plugins/check_http.c:1141
+#: plugins/check_http.c:1303
 #, fuzzy, c-format
 msgid "%sstring '%s' not found on '%s://%s:%d%s', "
 msgstr "CRITICAL - Muster nicht gefunden%s|%s %s\n"
 
-#: plugins/check_http.c:1154
+#: plugins/check_http.c:1317
 #, fuzzy, c-format
 msgid "%spattern not found, "
 msgstr "CRITICAL - Muster nicht gefunden%s|%s %s\n"
 
-#: plugins/check_http.c:1156
+#: plugins/check_http.c:1319
 #, fuzzy, c-format
 msgid "%spattern found, "
 msgstr "CRITICAL - Muster nicht gefunden%s|%s %s\n"
 
-#: plugins/check_http.c:1162
+#: plugins/check_http.c:1325
 #, fuzzy, c-format
 msgid "%sExecute Error: %s, "
 msgstr "HTTP CRITICAL - Fehler: %s\n"
 
-#: plugins/check_http.c:1178
+#: plugins/check_http.c:1341
 #, fuzzy, c-format
 msgid "%spage size %d too large, "
 msgstr "HTTP WARNING: Seitengröße %d zu klein%s|%s\n"
 
-#: plugins/check_http.c:1181
+#: plugins/check_http.c:1344
 #, fuzzy, c-format
 msgid "%spage size %d too small, "
 msgstr "HTTP WARNING: Seitengröße %d zu klein%s|%s\n"
 
-#: plugins/check_http.c:1194
+#: plugins/check_http.c:1357
 #, fuzzy, c-format
 msgid "%s - %d bytes in %.3f second response time %s|%s %s %s %s %s %s %s"
 msgstr " - %s - %.3f Sekunden Antwortzeit %s%s|%s %s\n"
 
-#: plugins/check_http.c:1206
+#: plugins/check_http.c:1369
 #, fuzzy, c-format
 msgid "%s - %d bytes in %.3f second response time %s|%s %s"
 msgstr " - %s - %.3f Sekunden Antwortzeit %s%s|%s %s\n"
 
-#: plugins/check_http.c:1244
+#: plugins/check_http.c:1499
 msgid "HTTP UNKNOWN - Could not allocate addr\n"
 msgstr "HTTP UNKNOWN - Konnte addr nicht zuweisen\n"
 
-#: plugins/check_http.c:1248 plugins/check_http.c:1279
+#: plugins/check_http.c:1504 plugins/check_http.c:1535
 #, fuzzy
 msgid "HTTP UNKNOWN - Could not allocate URL\n"
 msgstr "HTTP UNKNOWN - Konnte·url·nicht·zuweisen\n"
 
-#: plugins/check_http.c:1257
+#: plugins/check_http.c:1513
 #, c-format
 msgid "HTTP UNKNOWN - Could not find redirect location - %s%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1272
+#: plugins/check_http.c:1528
 #, fuzzy, c-format
 msgid "HTTP UNKNOWN - Empty redirect location%s\n"
 msgstr "HTTP UNKNOWN - Serverdatum unbekannt\n"
 
-#: plugins/check_http.c:1322
+#: plugins/check_http.c:1590
 #, c-format
 msgid "HTTP UNKNOWN - Could not parse redirect location - %s%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1332
+#: plugins/check_http.c:1600
 #, fuzzy, c-format
 msgid "HTTP WARNING - maximum redirection depth %d exceeded - %s://%s:%d%s%s\n"
 msgstr "HTTP WARNING - Umleitung verursacht eine Schleife - %s://%s:%d%s%s\n"
 
-#: plugins/check_http.c:1340
-#, c-format
-msgid "HTTP WARNING - redirection creates an infinite loop - %s://%s:%d%s%s\n"
+#: plugins/check_http.c:1608
+#, fuzzy, c-format
+msgid "HTTP CRITICAL - redirection creates an infinite loop - %s://%s:%d%s%s\n"
 msgstr "HTTP WARNING - Umleitung verursacht eine Schleife - %s://%s:%d%s%s\n"
 
-#: plugins/check_http.c:1361
+#: plugins/check_http.c:1629
 #, fuzzy, c-format
 msgid "HTTP UNKNOWN - Redirection to port above %d - %s://%s:%d%s%s\n"
 msgstr "HTTP WARNING - Umleitung verursacht eine Schleife - %s://%s:%d%s%s\n"
 
-#: plugins/check_http.c:1366
+#: plugins/check_http.c:1637
 #, c-format
 msgid "Redirection to %s://%s:%d%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1440
+#: plugins/check_http.c:1712
 #, fuzzy
 msgid "This plugin tests the HTTP service on the specified host. It can test"
 msgstr ""
 "Testet den DNS Dienst auf dem angegebenen Host mit dig\n"
 "\n"
 
-#: plugins/check_http.c:1441
+#: plugins/check_http.c:1713
 msgid "normal (http) and secure (https) servers, follow redirects, search for"
 msgstr ""
 
-#: plugins/check_http.c:1442
+#: plugins/check_http.c:1714
 msgid "strings and regular expressions, check connection times, and report on"
 msgstr ""
 
-#: plugins/check_http.c:1443
+#: plugins/check_http.c:1715
 #, fuzzy
 msgid "certificate expiration times."
 msgstr "Clientzertifikat benötigt\n"
 
-#: plugins/check_http.c:1449
+#: plugins/check_http.c:1722
+#, c-format
+msgid "In the first form, make an HTTP request."
+msgstr ""
+
+#: plugins/check_http.c:1723
+#, c-format
+msgid ""
+"In the second form, connect to the server and check the TLS certificate."
+msgstr ""
+
+#: plugins/check_http.c:1725
 #, c-format
 msgid "NOTE: One or both of -H and -I must be specified"
 msgstr ""
 
-#: plugins/check_http.c:1457
+#: plugins/check_http.c:1733
 msgid "Host name argument for servers using host headers (virtual host)"
 msgstr ""
 
-#: plugins/check_http.c:1458
+#: plugins/check_http.c:1734
 msgid "Append a port to include it in the header (eg: example.com:5000)"
 msgstr ""
 
-#: plugins/check_http.c:1460
+#: plugins/check_http.c:1736
 msgid ""
 "IP address or name (use numeric address if possible to bypass DNS lookup)."
 msgstr ""
 
-#: plugins/check_http.c:1462
+#: plugins/check_http.c:1738
 msgid "Port number (default: "
 msgstr ""
 
-#: plugins/check_http.c:1469
+#: plugins/check_http.c:1745
 msgid ""
 "Connect via SSL. Port defaults to 443. VERSION is optional, and prevents"
 msgstr ""
 
-#: plugins/check_http.c:1470
-msgid "auto-negotiation (1 = TLSv1, 2 = SSLv2, 3 = SSLv3)."
+#: plugins/check_http.c:1746
+msgid "auto-negotiation (2 = SSLv2, 3 = SSLv3, 1 = TLSv1, 1.1 = TLSv1.1,"
 msgstr ""
 
-#: plugins/check_http.c:1472
+#: plugins/check_http.c:1747
+msgid "1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."
+msgstr ""
+
+#: plugins/check_http.c:1749
 msgid "Enable SSL/TLS hostname extension support (SNI)"
 msgstr ""
 
-#: plugins/check_http.c:1474
+#: plugins/check_http.c:1751
 msgid ""
 "Minimum number of days a certificate has to be valid. Port defaults to 443"
 msgstr ""
 
-#: plugins/check_http.c:1475
-msgid "(when this option is used the URL is not checked.)"
+#: plugins/check_http.c:1752
+msgid ""
+"(when this option is used the URL is not checked by default. You can use"
 msgstr ""
 
-#: plugins/check_http.c:1477
+#: plugins/check_http.c:1753
+msgid " --continue-after-certificate to override this behavior)"
+msgstr ""
+
+#: plugins/check_http.c:1755
+msgid ""
+"Allows the HTTP check to continue after performing the certificate check."
+msgstr ""
+
+#: plugins/check_http.c:1756
+msgid "Does nothing unless -C is used."
+msgstr ""
+
+#: plugins/check_http.c:1758
 msgid "Name of file that contains the client certificate (PEM format)"
 msgstr ""
 
-#: plugins/check_http.c:1478
+#: plugins/check_http.c:1759
 msgid "to be used in establishing the SSL session"
 msgstr ""
 
-#: plugins/check_http.c:1480
+#: plugins/check_http.c:1761
 msgid "Name of file containing the private key (PEM format)"
 msgstr ""
 
-#: plugins/check_http.c:1481
+#: plugins/check_http.c:1762
 msgid "matching the client certificate"
 msgstr ""
 
-#: plugins/check_http.c:1485
+#: plugins/check_http.c:1766
 msgid "Comma-delimited list of strings, at least one of them is expected in"
 msgstr ""
 
-#: plugins/check_http.c:1486
+#: plugins/check_http.c:1767
 msgid "the first (status) line of the server response (default: "
 msgstr ""
 
-#: plugins/check_http.c:1488
+#: plugins/check_http.c:1769
 msgid ""
 "If specified skips all other status line logic (ex: 3xx, 4xx, 5xx processing)"
 msgstr ""
 
-#: plugins/check_http.c:1490
+#: plugins/check_http.c:1771
 msgid "String to expect in the response headers"
 msgstr ""
 
-#: plugins/check_http.c:1492
+#: plugins/check_http.c:1773
 msgid "String to expect in the content"
 msgstr ""
 
-#: plugins/check_http.c:1494
+#: plugins/check_http.c:1775
 msgid "URL to GET or POST (default: /)"
 msgstr ""
 
-#: plugins/check_http.c:1496
+#: plugins/check_http.c:1777
 msgid "URL encoded http POST data"
 msgstr ""
 
-#: plugins/check_http.c:1498
+#: plugins/check_http.c:1779
 msgid "Set HTTP method."
 msgstr ""
 
-#: plugins/check_http.c:1500
+#: plugins/check_http.c:1781
 msgid "Don't wait for document body: stop reading after headers."
 msgstr ""
 
-#: plugins/check_http.c:1501
+#: plugins/check_http.c:1782
 msgid "(Note that this still does an HTTP GET or POST, not a HEAD.)"
 msgstr ""
 
-#: plugins/check_http.c:1503
+#: plugins/check_http.c:1784
 msgid "Warn if document is more than SECONDS old. the number can also be of"
 msgstr ""
 
-#: plugins/check_http.c:1504
+#: plugins/check_http.c:1785
 msgid "the form \"10m\" for minutes, \"10h\" for hours, or \"10d\" for days."
 msgstr ""
 
-#: plugins/check_http.c:1506
+#: plugins/check_http.c:1787
 msgid "specify Content-Type header media type when POSTing\n"
 msgstr ""
 
-#: plugins/check_http.c:1509
+#: plugins/check_http.c:1790
 msgid "Allow regex to span newlines (must precede -r or -R)"
 msgstr ""
 
-#: plugins/check_http.c:1511
+#: plugins/check_http.c:1792
 msgid "Search page for regex STRING"
 msgstr ""
 
-#: plugins/check_http.c:1513
+#: plugins/check_http.c:1794
 msgid "Search page for case-insensitive regex STRING"
 msgstr ""
 
-#: plugins/check_http.c:1515
+#: plugins/check_http.c:1796
 msgid "Return CRITICAL if found, OK if not\n"
 msgstr ""
 
-#: plugins/check_http.c:1518
+#: plugins/check_http.c:1799
 msgid "Username:password on sites with basic authentication"
 msgstr ""
 
-#: plugins/check_http.c:1520
+#: plugins/check_http.c:1801
 msgid "Username:password on proxy-servers with basic authentication"
 msgstr ""
 
-#: plugins/check_http.c:1522
+#: plugins/check_http.c:1803
 msgid "String to be sent in http header as \"User Agent\""
 msgstr ""
 
-#: plugins/check_http.c:1524
+#: plugins/check_http.c:1805
 msgid ""
 "Any other tags to be sent in http header. Use multiple times for additional "
 "headers"
 msgstr ""
 
-#: plugins/check_http.c:1526
+#: plugins/check_http.c:1807
 msgid "Print additional performance data"
 msgstr ""
 
-#: plugins/check_http.c:1528
+#: plugins/check_http.c:1809
+msgid "Print body content below status line"
+msgstr ""
+
+#: plugins/check_http.c:1811
 msgid "Wrap output in HTML link (obsoleted by urlize)"
 msgstr ""
 
-#: plugins/check_http.c:1530
+#: plugins/check_http.c:1813
 msgid "How to handle redirected pages. sticky is like follow but stick to the"
 msgstr ""
 
-#: plugins/check_http.c:1531
+#: plugins/check_http.c:1814
 msgid "specified IP address. stickyport also ensures port stays the same."
 msgstr ""
 
-#: plugins/check_http.c:1533
+#: plugins/check_http.c:1816
+#, fuzzy
+msgid "Maximal number of redirects (default: "
+msgstr "Ungültige Portnummer"
+
+#: plugins/check_http.c:1819
 msgid "Minimum page size required (bytes) : Maximum page size required (bytes)"
 msgstr ""
 
-#: plugins/check_http.c:1543
+#: plugins/check_http.c:1828
 #, fuzzy
 msgid "This plugin will attempt to open an HTTP connection with the host."
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_http.c:1544
+#: plugins/check_http.c:1829
 msgid ""
 "Successful connects return STATE_OK, refusals and timeouts return "
 "STATE_CRITICAL"
 msgstr ""
 
-#: plugins/check_http.c:1545
+#: plugins/check_http.c:1830
 msgid ""
 "other errors return STATE_UNKNOWN.  Successful connects, but incorrect "
 "response"
 msgstr ""
 
-#: plugins/check_http.c:1546
+#: plugins/check_http.c:1831
 msgid ""
 "messages from the host result in STATE_WARNING return values.  If you are"
 msgstr ""
 
-#: plugins/check_http.c:1547
+#: plugins/check_http.c:1832
 msgid ""
 "checking a virtual server that uses 'host headers' you must supply the FQDN"
 msgstr ""
 
-#: plugins/check_http.c:1548
+#: plugins/check_http.c:1833
 msgid "(fully qualified domain name) as the [host_name] argument."
 msgstr ""
 
-#: plugins/check_http.c:1552
+#: plugins/check_http.c:1837
 msgid "This plugin can also check whether an SSL enabled web server is able to"
 msgstr ""
 
-#: plugins/check_http.c:1553
+#: plugins/check_http.c:1838
 msgid "serve content (optionally within a specified time) or whether the X509 "
 msgstr ""
 
-#: plugins/check_http.c:1554
+#: plugins/check_http.c:1839
 msgid "certificate is still valid for the specified number of days."
 msgstr ""
 
-#: plugins/check_http.c:1556
+#: plugins/check_http.c:1841
 #, fuzzy
 msgid "Please note that this plugin does not check if the presented server"
 msgstr ""
 "Testet den DNS Dienst auf dem angegebenen Host mit dig\n"
 "\n"
 
-#: plugins/check_http.c:1557
+#: plugins/check_http.c:1842
 msgid "certificate matches the hostname of the server, or if the certificate"
 msgstr ""
 
-#: plugins/check_http.c:1558
+#: plugins/check_http.c:1843
 msgid "has a valid chain of trust to one of the locally installed CAs."
 msgstr ""
 
-#: plugins/check_http.c:1562
+#: plugins/check_http.c:1847
 msgid ""
 "When the 'www.verisign.com' server returns its content within 5 seconds,"
 msgstr ""
 
-#: plugins/check_http.c:1563
+#: plugins/check_http.c:1848 plugins/check_http.c:1867
 msgid ""
 "a STATE_OK will be returned. When the server returns its content but exceeds"
 msgstr ""
 
-#: plugins/check_http.c:1564
+#: plugins/check_http.c:1849 plugins/check_http.c:1868
 msgid ""
 "the 5-second threshold, a STATE_WARNING will be returned. When an error "
 "occurs,"
 msgstr ""
 
-#: plugins/check_http.c:1565
+#: plugins/check_http.c:1850
 msgid "a STATE_CRITICAL will be returned."
 msgstr ""
 
-#: plugins/check_http.c:1568
+#: plugins/check_http.c:1853
 msgid ""
 "When the certificate of 'www.verisign.com' is valid for more than 14 days,"
 msgstr ""
 
-#: plugins/check_http.c:1569 plugins/check_http.c:1575
+#: plugins/check_http.c:1854 plugins/check_http.c:1860
 msgid ""
 "a STATE_OK is returned. When the certificate is still valid, but for less "
 "than"
 msgstr ""
 
-#: plugins/check_http.c:1570
+#: plugins/check_http.c:1855
 msgid ""
 "14 days, a STATE_WARNING is returned. A STATE_CRITICAL will be returned when"
 msgstr ""
 
-#: plugins/check_http.c:1571
+#: plugins/check_http.c:1856
 #, fuzzy
 msgid "the certificate is expired."
 msgstr "Clientzertifikat benötigt\n"
 
-#: plugins/check_http.c:1574
+#: plugins/check_http.c:1859
 msgid ""
 "When the certificate of 'www.verisign.com' is valid for more than 30 days,"
 msgstr ""
 
-#: plugins/check_http.c:1576
+#: plugins/check_http.c:1861
 msgid "30 days, but more than 14 days, a STATE_WARNING is returned."
 msgstr ""
 
-#: plugins/check_http.c:1577
+#: plugins/check_http.c:1862
 msgid ""
 "A STATE_CRITICAL will be returned when certificate expires in less than 14 "
 "days"
 msgstr ""
 
-#: plugins/check_ldap.c:133
-#, c-format
-msgid "Could not connect to the server at port %i\n"
+#: plugins/check_http.c:1865
+msgid ""
+"check_http -I 192.168.100.35 -p 80 -u https://www.verisign.com/ -S -j "
+"CONNECT -H www.verisign.com "
+msgstr ""
+
+#: plugins/check_http.c:1866
+msgid ""
+"all these options are needed: -I <proxy> -p <proxy-port> -u <check-url> -"
+"S(sl) -j CONNECT -H <webserver>"
+msgstr ""
+
+#: plugins/check_http.c:1869
+msgid ""
+"a STATE_CRITICAL will be returned. By adding a colon to the method you can "
+"set the method used"
+msgstr ""
+
+#: plugins/check_http.c:1870
+msgid "inside the proxied connection: -j CONNECT:POST"
 msgstr ""
 
 #: plugins/check_ldap.c:142
 #, c-format
+msgid "Could not connect to the server at port %i\n"
+msgstr ""
+
+#: plugins/check_ldap.c:151
+#, c-format
 msgid "Could not set protocol version %d\n"
 msgstr ""
 
-#: plugins/check_ldap.c:157
+#: plugins/check_ldap.c:166
 #, fuzzy, c-format
 msgid "Could not init TLS at port %i!\n"
 msgstr "Konnte stderr nicht öffnen für: %s\n"
 
-#: plugins/check_ldap.c:161
+#: plugins/check_ldap.c:170
 #, c-format
 msgid "TLS not supported by the libraries!\n"
 msgstr ""
 
-#: plugins/check_ldap.c:181
+#: plugins/check_ldap.c:190
 #, fuzzy, c-format
 msgid "Could not init startTLS at port %i!\n"
 msgstr "Konnte stderr nicht öffnen für: %s\n"
 
-#: plugins/check_ldap.c:185
+#: plugins/check_ldap.c:194
 #, c-format
 msgid "startTLS not supported by the library, needs LDAPv3!\n"
 msgstr ""
 
-#: plugins/check_ldap.c:195
+#: plugins/check_ldap.c:204
 #, c-format
 msgid "Could not bind to the LDAP server\n"
 msgstr ""
 
-#: plugins/check_ldap.c:204
+#: plugins/check_ldap.c:213
 #, c-format
 msgid "Could not search/find objectclasses in %s\n"
 msgstr ""
 
-#: plugins/check_ldap.c:227
+#: plugins/check_ldap.c:252
+#, fuzzy, c-format
+msgid "LDAP %s - found %d entries in %.3f seconds|%s %s\n"
+msgstr "HTTP OK %s - %.3f Sekunde Antwortzeit %s%s|%s %s\n"
+
+#: plugins/check_ldap.c:265
 #, c-format
 msgid "LDAP %s - %.3f seconds response time|%s\n"
 msgstr ""
 
-#: plugins/check_ldap.c:339 plugins/check_ldap.c:347
+#: plugins/check_ldap.c:386 plugins/check_ldap.c:394
 #, c-format
 msgid "%s cannot be combined with %s"
 msgstr ""
 
-#: plugins/check_ldap.c:379
+#: plugins/check_ldap.c:426
 msgid "Please specify the host name\n"
 msgstr ""
 
-#: plugins/check_ldap.c:382
+#: plugins/check_ldap.c:429
 msgid "Please specify the LDAP base\n"
 msgstr ""
 
-#: plugins/check_ldap.c:411
+#: plugins/check_ldap.c:465
 msgid "ldap attribute to search (default: \"(objectclass=*)\""
 msgstr ""
 
-#: plugins/check_ldap.c:413
+#: plugins/check_ldap.c:467
 msgid "ldap base (eg. ou=my unit, o=my org, c=at"
 msgstr ""
 
-#: plugins/check_ldap.c:415
+#: plugins/check_ldap.c:469
 msgid "ldap bind DN (if required)"
 msgstr ""
 
-#: plugins/check_ldap.c:417
-msgid "ldap password (if required)"
+#: plugins/check_ldap.c:471
+msgid ""
+"ldap password (if required, or set the password through environment variable "
+"'LDAP_PASSWORD')"
 msgstr ""
 
-#: plugins/check_ldap.c:419
+#: plugins/check_ldap.c:473
 msgid "use starttls mechanism introduced in protocol version 3"
 msgstr ""
 
-#: plugins/check_ldap.c:421
+#: plugins/check_ldap.c:475
 msgid "use ldaps (ldap v2 ssl method). this also sets the default port to"
 msgstr ""
 
-#: plugins/check_ldap.c:425
+#: plugins/check_ldap.c:479
 msgid "use ldap protocol version 2"
 msgstr ""
 
-#: plugins/check_ldap.c:427
+#: plugins/check_ldap.c:481
 msgid "use ldap protocol version 3"
 msgstr ""
 
-#: plugins/check_ldap.c:428
+#: plugins/check_ldap.c:482
 msgid "default protocol version:"
 msgstr ""
 
-#: plugins/check_ldap.c:439
+#: plugins/check_ldap.c:488
+msgid "Number of found entries to result in warning status"
+msgstr ""
+
+#: plugins/check_ldap.c:490
+msgid "Number of found entries to result in critical status"
+msgstr ""
+
+#: plugins/check_ldap.c:498
 msgid "If this plugin is called via 'check_ldaps', method 'STARTTLS' will be"
 msgstr ""
 
-#: plugins/check_ldap.c:440
+#: plugins/check_ldap.c:499
 #, c-format
 msgid ""
 " implied (using default port %i) unless --port=636 is specified. In that "
 "case\n"
 msgstr ""
 
-#: plugins/check_ldap.c:441
+#: plugins/check_ldap.c:500
 msgid "'SSL on connect' will be used no matter how the plugin was called."
 msgstr ""
 
-#: plugins/check_ldap.c:442
+#: plugins/check_ldap.c:501
 msgid ""
 "This detection is deprecated, please use 'check_ldap' with the '--starttls' "
 "or '--ssl' flags"
 msgstr ""
 
-#: plugins/check_ldap.c:443
+#: plugins/check_ldap.c:502
 msgid "to define the behaviour explicitly instead."
 msgstr ""
 
-#: plugins/check_load.c:87
+#: plugins/check_ldap.c:503
+msgid "The parameters --warn-entries and --crit-entries are optional."
+msgstr ""
+
+#: plugins/check_load.c:93
 msgid "Warning threshold must be float or float triplet!\n"
 msgstr ""
 
-#: plugins/check_load.c:132 plugins/check_load.c:148
+#: plugins/check_load.c:138 plugins/check_load.c:154
 #, c-format
 msgid "Error opening %s\n"
 msgstr ""
 
-#: plugins/check_load.c:163
+#: plugins/check_load.c:169
 #, fuzzy, c-format
-msgid "could not parse load from uptime: %s\n"
+msgid "could not parse load from uptime %s: %d\n"
 msgstr "Argumente konnten nicht ausgewertet werden"
 
-#: plugins/check_load.c:169
+#: plugins/check_load.c:175
 #, c-format
 msgid "Error code %d returned in %s\n"
 msgstr ""
 
-#: plugins/check_load.c:184
+#: plugins/check_load.c:183
 #, c-format
 msgid "Error in getloadavg()\n"
 msgstr ""
 
-#: plugins/check_load.c:187 plugins/check_load.c:189
+#: plugins/check_load.c:186 plugins/check_load.c:188
 #, c-format
 msgid "Error processing %s\n"
 msgstr ""
 
-#: plugins/check_load.c:198
+#: plugins/check_load.c:197 plugins/check_load.c:212
 #, c-format
 msgid "load average: %.2f, %.2f, %.2f"
 msgstr ""
 
-#: plugins/check_load.c:291
+#: plugins/check_load.c:327
 #, fuzzy, c-format
 msgid "Critical threshold for %d-minute load average is not specified\n"
 msgstr "Critical threshold muss ein positiver Integer sein\n"
 
-#: plugins/check_load.c:293
+#: plugins/check_load.c:329
 #, fuzzy, c-format
 msgid "Warning threshold for %d-minute load average is not specified\n"
 msgstr "Warning threshold muss ein positiver Integer sein\n"
 
-#: plugins/check_load.c:295
+#: plugins/check_load.c:331
 #, c-format
 msgid ""
 "Parameter inconsistency: %d-minute \"warning load\" is greater than "
 "\"critical load\"\n"
 msgstr ""
 
-#: plugins/check_load.c:311
+#: plugins/check_load.c:346
 #, c-format
 msgid "This plugin tests the current system load average."
 msgstr ""
 
-#: plugins/check_load.c:321
+#: plugins/check_load.c:356
 msgid "Exit with WARNING status if load average exceeds WLOADn"
 msgstr ""
 
-#: plugins/check_load.c:323
+#: plugins/check_load.c:358
 msgid "Exit with CRITICAL status if load average exceed CLOADn"
 msgstr ""
 
-#: plugins/check_load.c:324
+#: plugins/check_load.c:359
 msgid "the load average format is the same used by \"uptime\" and \"w\""
 msgstr ""
 
-#: plugins/check_load.c:326
+#: plugins/check_load.c:361
 msgid "Divide the load averages by the number of CPUs (when possible)"
+msgstr ""
+
+#: plugins/check_load.c:363
+msgid "Number of processes to show when printing the top consuming processes."
+msgstr ""
+
+#: plugins/check_load.c:364
+msgid "NUMBER_OF_PROCS=0 disables this feature. Default value is 0"
+msgstr ""
+
+#: plugins/check_load.c:401
+#, c-format
+msgid "'%s' exited with non-zero status.\n"
+msgstr ""
+
+#: plugins/check_load.c:405
+#, c-format
+msgid "some error occurred getting procs list.\n"
 msgstr ""
 
 #: plugins/check_mrtg.c:75
@@ -2043,7 +2230,7 @@ msgstr ""
 
 #: plugins/check_mrtgtraf.c:194
 #, c-format
-msgid "%s. In = %0.1f %s, %s. Out = %0.1f %s|%s %s\n"
+msgid "%s. In = %0.1f %s/s, %s. Out = %0.1f %s/s|%s %s\n"
 msgstr ""
 
 #: plugins/check_mrtgtraf.c:207
@@ -2128,130 +2315,134 @@ msgstr ""
 msgid "Usage"
 msgstr ""
 
-#: plugins/check_mysql.c:171
+#: plugins/check_mysql.c:185
 #, c-format
 msgid "status store_result error: %s\n"
 msgstr ""
 
-#: plugins/check_mysql.c:202
+#: plugins/check_mysql.c:216
 #, c-format
 msgid "slave query error: %s\n"
 msgstr ""
 
-#: plugins/check_mysql.c:209
+#: plugins/check_mysql.c:223
 #, c-format
 msgid "slave store_result error: %s\n"
 msgstr ""
 
-#: plugins/check_mysql.c:215
+#: plugins/check_mysql.c:229
 msgid "No slaves defined"
 msgstr ""
 
-#: plugins/check_mysql.c:223
+#: plugins/check_mysql.c:237
 #, c-format
 msgid "slave fetch row error: %s\n"
 msgstr ""
 
-#: plugins/check_mysql.c:228
+#: plugins/check_mysql.c:242
 #, c-format
 msgid "Slave running: %s"
 msgstr ""
 
-#: plugins/check_mysql.c:505
+#: plugins/check_mysql.c:520
 msgid "This program tests connections to a MySQL server"
 msgstr ""
 
-#: plugins/check_mysql.c:516
+#: plugins/check_mysql.c:531
+msgid "Ignore authentication failure and check for mysql connectivity only"
+msgstr ""
+
+#: plugins/check_mysql.c:534
 msgid "Use the specified socket (has no effect if -H is used)"
 msgstr ""
 
-#: plugins/check_mysql.c:519
+#: plugins/check_mysql.c:537
 msgid "Check database with indicated name"
 msgstr ""
 
-#: plugins/check_mysql.c:521
+#: plugins/check_mysql.c:539
 msgid "Read from the specified client options file"
 msgstr ""
 
-#: plugins/check_mysql.c:523
+#: plugins/check_mysql.c:541
 msgid "Use a client options group"
 msgstr ""
 
-#: plugins/check_mysql.c:525
+#: plugins/check_mysql.c:543
 msgid "Connect using the indicated username"
 msgstr ""
 
-#: plugins/check_mysql.c:527
+#: plugins/check_mysql.c:545
 msgid "Use the indicated password to authenticate the connection"
 msgstr ""
 
-#: plugins/check_mysql.c:528
+#: plugins/check_mysql.c:546
 msgid "IMPORTANT: THIS FORM OF AUTHENTICATION IS NOT SECURE!!!"
 msgstr ""
 
-#: plugins/check_mysql.c:529
+#: plugins/check_mysql.c:547
 msgid "Your clear-text password could be visible as a process table entry"
 msgstr ""
 
-#: plugins/check_mysql.c:531
+#: plugins/check_mysql.c:549
 msgid "Check if the slave thread is running properly."
 msgstr ""
 
-#: plugins/check_mysql.c:533
+#: plugins/check_mysql.c:551
 msgid "Exit with WARNING status if slave server is more than INTEGER seconds"
 msgstr ""
 
-#: plugins/check_mysql.c:534 plugins/check_mysql.c:537
+#: plugins/check_mysql.c:552 plugins/check_mysql.c:555
 msgid "behind master"
 msgstr ""
 
-#: plugins/check_mysql.c:536
+#: plugins/check_mysql.c:554
 msgid "Exit with CRITICAL status if slave server is more then INTEGER seconds"
 msgstr ""
 
-#: plugins/check_mysql.c:539
-msgid "Use ssl encryptation"
+#: plugins/check_mysql.c:557
+msgid "Use ssl encryption"
 msgstr ""
 
-#: plugins/check_mysql.c:541
+#: plugins/check_mysql.c:559
 msgid "Path to CA signing the cert"
 msgstr ""
 
-#: plugins/check_mysql.c:543
+#: plugins/check_mysql.c:561
 msgid "Path to SSL certificate"
 msgstr ""
 
-#: plugins/check_mysql.c:545
+#: plugins/check_mysql.c:563
 msgid "Path to private SSL key"
 msgstr ""
 
-#: plugins/check_mysql.c:547
+#: plugins/check_mysql.c:565
 msgid "Path to CA directory"
 msgstr ""
 
-#: plugins/check_mysql.c:549
+#: plugins/check_mysql.c:567
 msgid "List of valid SSL ciphers"
 msgstr ""
 
-#: plugins/check_mysql.c:553
+#: plugins/check_mysql.c:571
 msgid ""
 "There are no required arguments. By default, the local database is checked"
 msgstr ""
 
-#: plugins/check_mysql.c:554
+#: plugins/check_mysql.c:572
 msgid ""
 "using the default unix socket. You can force TCP on localhost by using an"
 msgstr ""
 
-#: plugins/check_mysql.c:555
+#: plugins/check_mysql.c:573
 msgid "IP address or FQDN ('localhost' will use the socket as well)."
 msgstr ""
 
-#: plugins/check_mysql.c:559
+#: plugins/check_mysql.c:577
 msgid "You must specify -p with an empty string to force an empty password,"
 msgstr ""
 
-#: plugins/check_mysql.c:560
+#: plugins/check_mysql.c:578
 msgid "overriding any my.cnf settings."
 msgstr ""
 
@@ -2272,7 +2463,7 @@ msgstr ""
 msgid "Cannot parse Nagios log file for valid time"
 msgstr ""
 
-#: plugins/check_nagios.c:183 plugins/check_procs.c:356
+#: plugins/check_nagios.c:183 plugins/check_procs.c:379
 #, c-format
 msgid "%d process"
 msgid_plural "%d processes"
@@ -2351,7 +2542,7 @@ msgstr ""
 msgid "Wrong client version - running: %s, required: %s"
 msgstr ""
 
-#: plugins/check_nt.c:153 plugins/check_nt.c:218
+#: plugins/check_nt.c:153 plugins/check_nt.c:239
 msgid "missing -l parameters"
 msgstr ""
 
@@ -2377,494 +2568,515 @@ msgstr ""
 msgid "not enough values for -l parameters"
 msgstr ""
 
-#: plugins/check_nt.c:206
-#, c-format
-msgid "System Uptime - %u day(s) %u hour(s) %u minute(s)"
-msgstr ""
-
-#: plugins/check_nt.c:220
+#: plugins/check_nt.c:208 plugins/check_nt.c:241
 msgid "wrong -l argument"
 msgstr ""
 
-#: plugins/check_nt.c:236
+#: plugins/check_nt.c:225
+#, c-format
+msgid "System Uptime - %u day(s) %u hour(s) %u minute(s) |uptime=%lu"
+msgstr ""
+
+#: plugins/check_nt.c:257
 #, c-format
 msgid "%s:\\ - total: %.2f Gb - used: %.2f Gb (%.0f%%) - free %.2f Gb (%.0f%%)"
 msgstr ""
 
-#: plugins/check_nt.c:239
+#: plugins/check_nt.c:260
 #, c-format
 msgid "'%s:\\ Used Space'=%.2fGb;%.2f;%.2f;0.00;%.2f"
 msgstr ""
 
-#: plugins/check_nt.c:253
+#: plugins/check_nt.c:274
 msgid "Free disk space : Invalid drive"
 msgstr ""
 
-#: plugins/check_nt.c:263
+#: plugins/check_nt.c:284
 msgid "No service/process specified"
 msgstr ""
 
-#: plugins/check_nt.c:271 plugins/check_nt.c:284 plugins/check_nt.c:288
-#: plugins/check_nt.c:622
+#: plugins/check_nt.c:292 plugins/check_nt.c:305 plugins/check_nt.c:309
+#: plugins/check_nt.c:643
 msgid "could not fetch information from server\n"
 msgstr ""
 
-#: plugins/check_nt.c:296
+#: plugins/check_nt.c:317
 #, c-format
 msgid ""
-"Memory usage: total:%.2f Mb - used: %.2f Mb (%.0f%%) - free: %.2f Mb (%.0f%%)"
+"Memory usage: total:%.2f MB - used: %.2f MB (%.0f%%) - free: %.2f MB (%.0f%%)"
 msgstr ""
 
-#: plugins/check_nt.c:299
+#: plugins/check_nt.c:320
 #, c-format
-msgid "'Memory usage'=%.2fMb;%.2f;%.2f;0.00;%.2f"
+msgid "'Memory usage'=%.2fMB;%.2f;%.2f;0.00;%.2f"
 msgstr ""
 
-#: plugins/check_nt.c:335 plugins/check_nt.c:420 plugins/check_nt.c:450
+#: plugins/check_nt.c:356 plugins/check_nt.c:441 plugins/check_nt.c:471
 msgid "No counter specified"
 msgstr ""
 
-#: plugins/check_nt.c:367
+#: plugins/check_nt.c:388
 msgid "Minimum value contains non-numbers"
 msgstr ""
 
-#: plugins/check_nt.c:371
+#: plugins/check_nt.c:392
 msgid "Maximum value contains non-numbers"
 msgstr ""
 
-#: plugins/check_nt.c:378
+#: plugins/check_nt.c:399
 msgid "No unit counter specified"
 msgstr ""
 
-#: plugins/check_nt.c:465
+#: plugins/check_nt.c:486
 msgid "Please specify a variable to check"
 msgstr ""
 
-#: plugins/check_nt.c:549
+#: plugins/check_nt.c:570
 #, fuzzy
 msgid "Server port must be an integer\n"
 msgstr "skip lines muss ein Integer sein"
 
-#: plugins/check_nt.c:603
+#: plugins/check_nt.c:624
 #, fuzzy
 msgid "You must provide a server address or host name"
 msgstr "Hostname oder Serveradresse muss angegeben werden"
 
-#: plugins/check_nt.c:609
+#: plugins/check_nt.c:630
 msgid "None"
 msgstr ""
 
-#: plugins/check_nt.c:666
+#: plugins/check_nt.c:687
 msgid "This plugin collects data from the NSClient service running on a"
 msgstr ""
 
-#: plugins/check_nt.c:667
+#: plugins/check_nt.c:688
 msgid "Windows NT/2000/XP/2003 server."
 msgstr ""
 
-#: plugins/check_nt.c:678
+#: plugins/check_nt.c:699
 msgid "Name of the host to check"
 msgstr ""
 
-#: plugins/check_nt.c:680
+#: plugins/check_nt.c:701
 #, fuzzy
 msgid "Optional port number (default: "
 msgstr "Ungültige Portnummer"
 
-#: plugins/check_nt.c:683
+#: plugins/check_nt.c:704
 msgid "Password needed for the request"
 msgstr ""
 
-#: plugins/check_nt.c:685 plugins/check_nwstat.c:1661
+#: plugins/check_nt.c:706 plugins/check_nwstat.c:1661
 #: plugins/check_overcr.c:432
 msgid "Threshold which will result in a warning status"
 msgstr ""
 
-#: plugins/check_nt.c:687 plugins/check_nwstat.c:1663
+#: plugins/check_nt.c:708 plugins/check_nwstat.c:1663
 #: plugins/check_overcr.c:434
 msgid "Threshold which will result in a critical status"
 msgstr ""
 
-#: plugins/check_nt.c:689
+#: plugins/check_nt.c:710
 msgid "Seconds before connection attempt times out (default: "
 msgstr ""
 
-#: plugins/check_nt.c:691
+#: plugins/check_nt.c:712
 msgid "Parameters passed to specified check (see below)"
 msgstr ""
 
-#: plugins/check_nt.c:693
+#: plugins/check_nt.c:714
 msgid "Display options (currently only SHOWALL works)"
 msgstr ""
 
-#: plugins/check_nt.c:695
+#: plugins/check_nt.c:716
 msgid "Return UNKNOWN on timeouts"
 msgstr ""
 
-#: plugins/check_nt.c:698
+#: plugins/check_nt.c:719
 msgid "Print this help screen"
 msgstr ""
 
-#: plugins/check_nt.c:700
+#: plugins/check_nt.c:721
 msgid "Print version information"
 msgstr ""
 
-#: plugins/check_nt.c:702
+#: plugins/check_nt.c:723
 msgid "Variable to check"
 msgstr ""
 
-#: plugins/check_nt.c:703
+#: plugins/check_nt.c:724
 msgid "Valid variables are:"
 msgstr ""
 
-#: plugins/check_nt.c:705
+#: plugins/check_nt.c:726
 msgid "Get the NSClient version"
 msgstr ""
 
-#: plugins/check_nt.c:706
+#: plugins/check_nt.c:727
 msgid "If -l <version> is specified, will return warning if versions differ."
 msgstr ""
 
-#: plugins/check_nt.c:708
+#: plugins/check_nt.c:729
 msgid "Average CPU load on last x minutes."
 msgstr ""
 
-#: plugins/check_nt.c:709
+#: plugins/check_nt.c:730
 msgid "Request a -l parameter with the following syntax:"
 msgstr ""
 
-#: plugins/check_nt.c:710
+#: plugins/check_nt.c:731
 msgid "-l <minutes range>,<warning threshold>,<critical threshold>."
 msgstr ""
 
-#: plugins/check_nt.c:711
+#: plugins/check_nt.c:732
 msgid "<minute range> should be less than 24*60."
 msgstr ""
 
-#: plugins/check_nt.c:712
+#: plugins/check_nt.c:733
 msgid ""
 "Thresholds are percentage and up to 10 requests can be done in one shot."
 msgstr ""
 
-#: plugins/check_nt.c:715
+#: plugins/check_nt.c:736
 msgid "Get the uptime of the machine."
 msgstr ""
 
-#: plugins/check_nt.c:716
-msgid "No specific parameters. No warning or critical threshold"
-msgstr ""
-
-#: plugins/check_nt.c:718
-msgid "Size and percentage of disk use."
-msgstr ""
-
-#: plugins/check_nt.c:719
-msgid "Request a -l parameter containing the drive letter only."
-msgstr ""
-
-#: plugins/check_nt.c:720 plugins/check_nt.c:723
-msgid "Warning and critical thresholds can be specified with -w and -c."
-msgstr ""
-
-#: plugins/check_nt.c:722
-msgid "Memory use."
-msgstr ""
-
-#: plugins/check_nt.c:725
-msgid "Check the state of one or several services."
-msgstr ""
-
-#: plugins/check_nt.c:726 plugins/check_nt.c:735
-msgid "Request a -l parameters with the following syntax:"
-msgstr ""
-
-#: plugins/check_nt.c:727
-msgid "-l <service1>,<service2>,<service3>,..."
-msgstr ""
-
-#: plugins/check_nt.c:728
-msgid "You can specify -d SHOWALL in case you want to see working services"
-msgstr ""
-
-#: plugins/check_nt.c:729
-msgid "in the returned string."
-msgstr ""
-
-#: plugins/check_nt.c:731
-msgid "Check if one or several process are running."
-msgstr ""
-
-#: plugins/check_nt.c:732
-msgid "Same syntax as SERVICESTATE."
-msgstr ""
-
-#: plugins/check_nt.c:734
-msgid "Check any performance counter of Windows NT/2000."
-msgstr ""
-
-#: plugins/check_nt.c:736
-msgid "-l \"\\\\<performance object>\\\\counter\",\"<description>"
-msgstr ""
-
 #: plugins/check_nt.c:737
-msgid "The <description> parameter is optional and is given to a printf "
+msgid "-l <unit> "
 msgstr ""
 
 #: plugins/check_nt.c:738
-msgid "output command which requires a float parameter."
+msgid "<unit> = seconds, minutes, hours, or days. (default: minutes)"
 msgstr ""
 
 #: plugins/check_nt.c:739
+#, fuzzy
+msgid "Thresholds will use the unit specified above."
+msgstr ""
+"Testet den DNS Dienst auf dem angegebenen Host mit dig\n"
+"\n"
+
+#: plugins/check_nt.c:741
+msgid "Size and percentage of disk use."
+msgstr ""
+
+#: plugins/check_nt.c:742
+msgid "Request a -l parameter containing the drive letter only."
+msgstr ""
+
+#: plugins/check_nt.c:743 plugins/check_nt.c:746
+msgid "Warning and critical thresholds can be specified with -w and -c."
+msgstr ""
+
+#: plugins/check_nt.c:745
+msgid "Memory use."
+msgstr ""
+
+#: plugins/check_nt.c:748
+msgid "Check the state of one or several services."
+msgstr ""
+
+#: plugins/check_nt.c:749 plugins/check_nt.c:758
+msgid "Request a -l parameters with the following syntax:"
+msgstr ""
+
+#: plugins/check_nt.c:750
+msgid "-l <service1>,<service2>,<service3>,..."
+msgstr ""
+
+#: plugins/check_nt.c:751
+msgid "You can specify -d SHOWALL in case you want to see working services"
+msgstr ""
+
+#: plugins/check_nt.c:752
+msgid "in the returned string."
+msgstr ""
+
+#: plugins/check_nt.c:754
+msgid "Check if one or several process are running."
+msgstr ""
+
+#: plugins/check_nt.c:755
+msgid "Same syntax as SERVICESTATE."
+msgstr ""
+
+#: plugins/check_nt.c:757
+msgid "Check any performance counter of Windows NT/2000."
+msgstr ""
+
+#: plugins/check_nt.c:759
+msgid "-l \"\\\\<performance object>\\\\counter\",\"<description>"
+msgstr ""
+
+#: plugins/check_nt.c:760
+msgid "The <description> parameter is optional and is given to a printf "
+msgstr ""
+
+#: plugins/check_nt.c:761
+msgid "output command which requires a float parameter."
+msgstr ""
+
+#: plugins/check_nt.c:762
 #, c-format
 msgid "If <description> does not include \"%%\", it is used as a label."
 msgstr ""
 
-#: plugins/check_nt.c:740 plugins/check_nt.c:755
+#: plugins/check_nt.c:763 plugins/check_nt.c:778
 msgid "Some examples:"
 msgstr ""
 
-#: plugins/check_nt.c:744
+#: plugins/check_nt.c:767
 msgid "Check any performance counter object of Windows NT/2000."
 msgstr ""
 
-#: plugins/check_nt.c:745
+#: plugins/check_nt.c:768
 msgid ""
 "Syntax: check_nt -H <hostname> -p <port> -v INSTANCES -l <counter object>"
 msgstr ""
 
-#: plugins/check_nt.c:746
+#: plugins/check_nt.c:769
 msgid "<counter object> is a Windows Perfmon Counter object (eg. Process),"
 msgstr ""
 
-#: plugins/check_nt.c:747
+#: plugins/check_nt.c:770
 msgid "if it is two words, it should be enclosed in quotes"
 msgstr ""
 
-#: plugins/check_nt.c:748
+#: plugins/check_nt.c:771
 msgid "The returned results will be a comma-separated list of instances on "
 msgstr ""
 
-#: plugins/check_nt.c:749
+#: plugins/check_nt.c:772
 msgid " the selected computer for that object."
 msgstr ""
 
-#: plugins/check_nt.c:750
+#: plugins/check_nt.c:773
 msgid ""
 "The purpose of this is to be run from command line to determine what "
 "instances"
 msgstr ""
 
-#: plugins/check_nt.c:751
+#: plugins/check_nt.c:774
 msgid ""
 " are available for monitoring without having to log onto the Windows server"
 msgstr ""
 
-#: plugins/check_nt.c:752
+#: plugins/check_nt.c:775
 msgid "  to run Perfmon directly."
 msgstr ""
 
-#: plugins/check_nt.c:753
+#: plugins/check_nt.c:776
 msgid ""
 "It can also be used in scripts that automatically create the monitoring "
 "service"
 msgstr ""
 
-#: plugins/check_nt.c:754
+#: plugins/check_nt.c:777
 msgid " configuration files."
 msgstr ""
 
-#: plugins/check_nt.c:756
+#: plugins/check_nt.c:779
 msgid "check_nt -H 192.168.1.1 -p 1248 -v INSTANCES -l Process"
 msgstr ""
 
-#: plugins/check_nt.c:759
+#: plugins/check_nt.c:782
 msgid ""
 "- The NSClient service should be running on the server to get any information"
 msgstr ""
 
-#: plugins/check_nt.c:761
+#: plugins/check_nt.c:784
 msgid "- Critical thresholds should be lower than warning thresholds"
 msgstr ""
 
-#: plugins/check_nt.c:762
+#: plugins/check_nt.c:785
 msgid "- Default port 1248 is sometimes in use by other services. The error"
 msgstr ""
 
-#: plugins/check_nt.c:763
+#: plugins/check_nt.c:786
 msgid ""
 "output when this happens contains \"Cannot map xxxxx to protocol number\"."
 msgstr ""
 
-#: plugins/check_nt.c:764
+#: plugins/check_nt.c:787
 msgid "One fix for this is to change the port to something else on check_nt "
 msgstr ""
 
-#: plugins/check_nt.c:765
+#: plugins/check_nt.c:788
 msgid "and on the client service it's connecting to."
 msgstr ""
 
-#: plugins/check_ntp.c:807 plugins/check_ntp_peer.c:612
-#: plugins/check_ntp_time.c:571
+#: plugins/check_ntp.c:629
+#, c-format
+msgid "jitter response too large (%lu bytes)\n"
+msgstr ""
+
+#: plugins/check_ntp.c:817 plugins/check_ntp_peer.c:619
+#: plugins/check_ntp_time.c:576
 msgid "NTP CRITICAL:"
 msgstr "NTP CRITICAL:"
 
-#: plugins/check_ntp.c:810 plugins/check_ntp_peer.c:615
-#: plugins/check_ntp_time.c:574
+#: plugins/check_ntp.c:820 plugins/check_ntp_peer.c:622
+#: plugins/check_ntp_time.c:579
 msgid "NTP WARNING:"
 msgstr "NTP WARNING:"
 
-#: plugins/check_ntp.c:813 plugins/check_ntp_peer.c:618
-#: plugins/check_ntp_time.c:577
+#: plugins/check_ntp.c:823 plugins/check_ntp_peer.c:625
+#: plugins/check_ntp_time.c:582
 msgid "NTP OK:"
 msgstr "NTP OK:"
 
-#: plugins/check_ntp.c:816 plugins/check_ntp_peer.c:621
-#: plugins/check_ntp_time.c:580
+#: plugins/check_ntp.c:826 plugins/check_ntp_peer.c:628
+#: plugins/check_ntp_time.c:585
 msgid "NTP UNKNOWN:"
 msgstr "NTP UNKNOWN:"
 
-#: plugins/check_ntp.c:820 plugins/check_ntp_peer.c:630
-#: plugins/check_ntp_time.c:584
+#: plugins/check_ntp.c:830 plugins/check_ntp_peer.c:637
+#: plugins/check_ntp_time.c:589
 msgid "Offset unknown"
 msgstr ""
 
-#: plugins/check_ntp.c:823 plugins/check_ntp_peer.c:633
-#: plugins/check_ntp_time.c:587
+#: plugins/check_ntp.c:833 plugins/check_ntp_peer.c:640
+#: plugins/check_ntp_peer.c:642 plugins/check_ntp_peer.c:644
+#: plugins/check_ntp_time.c:592
 msgid "Offset"
 msgstr ""
 
-#: plugins/check_ntp.c:844 plugins/check_ntp_peer.c:662
+#: plugins/check_ntp.c:854 plugins/check_ntp_peer.c:690
 #, fuzzy
 msgid "This plugin checks the selected ntp server"
 msgstr ""
 "Testet den DNS Dienst auf dem angegebenen Host mit dig\n"
 "\n"
 
-#: plugins/check_ntp.c:854 plugins/check_ntp_peer.c:674
-#: plugins/check_ntp_time.c:614
+#: plugins/check_ntp.c:864 plugins/check_ntp_peer.c:702
+#: plugins/check_ntp_time.c:619
 msgid "Offset to result in warning status (seconds)"
 msgstr ""
 
-#: plugins/check_ntp.c:856 plugins/check_ntp_peer.c:676
-#: plugins/check_ntp_time.c:616
+#: plugins/check_ntp.c:866 plugins/check_ntp_peer.c:704
+#: plugins/check_ntp_time.c:621
 msgid "Offset to result in critical status (seconds)"
 msgstr ""
 
-#: plugins/check_ntp.c:858 plugins/check_ntp_peer.c:682
+#: plugins/check_ntp.c:868 plugins/check_ntp_peer.c:710
 #, fuzzy
 msgid "Warning threshold for jitter"
 msgstr "Warning threshold  Integer sein"
 
-#: plugins/check_ntp.c:860 plugins/check_ntp_peer.c:684
+#: plugins/check_ntp.c:870 plugins/check_ntp_peer.c:712
 #, fuzzy
 msgid "Critical threshold for jitter"
 msgstr "Critical threshold muss ein Integer sein"
 
-#: plugins/check_ntp.c:870
+#: plugins/check_ntp.c:880
 msgid "Normal offset check:"
 msgstr ""
 
-#: plugins/check_ntp.c:873 plugins/check_ntp_peer.c:709
+#: plugins/check_ntp.c:883 plugins/check_ntp_peer.c:737
 msgid ""
 "Check jitter too, avoiding critical notifications if jitter isn't available"
 msgstr ""
 
-#: plugins/check_ntp.c:874 plugins/check_ntp_peer.c:710
+#: plugins/check_ntp.c:884 plugins/check_ntp_peer.c:738
 msgid "(See Notes above for more details on thresholds formats):"
 msgstr ""
 
-#: plugins/check_ntp.c:879 plugins/check_ntp.c:886
+#: plugins/check_ntp.c:889 plugins/check_ntp.c:896
 msgid "WARNING: check_ntp is deprecated. Please use check_ntp_peer or"
 msgstr ""
 
-#: plugins/check_ntp.c:880 plugins/check_ntp.c:887
+#: plugins/check_ntp.c:890 plugins/check_ntp.c:897
 msgid "check_ntp_time instead."
 msgstr ""
 
-#: plugins/check_ntp_peer.c:625
+#: plugins/check_ntp_peer.c:632
 msgid "Server not synchronized"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:627
+#: plugins/check_ntp_peer.c:634
 msgid "Server has the LI_ALARM bit set"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:672
+#: plugins/check_ntp_peer.c:700
 msgid ""
 "Returns UNKNOWN instead of CRITICAL or WARNING if server isn't synchronized"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:678
+#: plugins/check_ntp_peer.c:706
 #, fuzzy
 msgid "Warning threshold for stratum of server's synchronization peer"
 msgstr "Warning threshold  Integer sein"
 
-#: plugins/check_ntp_peer.c:680
+#: plugins/check_ntp_peer.c:708
 #, fuzzy
 msgid "Critical threshold for stratum of server's synchronization peer"
 msgstr "Critical threshold muss ein Integer sein"
 
-#: plugins/check_ntp_peer.c:686
+#: plugins/check_ntp_peer.c:714
 #, fuzzy
 msgid "Warning threshold for number of usable time sources (\"truechimers\")"
 msgstr "Warning threshold muss ein positiver Integer sein\n"
 
-#: plugins/check_ntp_peer.c:688
+#: plugins/check_ntp_peer.c:716
 #, fuzzy
 msgid "Critical threshold for number of usable time sources (\"truechimers\")"
 msgstr "Critical threshold muss ein positiver Integer sein\n"
 
-#: plugins/check_ntp_peer.c:693
+#: plugins/check_ntp_peer.c:721
 msgid "This plugin checks an NTP server independent of any commandline"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:694
+#: plugins/check_ntp_peer.c:722
 msgid "programs or external libraries."
 msgstr ""
 
-#: plugins/check_ntp_peer.c:697
+#: plugins/check_ntp_peer.c:725
 #, fuzzy
 msgid "Use this plugin to check the health of an NTP server. It supports"
 msgstr ""
 "Testet den DNS Dienst auf dem angegebenen Host mit dig\n"
 "\n"
 
-#: plugins/check_ntp_peer.c:698
+#: plugins/check_ntp_peer.c:726
 msgid "checking the offset with the sync peer, the jitter and stratum. This"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:699
+#: plugins/check_ntp_peer.c:727
 msgid "plugin will not check the clock offset between the local host and NTP"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:700
+#: plugins/check_ntp_peer.c:728
 msgid "server; please use check_ntp_time for that purpose."
 msgstr ""
 
-#: plugins/check_ntp_peer.c:706
+#: plugins/check_ntp_peer.c:734
 msgid "Simple NTP server check:"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:713
+#: plugins/check_ntp_peer.c:741
 msgid "Only check the number of usable time sources (\"truechimers\"):"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:716
+#: plugins/check_ntp_peer.c:744
 msgid "Check only stratum:"
 msgstr ""
 
-#: plugins/check_ntp_time.c:602
+#: plugins/check_ntp_time.c:607
 #, fuzzy
 msgid "This plugin checks the clock offset with the ntp server"
 msgstr ""
 "Testet den DNS Dienst auf dem angegebenen Host mit dig\n"
 "\n"
 
-#: plugins/check_ntp_time.c:612
+#: plugins/check_ntp_time.c:617
 msgid "Returns UNKNOWN instead of CRITICAL if offset cannot be found"
 msgstr ""
 
-#: plugins/check_ntp_time.c:621
+#: plugins/check_ntp_time.c:623
+msgid "Expected offset of the ntp server relative to local server (seconds)"
+msgstr ""
+
+#: plugins/check_ntp_time.c:628
 #, fuzzy
 msgid "This plugin checks the clock offset between the local host and a"
 msgstr ""
@@ -2873,20 +3085,28 @@ msgstr ""
 "unterschritten wird.\n"
 "\n"
 
-#: plugins/check_ntp_time.c:622
+#: plugins/check_ntp_time.c:629
 msgid "remote NTP server. It is independent of any commandline programs or"
 msgstr ""
 
-#: plugins/check_ntp_time.c:623
+#: plugins/check_ntp_time.c:630
 msgid "external libraries."
 msgstr ""
 
-#: plugins/check_ntp_time.c:627
+#: plugins/check_ntp_time.c:634
 msgid "If you'd rather want to monitor an NTP server, please use"
 msgstr ""
 
-#: plugins/check_ntp_time.c:628
+#: plugins/check_ntp_time.c:635
 msgid "check_ntp_peer."
+msgstr ""
+
+#: plugins/check_ntp_time.c:636
+msgid "--time-offset is useful for compensating for servers with known"
+msgstr ""
+
+#: plugins/check_ntp_time.c:637
+msgid "and expected clock skew."
 msgstr ""
 
 #: plugins/check_nwstat.c:194
@@ -3457,600 +3677,635 @@ msgid ""
 "higher than the warning threshold value, EXCEPT with the uptime variable"
 msgstr ""
 
-#: plugins/check_pgsql.c:222
+#: plugins/check_pgsql.c:224
 #, c-format
 msgid "CRITICAL - no connection to '%s' (%s).\n"
 msgstr ""
 
-#: plugins/check_pgsql.c:250
+#: plugins/check_pgsql.c:252
 #, c-format
 msgid " %s - database %s (%f sec.)|%s\n"
 msgstr ""
 
-#: plugins/check_pgsql.c:317 plugins/check_time.c:277 plugins/check_time.c:289
-#: plugins/check_users.c:181
+#: plugins/check_pgsql.c:320 plugins/check_time.c:277 plugins/check_time.c:289
+#: plugins/check_users.c:228
 msgid "Critical threshold must be a positive integer"
 msgstr "Critical threshold muss ein positiver Integer sein"
 
-#: plugins/check_pgsql.c:323 plugins/check_time.c:258 plugins/check_time.c:282
-#: plugins/check_users.c:187 plugins/check_users.c:197
-#: plugins/check_users.c:203
+#: plugins/check_pgsql.c:326 plugins/check_time.c:258 plugins/check_time.c:282
+#: plugins/check_users.c:226
 msgid "Warning threshold must be a positive integer"
 msgstr "Warning threshold muss ein positiver Integer sein"
 
-#: plugins/check_pgsql.c:347
-msgid "Database name is not valid"
+#: plugins/check_pgsql.c:350
+msgid "Database name exceeds the maximum length"
 msgstr ""
 
-#: plugins/check_pgsql.c:353
+#: plugins/check_pgsql.c:356
 msgid "User name is not valid"
 msgstr ""
 
-#: plugins/check_pgsql.c:504
+#: plugins/check_pgsql.c:471
 #, c-format
 msgid "Test whether a PostgreSQL Database is accepting connections."
 msgstr ""
 
-#: plugins/check_pgsql.c:516
+#: plugins/check_pgsql.c:483
 msgid "Database to check "
 msgstr ""
 
-#: plugins/check_pgsql.c:517
+#: plugins/check_pgsql.c:484
 #, c-format
-msgid "(default: %s)"
+msgid "(default: %s)\n"
 msgstr ""
 
-#: plugins/check_pgsql.c:519
+#: plugins/check_pgsql.c:486
 msgid "Login name of user"
 msgstr ""
 
-#: plugins/check_pgsql.c:521
+#: plugins/check_pgsql.c:488
 msgid "Password (BIG SECURITY ISSUE)"
 msgstr ""
 
-#: plugins/check_pgsql.c:523
+#: plugins/check_pgsql.c:490
 msgid "Connection parameters (keyword = value), see below"
 msgstr ""
 
-#: plugins/check_pgsql.c:530
+#: plugins/check_pgsql.c:497
 msgid "SQL query to run. Only first column in first row will be read"
 msgstr ""
 
-#: plugins/check_pgsql.c:532
+#: plugins/check_pgsql.c:499
+msgid "A name for the query, this string is used instead of the query"
+msgstr ""
+
+#: plugins/check_pgsql.c:500
+msgid "in the long output of the plugin"
+msgstr ""
+
+#: plugins/check_pgsql.c:502
 msgid "SQL query value to result in warning status (double)"
 msgstr ""
 
-#: plugins/check_pgsql.c:534
+#: plugins/check_pgsql.c:504
 msgid "SQL query value to result in critical status (double)"
 msgstr ""
 
-#: plugins/check_pgsql.c:539
+#: plugins/check_pgsql.c:509
 msgid "All parameters are optional."
 msgstr ""
 
-#: plugins/check_pgsql.c:540
+#: plugins/check_pgsql.c:510
 msgid ""
 "This plugin tests a PostgreSQL DBMS to determine whether it is active and"
 msgstr ""
 
-#: plugins/check_pgsql.c:541
+#: plugins/check_pgsql.c:511
 msgid "accepting queries. In its current operation, it simply connects to the"
 msgstr ""
 
-#: plugins/check_pgsql.c:542
+#: plugins/check_pgsql.c:512
 msgid ""
 "specified database, and then disconnects. If no database is specified, it"
 msgstr ""
 
-#: plugins/check_pgsql.c:543
+#: plugins/check_pgsql.c:513
 msgid ""
 "connects to the template1 database, which is present in every functioning"
 msgstr ""
 
-#: plugins/check_pgsql.c:544
+#: plugins/check_pgsql.c:514
 msgid "PostgreSQL DBMS."
 msgstr ""
 
-#: plugins/check_pgsql.c:546
+#: plugins/check_pgsql.c:516
 msgid "If a query is specified using the -q option, it will be executed after"
 msgstr ""
 
-#: plugins/check_pgsql.c:547
+#: plugins/check_pgsql.c:517
 msgid "connecting to the server. The result from the query has to be numeric."
 msgstr ""
 
-#: plugins/check_pgsql.c:548
+#: plugins/check_pgsql.c:518
 msgid ""
 "Multiple SQL commands, separated by semicolon, are allowed but the result "
 msgstr ""
 
-#: plugins/check_pgsql.c:549
+#: plugins/check_pgsql.c:519
 msgid "of the last command is taken into account only. The value of the first"
 msgstr ""
 
-#: plugins/check_pgsql.c:550
-msgid "column in the first row is used as the check result."
+#: plugins/check_pgsql.c:520
+msgid ""
+"column in the first row is used as the check result. If a second column is"
 msgstr ""
 
-#: plugins/check_pgsql.c:552
+#: plugins/check_pgsql.c:521
+msgid "present in the result set, this is added to the plugin output with a"
+msgstr ""
+
+#: plugins/check_pgsql.c:522
+msgid ""
+"prefix of \"Extra Info:\". This information can be displayed in the system"
+msgstr ""
+
+#: plugins/check_pgsql.c:523
+msgid "executing the plugin."
+msgstr ""
+
+#: plugins/check_pgsql.c:525
 msgid ""
 "See the chapter \"Monitoring Database Activity\" of the PostgreSQL manual"
 msgstr ""
 
-#: plugins/check_pgsql.c:553
+#: plugins/check_pgsql.c:526
 msgid ""
 "for details about how to access internal statistics of the database server."
 msgstr ""
 
-#: plugins/check_pgsql.c:555
+#: plugins/check_pgsql.c:528
 msgid ""
 "For a list of available connection parameters which may be used with the -o"
 msgstr ""
 
-#: plugins/check_pgsql.c:556
+#: plugins/check_pgsql.c:529
 msgid ""
 "command line option, see the documentation for PQconnectdb() in the chapter"
 msgstr ""
 
-#: plugins/check_pgsql.c:557
+#: plugins/check_pgsql.c:530
 msgid ""
 "\"libpq - C Library\" of the PostgreSQL manual. For example, this may be"
 msgstr ""
 
-#: plugins/check_pgsql.c:558
+#: plugins/check_pgsql.c:531
 msgid ""
 "used to specify a service name in pg_service.conf to be used for additional"
 msgstr ""
 
-#: plugins/check_pgsql.c:559
+#: plugins/check_pgsql.c:532
 msgid "connection parameters: -o 'service=<name>' or to specify the SSL mode:"
 msgstr ""
 
-#: plugins/check_pgsql.c:560
+#: plugins/check_pgsql.c:533
 msgid "-o 'sslmode=require'."
 msgstr ""
 
-#: plugins/check_pgsql.c:562
+#: plugins/check_pgsql.c:535
 msgid ""
 "The plugin will connect to a local postmaster if no host is specified. To"
 msgstr ""
 
-#: plugins/check_pgsql.c:563
+#: plugins/check_pgsql.c:536
 msgid ""
 "connect to a remote host, be sure that the remote postmaster accepts TCP/IP"
 msgstr ""
 
-#: plugins/check_pgsql.c:564
+#: plugins/check_pgsql.c:537
 msgid "connections (start the postmaster with the -i option)."
 msgstr ""
 
-#: plugins/check_pgsql.c:566
+#: plugins/check_pgsql.c:539
 msgid ""
 "Typically, the monitoring user (unless the --logname option is used) should "
 "be"
 msgstr ""
 
-#: plugins/check_pgsql.c:567
+#: plugins/check_pgsql.c:540
 msgid ""
 "able to connect to the database without a password. The plugin can also send"
 msgstr ""
 
-#: plugins/check_pgsql.c:568
+#: plugins/check_pgsql.c:541
 msgid "a password, but no effort is made to obscure or encrypt the password."
 msgstr ""
 
-#: plugins/check_pgsql.c:601
+#: plugins/check_pgsql.c:575
 #, c-format
 msgid "QUERY %s - %s: %s.\n"
 msgstr ""
 
-#: plugins/check_pgsql.c:601
+#: plugins/check_pgsql.c:575
 msgid "Error with query"
 msgstr ""
 
-#: plugins/check_pgsql.c:607
+#: plugins/check_pgsql.c:581
 msgid "No rows returned"
 msgstr ""
 
-#: plugins/check_pgsql.c:612
+#: plugins/check_pgsql.c:586
 msgid "No columns returned"
 msgstr ""
 
-#: plugins/check_pgsql.c:618
+#: plugins/check_pgsql.c:592
 #, fuzzy
 msgid "No data returned"
 msgstr "Keine Daten empfangen %s\n"
 
-#: plugins/check_pgsql.c:627
+#: plugins/check_pgsql.c:601
 msgid "Is not a numeric"
 msgstr ""
 
-#: plugins/check_pgsql.c:644
+#: plugins/check_pgsql.c:619
+#, fuzzy, c-format
+msgid "%s returned %f"
+msgstr "%s hat %s zurückgegeben"
+
+#: plugins/check_pgsql.c:622
 #, fuzzy, c-format
 msgid "'%s' returned %f"
 msgstr "%s hat %s zurückgegeben"
 
-#: plugins/check_ping.c:141
+#: plugins/check_ping.c:143
 msgid "CRITICAL - Could not interpret output from ping command\n"
 msgstr ""
 
-#: plugins/check_ping.c:157
+#: plugins/check_ping.c:159
 #, c-format
 msgid "PING %s - %sPacket loss = %d%%"
 msgstr ""
 
-#: plugins/check_ping.c:160
+#: plugins/check_ping.c:162
 #, c-format
 msgid "PING %s - %sPacket loss = %d%%, RTA = %2.2f ms"
 msgstr ""
 
-#: plugins/check_ping.c:257
+#: plugins/check_ping.c:263
 msgid "Could not realloc() addresses\n"
 msgstr ""
 
-#: plugins/check_ping.c:272 plugins/check_ping.c:352
+#: plugins/check_ping.c:278 plugins/check_ping.c:358
 #, c-format
 msgid "<max_packets> (%s) must be a non-negative number\n"
 msgstr ""
 
-#: plugins/check_ping.c:306
+#: plugins/check_ping.c:312
 #, c-format
 msgid "<wpl> (%s) must be an integer percentage\n"
 msgstr ""
 
-#: plugins/check_ping.c:317
+#: plugins/check_ping.c:323
 #, c-format
 msgid "<cpl> (%s) must be an integer percentage\n"
 msgstr ""
 
-#: plugins/check_ping.c:328
+#: plugins/check_ping.c:334
 #, c-format
 msgid "<wrta> (%s) must be a non-negative number\n"
 msgstr ""
 
-#: plugins/check_ping.c:339
+#: plugins/check_ping.c:345
 #, c-format
 msgid "<crta> (%s) must be a non-negative number\n"
 msgstr ""
 
-#: plugins/check_ping.c:372
+#: plugins/check_ping.c:378
 #, c-format
 msgid ""
 "%s: Warning threshold must be integer or percentage!\n"
 "\n"
 msgstr ""
 
-#: plugins/check_ping.c:385
+#: plugins/check_ping.c:391
 #, c-format
 msgid "<wrta> was not set\n"
 msgstr ""
 
-#: plugins/check_ping.c:389
+#: plugins/check_ping.c:395
 #, c-format
 msgid "<crta> was not set\n"
 msgstr ""
 
-#: plugins/check_ping.c:393
+#: plugins/check_ping.c:399
 #, c-format
 msgid "<wpl> was not set\n"
 msgstr ""
 
-#: plugins/check_ping.c:397
+#: plugins/check_ping.c:403
 #, c-format
 msgid "<cpl> was not set\n"
 msgstr ""
 
-#: plugins/check_ping.c:401
+#: plugins/check_ping.c:407
 #, c-format
 msgid "<wrta> (%f) cannot be larger than <crta> (%f)\n"
 msgstr ""
 
-#: plugins/check_ping.c:405
+#: plugins/check_ping.c:411
 #, c-format
 msgid "<wpl> (%d) cannot be larger than <cpl> (%d)\n"
 msgstr ""
 
-#: plugins/check_ping.c:442
+#: plugins/check_ping.c:448
 #, c-format
 msgid "Cannot open stderr for %s\n"
 msgstr ""
 
-#: plugins/check_ping.c:492 plugins/check_ping.c:494
+#: plugins/check_ping.c:505 plugins/check_ping.c:507
 msgid "System call sent warnings to stderr "
 msgstr ""
 
-#: plugins/check_ping.c:519
+#: plugins/check_ping.c:533
 #, fuzzy, c-format
 msgid "CRITICAL - Network Unreachable (%s)\n"
 msgstr "CRITICAL - Netzwerk nicht erreichbar (%s)"
 
-#: plugins/check_ping.c:521
+#: plugins/check_ping.c:535
 #, fuzzy, c-format
 msgid "CRITICAL - Host Unreachable (%s)\n"
 msgstr "CRITICAL - Netzwerk nicht erreichbar (%s)"
 
-#: plugins/check_ping.c:523
+#: plugins/check_ping.c:537
 #, fuzzy, c-format
 msgid "CRITICAL - Bogus ICMP: Port Unreachable (%s)\n"
 msgstr "CRITICAL - Netzwerk nicht erreichbar (%s)"
 
-#: plugins/check_ping.c:525
+#: plugins/check_ping.c:539
 #, fuzzy, c-format
 msgid "CRITICAL - Bogus ICMP: Protocol Unreachable (%s)\n"
 msgstr "CRITICAL - Netzwerk nicht erreichbar (%s)"
 
-#: plugins/check_ping.c:527
+#: plugins/check_ping.c:541
 #, fuzzy, c-format
 msgid "CRITICAL - Network Prohibited (%s)\n"
 msgstr "CRITICAL - Netzwerk nicht erreichbar (%s)"
 
-#: plugins/check_ping.c:529
+#: plugins/check_ping.c:543
 #, fuzzy, c-format
 msgid "CRITICAL - Host Prohibited (%s)\n"
 msgstr "CRITICAL - Netzwerk nicht erreichbar (%s)"
 
-#: plugins/check_ping.c:531
+#: plugins/check_ping.c:545
 #, fuzzy, c-format
 msgid "CRITICAL - Packet Filtered (%s)\n"
 msgstr "CRITICAL - Netzwerk nicht erreichbar (%s)"
 
-#: plugins/check_ping.c:533
+#: plugins/check_ping.c:547
 #, fuzzy, c-format
 msgid "CRITICAL - Host not found (%s)\n"
 msgstr "CRITICAL - Text nicht gefunden%s|%s %s\n"
 
-#: plugins/check_ping.c:535
+#: plugins/check_ping.c:549
 #, fuzzy, c-format
 msgid "CRITICAL - Time to live exceeded (%s)\n"
 msgstr "CRITICAL - Netzwerk nicht erreichbar (%s)"
 
-#: plugins/check_ping.c:537
+#: plugins/check_ping.c:551
 #, fuzzy, c-format
 msgid "CRITICAL - Destination Unreachable (%s)\n"
 msgstr "CRITICAL - Netzwerk nicht erreichbar (%s)"
 
-#: plugins/check_ping.c:544
+#: plugins/check_ping.c:558
 msgid "Unable to realloc warn_text\n"
 msgstr ""
 
-#: plugins/check_ping.c:561
+#: plugins/check_ping.c:575
 #, c-format
 msgid "Use ping to check connection statistics for a remote host."
 msgstr ""
 
-#: plugins/check_ping.c:573
+#: plugins/check_ping.c:587
 msgid "host to ping"
 msgstr ""
 
-#: plugins/check_ping.c:579
+#: plugins/check_ping.c:593
 msgid "number of ICMP ECHO packets to send"
 msgstr ""
 
-#: plugins/check_ping.c:580
+#: plugins/check_ping.c:594
 #, c-format
 msgid "(Default: %d)\n"
 msgstr ""
 
-#: plugins/check_ping.c:582
+#: plugins/check_ping.c:596
 msgid "show HTML in the plugin output (obsoleted by urlize)"
 msgstr ""
 
-#: plugins/check_ping.c:587
+#: plugins/check_ping.c:601
 msgid "THRESHOLD is <rta>,<pl>% where <rta> is the round trip average travel"
 msgstr ""
 
-#: plugins/check_ping.c:588
+#: plugins/check_ping.c:602
 msgid "time (ms) which triggers a WARNING or CRITICAL state, and <pl> is the"
 msgstr ""
 
-#: plugins/check_ping.c:589
+#: plugins/check_ping.c:603
 msgid "percentage of packet loss to trigger an alarm state."
 msgstr ""
 
-#: plugins/check_ping.c:592
+#: plugins/check_ping.c:606
 #, fuzzy
 msgid ""
 "This plugin uses the ping command to probe the specified host for packet loss"
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_ping.c:593
+#: plugins/check_ping.c:607
 msgid ""
 "(percentage) and round trip average (milliseconds). It can produce HTML "
 "output"
 msgstr ""
 
-#: plugins/check_ping.c:594
+#: plugins/check_ping.c:608
 msgid ""
 "linking to a traceroute CGI contributed by Ian Cass. The CGI can be found in"
 msgstr ""
 
-#: plugins/check_ping.c:595
+#: plugins/check_ping.c:609
 msgid "the contrib area of the downloads section at http://www.nagios.org/"
 msgstr ""
 
-#: plugins/check_procs.c:193
+#: plugins/check_procs.c:197
 #, c-format
 msgid "CMD: %s\n"
 msgstr ""
 
-#: plugins/check_procs.c:198
+#: plugins/check_procs.c:202
 msgid "System call sent warnings to stderr"
 msgstr ""
 
-#: plugins/check_procs.c:326
+#: plugins/check_procs.c:349
 #, c-format
 msgid "Not parseable: %s"
 msgstr ""
 
-#: plugins/check_procs.c:331
+#: plugins/check_procs.c:354
 #, c-format
 msgid "Unable to read output\n"
 msgstr ""
 
-#: plugins/check_procs.c:348
+#: plugins/check_procs.c:371
 #, c-format
 msgid "%d warn out of "
 msgstr ""
 
-#: plugins/check_procs.c:353
+#: plugins/check_procs.c:376
 #, c-format
 msgid "%d crit, %d warn out of "
 msgstr ""
 
-#: plugins/check_procs.c:359
+#: plugins/check_procs.c:382
 #, c-format
 msgid " with %s"
 msgstr ""
 
-#: plugins/check_procs.c:453
+#: plugins/check_procs.c:477
 #, fuzzy
 msgid "Parent Process ID must be an integer!"
 msgstr "Argument für check_dummy muss ein Integer sein"
 
-#: plugins/check_procs.c:459 plugins/check_procs.c:586
+#: plugins/check_procs.c:483 plugins/check_procs.c:627
 #, c-format
 msgid "%s%sSTATE = %s"
 msgstr ""
 
-#: plugins/check_procs.c:468
+#: plugins/check_procs.c:492
 #, fuzzy
 msgid "UID was not found"
 msgstr "%s [%s nicht gefunden]"
 
-#: plugins/check_procs.c:474
+#: plugins/check_procs.c:498
 #, fuzzy
 msgid "User name was not found"
 msgstr "%s [%s nicht gefunden]"
 
-#: plugins/check_procs.c:489
+#: plugins/check_procs.c:513
 #, c-format
 msgid "%s%scommand name '%s'"
 msgstr ""
 
-#: plugins/check_procs.c:524
+#: plugins/check_procs.c:522
+#, c-format
+msgid "%s%sexclude progs '%s'"
+msgstr ""
+
+#: plugins/check_procs.c:565
 #, fuzzy
 msgid "RSS must be an integer!"
 msgstr "skip lines muss ein Integer sein"
 
-#: plugins/check_procs.c:531
+#: plugins/check_procs.c:572
 #, fuzzy
 msgid "VSZ must be an integer!"
 msgstr "skip lines muss ein Integer sein"
 
-#: plugins/check_procs.c:539
+#: plugins/check_procs.c:580
 msgid "PCPU must be a float!"
 msgstr ""
 
-#: plugins/check_procs.c:563
+#: plugins/check_procs.c:604
 msgid "Metric must be one of PROCS, VSZ, RSS, CPU, ELAPSED!"
 msgstr ""
 
-#: plugins/check_procs.c:694
+#: plugins/check_procs.c:735
 msgid ""
 "Checks all processes and generates WARNING or CRITICAL states if the "
 "specified"
 msgstr ""
 
-#: plugins/check_procs.c:695
+#: plugins/check_procs.c:736
 msgid ""
 "metric is outside the required threshold ranges. The metric defaults to "
 "number"
 msgstr ""
 
-#: plugins/check_procs.c:696
+#: plugins/check_procs.c:737
 msgid ""
 "of processes.  Search filters can be applied to limit the processes to check."
 msgstr ""
 
-#: plugins/check_procs.c:705
+#: plugins/check_procs.c:746
 msgid "Generate warning state if metric is outside this range"
 msgstr ""
 
-#: plugins/check_procs.c:707
+#: plugins/check_procs.c:748
 msgid "Generate critical state if metric is outside this range"
 msgstr ""
 
-#: plugins/check_procs.c:709
+#: plugins/check_procs.c:750
 msgid "Check thresholds against metric. Valid types:"
 msgstr ""
 
-#: plugins/check_procs.c:710
+#: plugins/check_procs.c:751
 msgid "PROCS   - number of processes (default)"
 msgstr ""
 
-#: plugins/check_procs.c:711
+#: plugins/check_procs.c:752
 msgid "VSZ     - virtual memory size"
 msgstr ""
 
-#: plugins/check_procs.c:712
+#: plugins/check_procs.c:753
 msgid "RSS     - resident set memory size"
 msgstr ""
 
-#: plugins/check_procs.c:713
+#: plugins/check_procs.c:754
 msgid "CPU     - percentage CPU"
 msgstr ""
 
-#: plugins/check_procs.c:716
+#: plugins/check_procs.c:757
 msgid "ELAPSED - time elapsed in seconds"
 msgstr ""
 
-#: plugins/check_procs.c:721
+#: plugins/check_procs.c:762
 msgid "Extra information. Up to 3 verbosity levels"
 msgstr ""
 
-#: plugins/check_procs.c:724
+#: plugins/check_procs.c:765
 msgid "Filter own process the traditional way by PID instead of /proc/pid/exe"
 msgstr ""
 
-#: plugins/check_procs.c:729
+#: plugins/check_procs.c:770
 msgid "Only scan for processes that have, in the output of `ps`, one or"
 msgstr ""
 
-#: plugins/check_procs.c:730
+#: plugins/check_procs.c:771
 msgid "more of the status flags you specify (for example R, Z, S, RS,"
 msgstr ""
 
-#: plugins/check_procs.c:731
+#: plugins/check_procs.c:772
 msgid "RSZDT, plus others based on the output of your 'ps' command)."
 msgstr ""
 
-#: plugins/check_procs.c:733
+#: plugins/check_procs.c:774
 msgid "Only scan for children of the parent process ID indicated."
 msgstr ""
 
-#: plugins/check_procs.c:735
+#: plugins/check_procs.c:776
 msgid "Only scan for processes with VSZ higher than indicated."
 msgstr ""
 
-#: plugins/check_procs.c:737
+#: plugins/check_procs.c:778
 msgid "Only scan for processes with RSS higher than indicated."
 msgstr ""
 
-#: plugins/check_procs.c:739
+#: plugins/check_procs.c:780
 msgid "Only scan for processes with PCPU higher than indicated."
 msgstr ""
 
-#: plugins/check_procs.c:741
+#: plugins/check_procs.c:782
 msgid "Only scan for processes with user name or ID indicated."
 msgstr ""
 
-#: plugins/check_procs.c:743
+#: plugins/check_procs.c:784
 msgid "Only scan for processes with args that contain STRING."
 msgstr ""
 
-#: plugins/check_procs.c:745
+#: plugins/check_procs.c:786
 msgid "Only scan for processes with args that contain the regex STRING."
 msgstr ""
 
-#: plugins/check_procs.c:747
+#: plugins/check_procs.c:788
 msgid "Only scan for exact matches of COMMAND (without path)."
 msgstr ""
 
-#: plugins/check_procs.c:749
+#: plugins/check_procs.c:790
+msgid "Exclude processes which match this comma separated list"
+msgstr ""
+
+#: plugins/check_procs.c:792
 msgid "Only scan for non kernel threads (works on Linux only)."
 msgstr ""
 
-#: plugins/check_procs.c:751
+#: plugins/check_procs.c:794
 #, c-format
 msgid ""
 "\n"
@@ -4060,7 +4315,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: plugins/check_procs.c:756
+#: plugins/check_procs.c:799
 #, c-format
 msgid ""
 "This plugin checks the number of currently running processes and\n"
@@ -4071,166 +4326,181 @@ msgid ""
 "\n"
 msgstr ""
 
-#: plugins/check_procs.c:765
+#: plugins/check_procs.c:808
 msgid "Warning if not two processes with command name portsentry."
 msgstr ""
 
-#: plugins/check_procs.c:766
+#: plugins/check_procs.c:809
 msgid "Critical if < 2 or > 1024 processes"
 msgstr ""
 
-#: plugins/check_procs.c:768
+#: plugins/check_procs.c:811
+msgid "Critical if not at least 1 process with command sshd"
+msgstr ""
+
+#: plugins/check_procs.c:813
+msgid "Warning if > 1024 processes with command name sshd."
+msgstr ""
+
+#: plugins/check_procs.c:814
+msgid "Critical if < 1 processes with command name sshd."
+msgstr ""
+
+#: plugins/check_procs.c:816
 msgid "Warning alert if > 10 processes with command arguments containing"
 msgstr ""
 
-#: plugins/check_procs.c:769
+#: plugins/check_procs.c:817
 msgid "'/usr/local/bin/perl' and owned by root"
 msgstr ""
 
-#: plugins/check_procs.c:771
+#: plugins/check_procs.c:819
 msgid "Alert if VSZ of any processes over 50K or 100K"
 msgstr ""
 
-#: plugins/check_procs.c:773
-#, c-format
-msgid "Alert if CPU of any processes over 10%% or 20%%"
+#: plugins/check_procs.c:821
+msgid "Alert if CPU of any processes over 10% or 20%"
 msgstr ""
 
-#: plugins/check_radius.c:165
-msgid "Config file error"
+#: plugins/check_radius.c:181
+msgid "Config file error\n"
 msgstr ""
 
-#: plugins/check_radius.c:174
-msgid "Out of Memory?"
-msgstr ""
-
-#: plugins/check_radius.c:178
-msgid "Invalid NAS-Identifier"
-msgstr ""
-
-#: plugins/check_radius.c:183 plugins/check_radius.c:185
-#: plugins/check_radius.c:191
+#: plugins/check_radius.c:190
 #, fuzzy
-msgid "Invalid NAS-IP-Address"
+msgid "Out of Memory?\n"
+msgstr "Kein Papier"
+
+#: plugins/check_radius.c:194
+#, fuzzy
+msgid "Invalid NAS-Identifier\n"
 msgstr "Ungültige(r) Hostname/Adresse"
 
-#: plugins/check_radius.c:188
-msgid "Can't find local IP for NAS-IP-Address"
+#: plugins/check_radius.c:199 plugins/check_smtp.c:155
+#, c-format
+msgid "gethostname() failed!\n"
 msgstr ""
 
-#: plugins/check_radius.c:202
-msgid "Timeout"
+#: plugins/check_radius.c:203 plugins/check_radius.c:206
+#, fuzzy
+msgid "Invalid NAS-IP-Address\n"
+msgstr "Ungültige(r) Hostname/Adresse"
+
+#: plugins/check_radius.c:217
+msgid "Timeout\n"
 msgstr ""
 
-#: plugins/check_radius.c:204
-msgid "Auth Error"
+#: plugins/check_radius.c:219
+msgid "Auth Error\n"
 msgstr ""
 
-#: plugins/check_radius.c:206
-msgid "Auth Failed"
+#: plugins/check_radius.c:221
+#, fuzzy
+msgid "Auth Failed\n"
+msgstr "Fehlgeschlagen"
+
+#: plugins/check_radius.c:223
+msgid "Bad Response\n"
 msgstr ""
 
-#: plugins/check_radius.c:208
-msgid "Bad Response"
+#: plugins/check_radius.c:227
+msgid "Auth OK\n"
 msgstr ""
 
-#: plugins/check_radius.c:212
-msgid "Auth OK"
-msgstr ""
-
-#: plugins/check_radius.c:213
+#: plugins/check_radius.c:228
 #, fuzzy, c-format
 msgid "Unexpected result code %d"
 msgstr "Erwartet: %s aber: %s erhalten"
 
-#: plugins/check_radius.c:302
+#: plugins/check_radius.c:317
 msgid "Number of retries must be a positive integer"
 msgstr ""
 
-#: plugins/check_radius.c:316
+#: plugins/check_radius.c:331
 msgid "User not specified"
 msgstr ""
 
-#: plugins/check_radius.c:318
+#: plugins/check_radius.c:333
 msgid "Password not specified"
 msgstr ""
 
-#: plugins/check_radius.c:320
+#: plugins/check_radius.c:335
 msgid "Configuration file not specified"
 msgstr ""
 
-#: plugins/check_radius.c:338
+#: plugins/check_radius.c:353
 #, fuzzy
 msgid "Tests to see if a RADIUS server is accepting connections."
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_radius.c:350
+#: plugins/check_radius.c:365
 msgid "The user to authenticate"
 msgstr ""
 
-#: plugins/check_radius.c:352
+#: plugins/check_radius.c:367
 msgid "Password for authentication (SECURITY RISK)"
 msgstr ""
 
-#: plugins/check_radius.c:354
+#: plugins/check_radius.c:369
 msgid "NAS identifier"
 msgstr ""
 
-#: plugins/check_radius.c:356
+#: plugins/check_radius.c:371
 msgid "NAS IP Address"
 msgstr ""
 
-#: plugins/check_radius.c:358
+#: plugins/check_radius.c:373
 msgid "Configuration file"
 msgstr ""
 
-#: plugins/check_radius.c:360
+#: plugins/check_radius.c:375
 msgid "Response string to expect from the server"
 msgstr ""
 
-#: plugins/check_radius.c:362
+#: plugins/check_radius.c:377
 msgid "Number of times to retry a failed connection"
 msgstr ""
 
-#: plugins/check_radius.c:367
+#: plugins/check_radius.c:382
 #, fuzzy
 msgid ""
 "This plugin tests a RADIUS server to see if it is accepting connections."
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_radius.c:368
+#: plugins/check_radius.c:383
 msgid ""
 "The server to test must be specified in the invocation, as well as a user"
 msgstr ""
 
-#: plugins/check_radius.c:369
+#: plugins/check_radius.c:384
 msgid ""
 "name and password. A configuration file may also be present. The format of"
 msgstr ""
 
-#: plugins/check_radius.c:370
+#: plugins/check_radius.c:385
 msgid ""
 "the configuration file is described in the radiusclient library sources."
 msgstr ""
 
-#: plugins/check_radius.c:371
+#: plugins/check_radius.c:386
 msgid "The password option presents a substantial security issue because the"
 msgstr ""
 
-#: plugins/check_radius.c:372
+#: plugins/check_radius.c:387
 msgid ""
 "password can possibly be determined by careful watching of the command line"
 msgstr ""
 
-#: plugins/check_radius.c:373
-msgid "in a process listing. This risk is exacerbated because the monitor will"
+#: plugins/check_radius.c:388
+msgid "in a process listing. This risk is exacerbated because the plugin will"
 msgstr ""
 
-#: plugins/check_radius.c:374
-msgid "run the plugin at regular predictable intervals. Please be sure that"
+#: plugins/check_radius.c:389
+msgid ""
+"typically be executed at regular predictable intervals. Please be sure that"
 msgstr ""
 
-#: plugins/check_radius.c:375
+#: plugins/check_radius.c:390
 msgid "the password used does not allow access to sensitive system resources."
 msgstr ""
 
@@ -4244,819 +4514,921 @@ msgstr ""
 msgid "No data received from %s\n"
 msgstr ""
 
-#: plugins/check_real.c:118 plugins/check_real.c:191
+#: plugins/check_real.c:118 plugins/check_real.c:192
 #, fuzzy
 msgid "Invalid REAL response received from host"
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_real.c:120 plugins/check_real.c:193
+#: plugins/check_real.c:120 plugins/check_real.c:194
 #, c-format
 msgid "Invalid REAL response received from host on port %d\n"
 msgstr ""
 
-#: plugins/check_real.c:184 plugins/check_tcp.c:311
+#: plugins/check_real.c:185 plugins/check_tcp.c:315
 #, c-format
 msgid "No data received from host\n"
 msgstr ""
 
-#: plugins/check_real.c:247
+#: plugins/check_real.c:248
 #, c-format
 msgid "REAL %s - %d second response time\n"
 msgstr ""
 
-#: plugins/check_real.c:336 plugins/check_ups.c:536
+#: plugins/check_real.c:337 plugins/check_ups.c:539
 msgid "Warning time must be a positive integer"
 msgstr "Warnung time muss ein positiver Integer sein"
 
-#: plugins/check_real.c:345 plugins/check_ups.c:527
+#: plugins/check_real.c:346 plugins/check_ups.c:530
 msgid "Critical time must be a positive integer"
 msgstr "Critical time muss ein positiver Integer sein"
 
-#: plugins/check_real.c:381
+#: plugins/check_real.c:382
 #, fuzzy
 msgid "You must provide a server to check"
 msgstr "%s: Hostname muss angegeben werden\n"
 
-#: plugins/check_real.c:413
+#: plugins/check_real.c:414
 #, fuzzy
 msgid "This plugin tests the REAL service on the specified host."
 msgstr ""
 "Testet den DNS Dienst auf dem angegebenen Host mit dig\n"
 "\n"
 
-#: plugins/check_real.c:425
+#: plugins/check_real.c:426
 msgid "Connect to this url"
 msgstr ""
 
-#: plugins/check_real.c:427
+#: plugins/check_real.c:428
 #, c-format
 msgid "String to expect in first line of server response (default: %s)\n"
 msgstr ""
 
-#: plugins/check_real.c:437
+#: plugins/check_real.c:438
 #, fuzzy
 msgid "This plugin will attempt to open an RTSP connection with the host."
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_real.c:438 plugins/check_smtp.c:830
+#: plugins/check_real.c:439 plugins/check_smtp.c:862
 msgid "Successful connects return STATE_OK, refusals and timeouts return"
-msgstr ""
-
-#: plugins/check_real.c:439
-msgid ""
-"STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful connects,"
 msgstr ""
 
 #: plugins/check_real.c:440
 msgid ""
-"but incorrect response messages from the host result in STATE_WARNING return"
+"STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful connects,"
 msgstr ""
 
 #: plugins/check_real.c:441
+msgid ""
+"but incorrect response messages from the host result in STATE_WARNING return"
+msgstr ""
+
+#: plugins/check_real.c:442
 msgid "values."
 msgstr ""
 
-#: plugins/check_smtp.c:150 plugins/check_swap.c:265 plugins/check_swap.c:271
+#: plugins/check_smtp.c:151 plugins/check_swap.c:283 plugins/check_swap.c:289
 #, c-format
 msgid "malloc() failed!\n"
 msgstr ""
 
-#: plugins/check_smtp.c:154
-#, c-format
-msgid "gethostname() failed!\n"
-msgstr ""
-
-#: plugins/check_smtp.c:189 plugins/check_smtp.c:213
+#: plugins/check_smtp.c:199 plugins/check_smtp.c:211
 #, c-format
 msgid "recv() failed\n"
 msgstr ""
 
-#: plugins/check_smtp.c:200
-#, fuzzy, c-format
-msgid "Invalid SMTP response received from host: %s\n"
-msgstr "Ungültige HTTP Antwort von Host empfangen\n"
-
-#: plugins/check_smtp.c:202
-#, fuzzy, c-format
-msgid "Invalid SMTP response received from host on port %d: %s\n"
-msgstr "Ungültige HTTP Antwort von Host erhalten auf Port %d\n"
-
-#: plugins/check_smtp.c:223
+#: plugins/check_smtp.c:221
 #, c-format
 msgid "WARNING - TLS not supported by server\n"
 msgstr ""
 
-#: plugins/check_smtp.c:235
+#: plugins/check_smtp.c:233
 #, c-format
 msgid "Server does not support STARTTLS\n"
 msgstr ""
 
-#: plugins/check_smtp.c:241
+#: plugins/check_smtp.c:239
 #, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr ""
 
-#: plugins/check_smtp.c:261
+#: plugins/check_smtp.c:259
 msgid "SMTP UNKNOWN - Cannot send EHLO command via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:266
+#: plugins/check_smtp.c:264
 #, c-format
 msgid "sent %s"
 msgstr ""
 
-#: plugins/check_smtp.c:268
+#: plugins/check_smtp.c:266
 msgid "SMTP UNKNOWN - Cannot read EHLO response via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:303 plugins/check_snmp.c:806
+#: plugins/check_smtp.c:296
+#, fuzzy, c-format
+msgid "Invalid SMTP response received from host: %s\n"
+msgstr "Ungültige HTTP Antwort von Host empfangen\n"
+
+#: plugins/check_smtp.c:298
+#, fuzzy, c-format
+msgid "Invalid SMTP response received from host on port %d: %s\n"
+msgstr "Ungültige HTTP Antwort von Host erhalten auf Port %d\n"
+
+#: plugins/check_smtp.c:321 plugins/check_snmp.c:865
 #, c-format
 msgid "Could Not Compile Regular Expression"
 msgstr ""
 
-#: plugins/check_smtp.c:312
+#: plugins/check_smtp.c:330
 #, c-format
 msgid "SMTP %s - Invalid response '%s' to command '%s'\n"
 msgstr ""
 
-#: plugins/check_smtp.c:316 plugins/check_snmp.c:511
+#: plugins/check_smtp.c:334 plugins/check_snmp.c:540
 #, c-format
 msgid "Execute Error: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:330
+#: plugins/check_smtp.c:348
 msgid "no authuser specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:335
+#: plugins/check_smtp.c:353
 msgid "no authpass specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:342 plugins/check_smtp.c:363 plugins/check_smtp.c:383
-#: plugins/check_smtp.c:688
+#: plugins/check_smtp.c:360 plugins/check_smtp.c:381 plugins/check_smtp.c:401
+#: plugins/check_smtp.c:714
 #, c-format
 msgid "sent %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:345
+#: plugins/check_smtp.c:363
 #, fuzzy
 msgid "recv() failed after AUTH LOGIN, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:350 plugins/check_smtp.c:371 plugins/check_smtp.c:391
-#: plugins/check_smtp.c:699
+#: plugins/check_smtp.c:368 plugins/check_smtp.c:389 plugins/check_smtp.c:409
+#: plugins/check_smtp.c:725
 #, fuzzy, c-format
 msgid "received %s\n"
 msgstr "Keine Daten empfangen %s\n"
 
-#: plugins/check_smtp.c:354
+#: plugins/check_smtp.c:372
 #, fuzzy
 msgid "invalid response received after AUTH LOGIN, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:367
+#: plugins/check_smtp.c:385
 msgid "recv() failed after sending authuser, "
 msgstr ""
 
-#: plugins/check_smtp.c:375
+#: plugins/check_smtp.c:393
 #, fuzzy
 msgid "invalid response received after authuser, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:387
+#: plugins/check_smtp.c:405
 msgid "recv() failed after sending authpass, "
 msgstr ""
 
-#: plugins/check_smtp.c:395
+#: plugins/check_smtp.c:413
 #, fuzzy
 msgid "invalid response received after authpass, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:402
+#: plugins/check_smtp.c:420
 msgid "only authtype LOGIN is supported, "
 msgstr ""
 
-#: plugins/check_smtp.c:426
+#: plugins/check_smtp.c:444
 #, fuzzy, c-format
 msgid "SMTP %s - %s%.3f sec. response time%s%s|%s\n"
 msgstr " - %s - %.3f Sekunden Antwortzeit %s%s|%s %s\n"
 
-#: plugins/check_smtp.c:536 plugins/check_smtp.c:548
+#: plugins/check_smtp.c:556 plugins/check_smtp.c:568
 #, c-format
 msgid "Could not realloc() units [%d]\n"
 msgstr ""
 
-#: plugins/check_smtp.c:556
+#: plugins/check_smtp.c:576
 #, fuzzy
 msgid "Critical time must be a positive"
 msgstr "Critical time muss ein positiver Integer sein"
 
-#: plugins/check_smtp.c:564
+#: plugins/check_smtp.c:584
 #, fuzzy
 msgid "Warning time must be a positive"
 msgstr "Warnung time muss ein positiver Integer sein"
 
-#: plugins/check_smtp.c:611
+#: plugins/check_smtp.c:627
 msgid "SSL support not available - install OpenSSL and recompile"
 msgstr ""
 
-#: plugins/check_smtp.c:679 plugins/check_smtp.c:684
+#: plugins/check_smtp.c:705 plugins/check_smtp.c:710
 #, c-format
 msgid "Connection closed by server before sending QUIT command\n"
 msgstr ""
 
-#: plugins/check_smtp.c:694
+#: plugins/check_smtp.c:720
 #, fuzzy, c-format
 msgid "recv() failed after QUIT."
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:696
+#: plugins/check_smtp.c:722
 #, c-format
 msgid "Connection reset by peer."
 msgstr ""
 
-#: plugins/check_smtp.c:784
+#: plugins/check_smtp.c:812
 #, fuzzy
 msgid "This plugin will attempt to open an SMTP connection with the host."
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_smtp.c:798
+#: plugins/check_smtp.c:826
 #, c-format
 msgid "    String to expect in first line of server response (default: '%s')\n"
 msgstr ""
 
-#: plugins/check_smtp.c:800
+#: plugins/check_smtp.c:828
 msgid "SMTP command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:802
+#: plugins/check_smtp.c:830
 msgid "Expected response to command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:804
+#: plugins/check_smtp.c:832
 msgid "FROM-address to include in MAIL command, required by Exchange 2000"
 msgstr ""
 
-#: plugins/check_smtp.c:806
+#: plugins/check_smtp.c:834
 msgid "FQDN used for HELO"
 msgstr ""
 
-#: plugins/check_smtp.c:809 plugins/check_tcp.c:665
+#: plugins/check_smtp.c:836
+msgid "Use PROXY protocol prefix for the connection."
+msgstr ""
+
+#: plugins/check_smtp.c:839 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."
 msgstr ""
 
-#: plugins/check_smtp.c:811
+#: plugins/check_smtp.c:841
 msgid "Use STARTTLS for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:815
+#: plugins/check_smtp.c:845
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"
 msgstr ""
 
-#: plugins/check_smtp.c:817
+#: plugins/check_smtp.c:847
 msgid "SMTP AUTH username"
 msgstr ""
 
-#: plugins/check_smtp.c:819
+#: plugins/check_smtp.c:849
 msgid "SMTP AUTH password"
 msgstr ""
 
-#: plugins/check_smtp.c:821
+#: plugins/check_smtp.c:851
+msgid "Send LHLO instead of HELO/EHLO"
+msgstr ""
+
+#: plugins/check_smtp.c:853
 msgid "Ignore failure when sending QUIT command to server"
 msgstr ""
 
-#: plugins/check_smtp.c:831
+#: plugins/check_smtp.c:863
 msgid "STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful"
 msgstr ""
 
-#: plugins/check_smtp.c:832
+#: plugins/check_smtp.c:864
 msgid "connects, but incorrect response messages from the host result in"
 msgstr ""
 
-#: plugins/check_smtp.c:833
+#: plugins/check_smtp.c:865
 msgid "STATE_WARNING return values."
 msgstr ""
 
-#: plugins/check_snmp.c:169 plugins/check_snmp.c:582
+#: plugins/check_snmp.c:177 plugins/check_snmp.c:626
 msgid "Cannot malloc"
 msgstr ""
 
-#: plugins/check_snmp.c:356
+#: plugins/check_snmp.c:368
 #, fuzzy, c-format
 msgid "External command error: %s\n"
 msgstr "Papierfehler"
 
-#: plugins/check_snmp.c:361
+#: plugins/check_snmp.c:373
 #, c-format
 msgid "External command error with no output (return code: %d)\n"
 msgstr ""
 
-#: plugins/check_snmp.c:464
+#: plugins/check_snmp.c:486 plugins/check_snmp.c:488 plugins/check_snmp.c:490
+#: plugins/check_snmp.c:492
 #, fuzzy, c-format
 msgid "No valid data returned (%s)\n"
 msgstr "Keine Daten empfangen %s\n"
 
-#: plugins/check_snmp.c:475
+#: plugins/check_snmp.c:504
 msgid "Time duration between plugin calls is invalid"
 msgstr ""
 
-#: plugins/check_snmp.c:588
+#: plugins/check_snmp.c:632
 msgid "Cannot asprintf()"
 msgstr ""
 
-#: plugins/check_snmp.c:594
+#: plugins/check_snmp.c:638
 msgid "Cannot realloc()"
 msgstr ""
 
-#: plugins/check_snmp.c:610
+#: plugins/check_snmp.c:654
 msgid "No previous data to calculate rate - assume okay"
 msgstr ""
 
-#: plugins/check_snmp.c:751
+#: plugins/check_snmp.c:804
 #, fuzzy
 msgid "Retries interval must be a positive integer"
 msgstr "Time interval muss ein positiver Integer sein"
 
-#: plugins/check_snmp.c:831
+#: plugins/check_snmp.c:841
+#, fuzzy
+msgid "Exit status must be a positive integer"
+msgstr "Maxbytes muss ein positiver Integer sein"
+
+#: plugins/check_snmp.c:890
 #, fuzzy, c-format
 msgid "Could not reallocate labels[%d]"
 msgstr "Konnte addr nicht zuweisen\n"
 
-#: plugins/check_snmp.c:844
+#: plugins/check_snmp.c:903
 #, fuzzy
 msgid "Could not reallocate labels\n"
 msgstr "Konnte·url·nicht·zuweisen\n"
 
-#: plugins/check_snmp.c:860
+#: plugins/check_snmp.c:919
 #, fuzzy, c-format
 msgid "Could not reallocate units [%d]\n"
 msgstr "Konnte·url·nicht·zuweisen\n"
 
-#: plugins/check_snmp.c:872
+#: plugins/check_snmp.c:931
 msgid "Could not realloc() units\n"
 msgstr ""
 
-#: plugins/check_snmp.c:889
+#: plugins/check_snmp.c:948
 #, fuzzy
 msgid "Rate multiplier must be a positive integer"
 msgstr "Paketgröße muss ein positiver Integer sein"
 
-#: plugins/check_snmp.c:947
+#: plugins/check_snmp.c:1023
 #, fuzzy
 msgid "No host specified\n"
 msgstr ""
 "Kein Hostname angegeben\n"
 "\n"
 
-#: plugins/check_snmp.c:951
+#: plugins/check_snmp.c:1027
 #, fuzzy
 msgid "No OIDs specified\n"
 msgstr ""
 "Kein Hostname angegeben\n"
 "\n"
 
-#: plugins/check_snmp.c:973
-msgid "Invalid seclevel"
-msgstr ""
-
-#: plugins/check_snmp.c:980 plugins/check_snmp.c:983 plugins/check_snmp.c:1001
+#: plugins/check_snmp.c:1050 plugins/check_snmp.c:1068
+#: plugins/check_snmp.c:1086
 #, c-format
 msgid "Required parameter: %s\n"
 msgstr ""
 
-#: plugins/check_snmp.c:1022
-msgid "Invalid SNMP version"
-msgstr ""
-
-#: plugins/check_snmp.c:1039
-msgid "Unbalanced quotes\n"
-msgstr ""
-
-#: plugins/check_snmp.c:1088
-msgid "Check status of remote machines and obtain system information via SNMP"
-msgstr ""
-
-#: plugins/check_snmp.c:1101
-msgid "Use SNMP GETNEXT instead of SNMP GET"
-msgstr ""
-
-#: plugins/check_snmp.c:1103
-msgid "SNMP protocol version"
-msgstr ""
-
-#: plugins/check_snmp.c:1105
-msgid "SNMPv3 securityLevel"
+#: plugins/check_snmp.c:1061
+msgid "Invalid seclevel"
 msgstr ""
 
 #: plugins/check_snmp.c:1107
-msgid "SNMPv3 auth proto"
-msgstr ""
-
-#: plugins/check_snmp.c:1109
-msgid "SNMPv3 priv proto (default DES)"
-msgstr ""
-
-#: plugins/check_snmp.c:1113
-msgid "Optional community string for SNMP communication"
-msgstr ""
-
-#: plugins/check_snmp.c:1114
-msgid "default is"
-msgstr ""
-
-#: plugins/check_snmp.c:1116
-msgid "SNMPv3 username"
-msgstr ""
-
-#: plugins/check_snmp.c:1118
-msgid "SNMPv3 authentication password"
-msgstr ""
-
-#: plugins/check_snmp.c:1120
-msgid "SNMPv3 privacy password"
+msgid "Invalid SNMP version"
 msgstr ""
 
 #: plugins/check_snmp.c:1124
+msgid "Unbalanced quotes\n"
+msgstr ""
+
+#: plugins/check_snmp.c:1182
+#, c-format
+msgid "multiplier set (%.1f), but input is not a number: %s"
+msgstr ""
+
+#: plugins/check_snmp.c:1211
+msgid "Check status of remote machines and obtain system information via SNMP"
+msgstr ""
+
+#: plugins/check_snmp.c:1225
+msgid "Use SNMP GETNEXT instead of SNMP GET"
+msgstr ""
+
+#: plugins/check_snmp.c:1227
+msgid "SNMP protocol version"
+msgstr ""
+
+#: plugins/check_snmp.c:1229
+msgid "SNMPv3 context"
+msgstr ""
+
+#: plugins/check_snmp.c:1231
+msgid "SNMPv3 securityLevel"
+msgstr ""
+
+#: plugins/check_snmp.c:1233
+msgid "SNMPv3 auth proto"
+msgstr ""
+
+#: plugins/check_snmp.c:1235
+msgid "SNMPv3 priv proto (default DES)"
+msgstr ""
+
+#: plugins/check_snmp.c:1239
+msgid "Optional community string for SNMP communication"
+msgstr ""
+
+#: plugins/check_snmp.c:1240
+msgid "default is"
+msgstr ""
+
+#: plugins/check_snmp.c:1242
+msgid "SNMPv3 username"
+msgstr ""
+
+#: plugins/check_snmp.c:1244
+msgid "SNMPv3 authentication password"
+msgstr ""
+
+#: plugins/check_snmp.c:1246
+msgid "SNMPv3 privacy password"
+msgstr ""
+
+#: plugins/check_snmp.c:1250
 msgid "Object identifier(s) or SNMP variables whose value you wish to query"
 msgstr ""
 
-#: plugins/check_snmp.c:1126
+#: plugins/check_snmp.c:1252
 msgid ""
 "List of MIBS to be loaded (default = none if using numeric OIDs or 'ALL'"
 msgstr ""
 
-#: plugins/check_snmp.c:1127
+#: plugins/check_snmp.c:1253
 msgid "for symbolic OIDs.)"
 msgstr ""
 
-#: plugins/check_snmp.c:1129
+#: plugins/check_snmp.c:1255
 msgid "Delimiter to use when parsing returned data. Default is"
 msgstr ""
 
-#: plugins/check_snmp.c:1130
+#: plugins/check_snmp.c:1256
 msgid "Any data on the right hand side of the delimiter is considered"
 msgstr ""
 
-#: plugins/check_snmp.c:1131
+#: plugins/check_snmp.c:1257
 msgid "to be the data that should be used in the evaluation."
 msgstr ""
 
-#: plugins/check_snmp.c:1135
+#: plugins/check_snmp.c:1259
+msgid "If the check returns a 0 length string or NULL value"
+msgstr ""
+
+#: plugins/check_snmp.c:1260
+msgid "This option allows you to choose what status you want it to exit"
+msgstr ""
+
+#: plugins/check_snmp.c:1261
+msgid "Excluding this option renders the default exit of 3(STATE_UNKNOWN)"
+msgstr ""
+
+#: plugins/check_snmp.c:1262
+msgid "0 = OK"
+msgstr ""
+
+#: plugins/check_snmp.c:1263
+#, fuzzy
+msgid "1 = WARNING"
+msgstr "WARNING"
+
+#: plugins/check_snmp.c:1264
+#, fuzzy
+msgid "2 = CRITICAL"
+msgstr "CRITICAL"
+
+#: plugins/check_snmp.c:1265
+#, fuzzy
+msgid "3 = UNKNOWN"
+msgstr "UNKNOWN"
+
+#: plugins/check_snmp.c:1269
 #, fuzzy
 msgid "Warning threshold range(s)"
 msgstr "Warning threshold  Integer sein"
 
-#: plugins/check_snmp.c:1137
+#: plugins/check_snmp.c:1271
 #, fuzzy
 msgid "Critical threshold range(s)"
 msgstr "Critical threshold muss ein Integer sein"
 
-#: plugins/check_snmp.c:1139
+#: plugins/check_snmp.c:1273
 msgid "Enable rate calculation. See 'Rate Calculation' below"
 msgstr ""
 
-#: plugins/check_snmp.c:1141
+#: plugins/check_snmp.c:1275
 msgid ""
 "Converts rate per second. For example, set to 60 to convert to per minute"
 msgstr ""
 
-#: plugins/check_snmp.c:1143
+#: plugins/check_snmp.c:1277
 msgid "Add/subtract the specified OFFSET to numeric sensor data"
 msgstr ""
 
-#: plugins/check_snmp.c:1147
+#: plugins/check_snmp.c:1281
 msgid "Return OK state (for that OID) if STRING is an exact match"
 msgstr ""
 
-#: plugins/check_snmp.c:1149
+#: plugins/check_snmp.c:1283
 msgid ""
 "Return OK state (for that OID) if extended regular expression REGEX matches"
 msgstr ""
 
-#: plugins/check_snmp.c:1151
+#: plugins/check_snmp.c:1285
 msgid ""
 "Return OK state (for that OID) if case-insensitive extended REGEX matches"
 msgstr ""
 
-#: plugins/check_snmp.c:1153
+#: plugins/check_snmp.c:1287
 msgid "Invert search result (CRITICAL if found)"
 msgstr ""
 
-#: plugins/check_snmp.c:1157
+#: plugins/check_snmp.c:1291
 msgid "Prefix label for output from plugin"
 msgstr ""
 
-#: plugins/check_snmp.c:1159
+#: plugins/check_snmp.c:1293
 msgid "Units label(s) for output data (e.g., 'sec.')."
 msgstr ""
 
-#: plugins/check_snmp.c:1161
+#: plugins/check_snmp.c:1295
 msgid "Separates output on multiple OID requests"
 msgstr ""
 
-#: plugins/check_snmp.c:1165
-msgid "Number of retries to be used in the requests"
+#: plugins/check_snmp.c:1297
+msgid "Multiplies current value, 0 < n < 1 works as divider, defaults to 1"
 msgstr ""
 
-#: plugins/check_snmp.c:1168
+#: plugins/check_snmp.c:1299
+msgid "C-style format string for float values (see option -M)"
+msgstr ""
+
+#: plugins/check_snmp.c:1302
+msgid ""
+"NOTE the final timeout value is calculated using this formula: "
+"timeout_interval * retries + 5"
+msgstr ""
+
+#: plugins/check_snmp.c:1304
+msgid "Number of retries to be used in the requests, default: "
+msgstr ""
+
+#: plugins/check_snmp.c:1307
 msgid "Label performance data with OIDs instead of --label's"
 msgstr ""
 
-#: plugins/check_snmp.c:1173
+#: plugins/check_snmp.c:1312
 msgid ""
 "This plugin uses the 'snmpget' command included with the NET-SNMP package."
 msgstr ""
 
-#: plugins/check_snmp.c:1174
+#: plugins/check_snmp.c:1313
 msgid ""
 "if you don't have the package installed, you will need to download it from"
 msgstr ""
 
-#: plugins/check_snmp.c:1175
+#: plugins/check_snmp.c:1314
 msgid "http://net-snmp.sourceforge.net before you can use this plugin."
 msgstr ""
 
-#: plugins/check_snmp.c:1179
+#: plugins/check_snmp.c:1318
 msgid ""
 "- Multiple OIDs (and labels) may be indicated by a comma or space-delimited  "
 msgstr ""
 
-#: plugins/check_snmp.c:1180
+#: plugins/check_snmp.c:1319
 msgid "list (lists with internal spaces must be quoted)."
 msgstr ""
 
-#: plugins/check_snmp.c:1184
+#: plugins/check_snmp.c:1323
 msgid ""
 "- When checking multiple OIDs, separate ranges by commas like '-w "
 "1:10,1:,:20'"
 msgstr ""
 
-#: plugins/check_snmp.c:1185
+#: plugins/check_snmp.c:1324
 msgid "- Note that only one string and one regex may be checked at present"
 msgstr ""
 
-#: plugins/check_snmp.c:1186
+#: plugins/check_snmp.c:1325
 msgid ""
 "- All evaluation methods other than PR, STR, and SUBSTR expect that the value"
 msgstr ""
 
-#: plugins/check_snmp.c:1187
+#: plugins/check_snmp.c:1326
 msgid "returned from the SNMP query is an unsigned integer."
 msgstr ""
 
-#: plugins/check_snmp.c:1190
+#: plugins/check_snmp.c:1329
 msgid "Rate Calculation:"
 msgstr ""
 
-#: plugins/check_snmp.c:1191
+#: plugins/check_snmp.c:1330
 msgid "In many places, SNMP returns counters that are only meaningful when"
 msgstr ""
 
-#: plugins/check_snmp.c:1192
+#: plugins/check_snmp.c:1331
 msgid "calculating the counter difference since the last check. check_snmp"
 msgstr ""
 
-#: plugins/check_snmp.c:1193
+#: plugins/check_snmp.c:1332
 msgid "saves the last state information in a file so that the rate per second"
 msgstr ""
 
-#: plugins/check_snmp.c:1194
+#: plugins/check_snmp.c:1333
 msgid "can be calculated. Use the --rate option to save state information."
 msgstr ""
 
-#: plugins/check_snmp.c:1195
+#: plugins/check_snmp.c:1334
 msgid ""
 "On the first run, there will be no prior state - this will return with OK."
 msgstr ""
 
-#: plugins/check_snmp.c:1196
+#: plugins/check_snmp.c:1335
 msgid "The state is uniquely determined by the arguments to the plugin, so"
 msgstr ""
 
-#: plugins/check_snmp.c:1197
+#: plugins/check_snmp.c:1336
 msgid "changing the arguments will create a new state file."
 msgstr ""
 
-#: plugins/check_ssh.c:165
+#: plugins/check_ssh.c:170
 #, fuzzy
 msgid "Port number must be a positive integer"
 msgstr "Port muss ein positiver Integer sein"
 
-#: plugins/check_ssh.c:232
+#: plugins/check_ssh.c:237
 #, c-format
 msgid "Server answer: %s"
 msgstr ""
 
-#: plugins/check_ssh.c:251
+#: plugins/check_ssh.c:256
 #, c-format
-msgid "SSH WARNING - %s (protocol %s) version mismatch, expected '%s'\n"
+msgid "SSH CRITICAL - %s (protocol %s) version mismatch, expected '%s'\n"
 msgstr ""
 
-#: plugins/check_ssh.c:260
+#: plugins/check_ssh.c:264
+#, c-format
+msgid ""
+"SSH CRITICAL - %s (protocol %s) protocol version mismatch, expected '%s'\n"
+msgstr ""
+
+#: plugins/check_ssh.c:273
 #, c-format
 msgid "SSH OK - %s (protocol %s) | %s\n"
 msgstr ""
 
-#: plugins/check_ssh.c:281
+#: plugins/check_ssh.c:294
 msgid "Try to connect to an SSH server at specified server and port"
 msgstr ""
 
-#: plugins/check_ssh.c:297
+#: plugins/check_ssh.c:310
 msgid ""
-"Warn if string doesn't match expected server version (ex: OpenSSH_3.9p1)"
+"Alert if string doesn't match expected server version (ex: OpenSSH_3.9p1)"
 msgstr ""
 
-#: plugins/check_swap.c:169
+#: plugins/check_ssh.c:313
+msgid "Alert if protocol doesn't match expected protocol version (ex: 2.0)"
+msgstr ""
+
+#: plugins/check_swap.c:187
 #, c-format
 msgid "Command: %s\n"
 msgstr ""
 
-#: plugins/check_swap.c:171
+#: plugins/check_swap.c:189
 #, c-format
 msgid "Format: %s\n"
 msgstr ""
 
-#: plugins/check_swap.c:207
+#: plugins/check_swap.c:225
 #, c-format
 msgid "total=%.0f, used=%.0f, free=%.0f\n"
 msgstr ""
 
-#: plugins/check_swap.c:221
+#: plugins/check_swap.c:239
 #, c-format
 msgid "total=%.0f, free=%.0f\n"
 msgstr ""
 
-#: plugins/check_swap.c:253
+#: plugins/check_swap.c:271
 msgid "Error getting swap devices\n"
 msgstr ""
 
-#: plugins/check_swap.c:256
+#: plugins/check_swap.c:274
 msgid "SWAP OK: No swap devices defined\n"
 msgstr ""
 
-#: plugins/check_swap.c:277 plugins/check_swap.c:319
+#: plugins/check_swap.c:295 plugins/check_swap.c:337
 msgid "swapctl failed: "
 msgstr ""
 
-#: plugins/check_swap.c:278 plugins/check_swap.c:320
+#: plugins/check_swap.c:296 plugins/check_swap.c:338
 msgid "Error in swapctl call\n"
 msgstr ""
 
-#: plugins/check_swap.c:357
+#: plugins/check_swap.c:376
 #, c-format
-msgid "SWAP %s - %d%% free (%d MB out of %d MB) %s|"
+msgid "SWAP %s - %d%% free (%dMB out of %dMB) %s|"
 msgstr ""
 
-#: plugins/check_swap.c:435
-msgid "Warning threshold must be integer or percentage!"
+#: plugins/check_swap.c:472
+#, fuzzy
+msgid "Warning threshold percentage must be <= 100!"
+msgstr "Warning threshold  Integer sein"
+
+#: plugins/check_swap.c:482
+#, fuzzy
+msgid "Warning threshold be positive integer or percentage!"
 msgstr "Warning threshold muss ein Integer oder ein Prozentwert sein"
 
-#: plugins/check_swap.c:453
-msgid "Critical threshold must be integer or percentage!"
+#: plugins/check_swap.c:502
+#, fuzzy
+msgid "Critical threshold percentage must be <= 100!"
+msgstr "Critical threshold muss ein Integer sein"
+
+#: plugins/check_swap.c:512
+#, fuzzy
+msgid "Critical threshold be positive integer or percentage!"
 msgstr "Critical threshold muss ein Integer oder ein Prozentwert sein!"
 
-#: plugins/check_swap.c:507
-#, fuzzy
-msgid "Warning percentage should be more than critical percentage"
-msgstr "Warning threshold muss ein Integer oder ein Prozentwert sein"
-
-#: plugins/check_swap.c:511
-msgid "Warning free space should be more than critical free space"
+#: plugins/check_swap.c:521
+msgid ""
+"no-swap result must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) "
+"or integer (0-3)."
 msgstr ""
 
-#: plugins/check_swap.c:525
+#: plugins/check_swap.c:558
+#, fuzzy
+msgid "Warning should be more than critical"
+msgstr "Warning threshold muss ein Integer oder ein Prozentwert sein"
+
+#: plugins/check_swap.c:572
 msgid "Check swap space on local machine."
 msgstr ""
 
-#: plugins/check_swap.c:535
+#: plugins/check_swap.c:582
 msgid ""
 "Exit with WARNING status if less than INTEGER bytes of swap space are free"
 msgstr ""
 
-#: plugins/check_swap.c:537
+#: plugins/check_swap.c:584
 msgid "Exit with WARNING status if less than PERCENT of swap space is free"
 msgstr ""
 
-#: plugins/check_swap.c:539
+#: plugins/check_swap.c:586
 msgid ""
 "Exit with CRITICAL status if less than INTEGER bytes of swap space are free"
 msgstr ""
 
-#: plugins/check_swap.c:541
+#: plugins/check_swap.c:588
 msgid "Exit with CRITICAL status if less than PERCENT of swap space is free"
 msgstr ""
 
-#: plugins/check_swap.c:543
+#: plugins/check_swap.c:590
 msgid "Conduct comparisons for all swap partitions, one by one"
 msgstr ""
 
-#: plugins/check_swap.c:548
+#: plugins/check_swap.c:592
+msgid ""
+"Resulting state when there is no swap regardless of thresholds. Default:"
+msgstr ""
+
+#: plugins/check_swap.c:597
+msgid ""
+"Both INTEGER and PERCENT thresholds can be specified, they are all checked."
+msgstr ""
+
+#: plugins/check_swap.c:598
 msgid "On AIX, if -a is specified, uses lsps -a, otherwise uses lsps -s."
 msgstr ""
 
-#: plugins/check_tcp.c:206
+#: plugins/check_tcp.c:210
 msgid "CRITICAL - Generic check_tcp called with unknown service\n"
 msgstr ""
 
-#: plugins/check_tcp.c:230
+#: plugins/check_tcp.c:234
 msgid "With UDP checks, a send/expect string must be specified."
 msgstr ""
 
-#: plugins/check_tcp.c:431
+#: plugins/check_tcp.c:445
 msgid "No arguments found"
 msgstr ""
 
-#: plugins/check_tcp.c:534
+#: plugins/check_tcp.c:548
 msgid "Maxbytes must be a positive integer"
 msgstr "Maxbytes muss ein positiver Integer sein"
 
-#: plugins/check_tcp.c:552
+#: plugins/check_tcp.c:566
 msgid "Refuse must be one of ok, warn, crit"
 msgstr ""
 
-#: plugins/check_tcp.c:562
+#: plugins/check_tcp.c:576
 msgid "Mismatch must be one of ok, warn, crit"
 msgstr ""
 
-#: plugins/check_tcp.c:568
+#: plugins/check_tcp.c:582
 msgid "Delay must be a positive integer"
 msgstr "Delay muss ein positiver Integer sein"
 
-#: plugins/check_tcp.c:613
+#: plugins/check_tcp.c:637
 #, fuzzy
 msgid "You must provide a server address"
 msgstr "%s: Hostname muss angegeben werden\n"
 
-#: plugins/check_tcp.c:615
+#: plugins/check_tcp.c:639
 #, fuzzy
 msgid "Invalid hostname, address or socket"
 msgstr "Ungültige(r) Hostname/Adresse"
 
-#: plugins/check_tcp.c:629
+#: plugins/check_tcp.c:653
 #, fuzzy, c-format
 msgid ""
 "This plugin tests %s connections with the specified host (or unix socket).\n"
 "\n"
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_tcp.c:642
+#: plugins/check_tcp.c:666
 msgid ""
-"Can use \\n, \\r, \\t or \\ in send or quit string. Must come before send or "
-"quit option"
+"Can use \\n, \\r, \\t or \\\\ in send or quit string. Must come before send "
+"or quit option"
 msgstr ""
 
-#: plugins/check_tcp.c:643
+#: plugins/check_tcp.c:667
 msgid "Default: nothing added to send, \\r\\n added to end of quit"
 msgstr ""
 
-#: plugins/check_tcp.c:645
+#: plugins/check_tcp.c:669
 msgid "String to send to the server"
 msgstr ""
 
-#: plugins/check_tcp.c:647
+#: plugins/check_tcp.c:671
 msgid "String to expect in server response"
 msgstr ""
 
-#: plugins/check_tcp.c:647
+#: plugins/check_tcp.c:671
 msgid "(may be repeated)"
 msgstr ""
 
-#: plugins/check_tcp.c:649
+#: plugins/check_tcp.c:673
 msgid "All expect strings need to occur in server response. Default is any"
 msgstr ""
 
-#: plugins/check_tcp.c:651
+#: plugins/check_tcp.c:675
 msgid "String to send server to initiate a clean close of the connection"
 msgstr ""
 
-#: plugins/check_tcp.c:653
+#: plugins/check_tcp.c:677
 msgid "Accept TCP refusals with states ok, warn, crit (default: crit)"
 msgstr ""
 
-#: plugins/check_tcp.c:655
+#: plugins/check_tcp.c:679
 msgid ""
 "Accept expected string mismatches with states ok, warn, crit (default: warn)"
 msgstr ""
 
-#: plugins/check_tcp.c:657
+#: plugins/check_tcp.c:681
 #, fuzzy
 msgid "Hide output from TCP socket"
 msgstr "Konnte TCP socket nicht öffnen\n"
 
-#: plugins/check_tcp.c:659
+#: plugins/check_tcp.c:683
 msgid "Close connection once more than this number of bytes are received"
 msgstr ""
 
-#: plugins/check_tcp.c:661
+#: plugins/check_tcp.c:685
 msgid "Seconds to wait between sending string and polling for response"
 msgstr ""
 
-#: plugins/check_tcp.c:666
+#: plugins/check_tcp.c:690
 msgid "1st is #days for warning, 2nd is critical (if not specified - 0)."
 msgstr ""
 
-#: plugins/check_tcp.c:668
+#: plugins/check_tcp.c:692
 msgid "Use SSL for the connection."
+msgstr ""
+
+#: plugins/check_tcp.c:694
+msgid "SSL server_name"
 msgstr ""
 
 #: plugins/check_time.c:102
@@ -5176,39 +5548,43 @@ msgstr ""
 msgid "UPS does not support any available options\n"
 msgstr "IPv6 Unterstützung nicht vorhanden"
 
-#: plugins/check_ups.c:348 plugins/check_ups.c:411
+#: plugins/check_ups.c:348 plugins/check_ups.c:414
 #, fuzzy
 msgid "Invalid response received from host"
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_ups.c:420
+#: plugins/check_ups.c:406
+msgid "UPS name to long for buffer"
+msgstr ""
+
+#: plugins/check_ups.c:423
 #, fuzzy, c-format
 msgid "CRITICAL - no such UPS '%s' on that host\n"
 msgstr "%s [%s nicht gefunden]"
 
-#: plugins/check_ups.c:430
+#: plugins/check_ups.c:433
 #, fuzzy
 msgid "CRITICAL - UPS data is stale"
 msgstr "CRITICAL - Serverdatum \"%100s\" konnte nicht verarbeitet werden"
 
-#: plugins/check_ups.c:435
+#: plugins/check_ups.c:438
 #, fuzzy, c-format
 msgid "Unknown error: %s\n"
 msgstr "Papierfehler"
 
-#: plugins/check_ups.c:442
+#: plugins/check_ups.c:445
 msgid "Error: unable to parse variable"
 msgstr ""
 
-#: plugins/check_ups.c:549
+#: plugins/check_ups.c:552
 msgid "Unrecognized UPS variable"
 msgstr ""
 
-#: plugins/check_ups.c:587
+#: plugins/check_ups.c:590
 msgid "Error : no UPS indicated"
 msgstr ""
 
-#: plugins/check_ups.c:607
+#: plugins/check_ups.c:610
 #, fuzzy
 msgid ""
 "This plugin tests the UPS service on the specified host. Network UPS Tools"
@@ -5216,97 +5592,102 @@ msgstr ""
 "Testet den DNS Dienst auf dem angegebenen Host mit dig\n"
 "\n"
 
-#: plugins/check_ups.c:608
+#: plugins/check_ups.c:611
 msgid "from www.networkupstools.org must be running for this plugin to work."
 msgstr ""
 
-#: plugins/check_ups.c:620
+#: plugins/check_ups.c:623
 msgid "Name of UPS"
 msgstr ""
 
-#: plugins/check_ups.c:622
+#: plugins/check_ups.c:625
 msgid "Output of temperatures in Celsius"
 msgstr ""
 
-#: plugins/check_ups.c:624
+#: plugins/check_ups.c:627
 msgid "Valid values for STRING are"
 msgstr ""
 
-#: plugins/check_ups.c:635
+#: plugins/check_ups.c:638
 msgid ""
 "This plugin attempts to determine the status of a UPS (Uninterruptible Power"
 msgstr ""
 
-#: plugins/check_ups.c:636
+#: plugins/check_ups.c:639
 msgid ""
 "Supply) on a local or remote host. If the UPS is online or calibrating, the"
 msgstr ""
 
-#: plugins/check_ups.c:637
+#: plugins/check_ups.c:640
 msgid ""
 "plugin will return an OK state. If the battery is on it will return a WARNING"
 msgstr ""
 
-#: plugins/check_ups.c:638
+#: plugins/check_ups.c:641
 msgid ""
 "state. If the UPS is off or has a low battery the plugin will return a "
 "CRITICAL"
 msgstr ""
 
-#: plugins/check_ups.c:643
+#: plugins/check_ups.c:646
 msgid ""
 "You may also specify a variable to check (such as temperature, utility "
 "voltage,"
 msgstr ""
 
-#: plugins/check_ups.c:644
+#: plugins/check_ups.c:647
 msgid ""
 "battery load, etc.) as well as warning and critical thresholds for the value"
 msgstr ""
 
-#: plugins/check_ups.c:645
+#: plugins/check_ups.c:648
 msgid ""
 "of that variable.  If the remote host has multiple UPS that are being "
 "monitored"
 msgstr ""
 
-#: plugins/check_ups.c:646
+#: plugins/check_ups.c:649
 msgid "you will have to use the --ups option to specify which UPS to check."
 msgstr ""
 
-#: plugins/check_ups.c:648
+#: plugins/check_ups.c:651
 msgid ""
 "This plugin requires that the UPSD daemon distributed with Russell Kroll's"
 msgstr ""
 
-#: plugins/check_ups.c:649
+#: plugins/check_ups.c:652
 msgid ""
 "Network UPS Tools be installed on the remote host. If you do not have the"
 msgstr ""
 
-#: plugins/check_ups.c:650
+#: plugins/check_ups.c:653
 msgid "package installed on your system, you can download it from"
 msgstr ""
 
-#: plugins/check_ups.c:651
+#: plugins/check_ups.c:654
 msgid "http://www.networkupstools.org"
 msgstr ""
 
-#: plugins/check_users.c:110
+#: plugins/check_users.c:91
+#, fuzzy, c-format
+msgid "Could not enumerate RD sessions: %d\n"
+msgstr "Konnte·url·nicht·zuweisen\n"
+
+#: plugins/check_users.c:146
 #, c-format
 msgid "# users=%d"
 msgstr ""
 
-#: plugins/check_users.c:133
+#: plugins/check_users.c:164
 msgid "Unable to read output"
 msgstr ""
 
-#: plugins/check_users.c:140
+#: plugins/check_users.c:166
 #, c-format
 msgid "USERS %s - %d users currently logged in |%s\n"
 msgstr ""
 
-#: plugins/check_users.c:219
+#: plugins/check_users.c:241
 #, fuzzy
 msgid "This plugin checks the number of users currently logged in on the local"
 msgstr ""
@@ -5315,230 +5696,266 @@ msgstr ""
 "unterschritten wird.\n"
 "\n"
 
-#: plugins/check_users.c:220
+#: plugins/check_users.c:242
 msgid ""
 "system and generates an error if the number exceeds the thresholds specified."
 msgstr ""
 
-#: plugins/check_users.c:230
+#: plugins/check_users.c:252
 msgid "Set WARNING status if more than INTEGER users are logged in"
 msgstr ""
 
-#: plugins/check_users.c:232
+#: plugins/check_users.c:254
 msgid "Set CRITICAL status if more than INTEGER users are logged in"
 msgstr ""
 
-#: plugins/check_ide_smart.c:256
+#: plugins/check_ide_smart.c:218
+msgid ""
+"DEPRECATION WARNING: the -q switch (quiet output) is no longer \"quiet\"."
+msgstr ""
+
+#: plugins/check_ide_smart.c:219
+msgid "Nagios-compatible output is now always returned."
+msgstr ""
+
+#: plugins/check_ide_smart.c:224
+msgid "SMART commands are broken and have been disabled (See Notes in --help)."
+msgstr ""
+
+#: plugins/check_ide_smart.c:228
+msgid ""
+"DEPRECATION WARNING: the -n switch (Nagios-compatible output) is now the"
+msgstr ""
+
+#: plugins/check_ide_smart.c:229
+msgid "default and will be removed from future releases."
+msgstr ""
+
+#: plugins/check_ide_smart.c:257
 #, fuzzy, c-format
 msgid "CRITICAL - Couldn't open device %s: %s\n"
 msgstr "CRITICAL - Device konnte nicht geöffnet werden: %s\n"
 
-#: plugins/check_ide_smart.c:261
+#: plugins/check_ide_smart.c:262
 #, c-format
 msgid "CRITICAL - SMART_CMD_ENABLE\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:323 plugins/check_ide_smart.c:350
+#: plugins/check_ide_smart.c:303 plugins/check_ide_smart.c:330
 #, c-format
 msgid "CRITICAL - SMART_READ_VALUES: %s\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:421
+#: plugins/check_ide_smart.c:376
 #, c-format
 msgid "CRITICAL - %d Harddrive PreFailure%cDetected! %d/%d tests failed.\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:429
+#: plugins/check_ide_smart.c:384
 #, c-format
 msgid "WARNING - %d Harddrive Advisor%s Detected. %d/%d tests failed.\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:437
+#: plugins/check_ide_smart.c:392
 #, c-format
 msgid "OK - Operational (%d/%d tests passed)\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:441
+#: plugins/check_ide_smart.c:396
 #, c-format
 msgid "ERROR - Status '%d' unknown. %d/%d tests passed\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:474
+#: plugins/check_ide_smart.c:429
 #, c-format
 msgid "OffLineStatus=%d {%s}, AutoOffLine=%s, OffLineTimeout=%d minutes\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:480
+#: plugins/check_ide_smart.c:435
 #, c-format
 msgid "OffLineCapability=%d {%s %s %s}\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:486
+#: plugins/check_ide_smart.c:441
 #, c-format
 msgid "SmartRevision=%d, CheckSum=%d, SmartCapability=%d {%s %s}\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:508 plugins/check_ide_smart.c:532
+#: plugins/check_ide_smart.c:463 plugins/check_ide_smart.c:492
 #, c-format
 msgid "CRITICAL - %s: %s\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:553 plugins/check_ide_smart.c:580
+#: plugins/check_ide_smart.c:467 plugins/check_ide_smart.c:496
+#, c-format
+msgid "OK - Command sent (%s)\n"
+msgstr ""
+
+#: plugins/check_ide_smart.c:517 plugins/check_ide_smart.c:544
 #, c-format
 msgid "CRITICAL - SMART_READ_THRESHOLDS: %s\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:599
+#: plugins/check_ide_smart.c:563
 #, c-format
 msgid ""
 "This plugin checks a local hard drive with the (Linux specific) SMART "
 "interface [http://smartlinux.sourceforge.net/smart/index.php]."
 msgstr ""
 
-#: plugins/check_ide_smart.c:609
+#: plugins/check_ide_smart.c:573
 msgid "Select device DEVICE"
 msgstr ""
 
-#: plugins/check_ide_smart.c:610
+#: plugins/check_ide_smart.c:574
 msgid ""
-"Note: if the device is selected with this option, _no_ other options are "
-"accepted"
+"Note: if the device is specified without this option, any further option will"
 msgstr ""
 
-#: plugins/check_ide_smart.c:612
-msgid "Perform immediately offline tests"
+#: plugins/check_ide_smart.c:575
+msgid "be ignored."
 msgstr ""
 
-#: plugins/check_ide_smart.c:614
-msgid "Returns the number of failed tests"
+#: plugins/check_ide_smart.c:581
+msgid ""
+"The SMART command modes (-i/--immediate, -0/--auto-off and -1/--auto-on) were"
 msgstr ""
 
-#: plugins/check_ide_smart.c:616
-msgid "Turn on automatic offline tests"
+#: plugins/check_ide_smart.c:582
+msgid ""
+"broken in an underhand manner and have been disabled. You can use smartctl"
 msgstr ""
 
-#: plugins/check_ide_smart.c:618
-msgid "Turn off automatic offline tests"
+#: plugins/check_ide_smart.c:583
+msgid "instead:"
 msgstr ""
 
-#: plugins/check_ide_smart.c:620
-msgid "Output suitable for the monitoring system"
+#: plugins/check_ide_smart.c:584
+msgid "-0/--auto-off:  use \"smartctl --offlineauto=off\""
 msgstr ""
 
-#: plugins/negate.c:99
+#: plugins/check_ide_smart.c:585
+msgid "-1/--auto-on:   use \"smartctl --offlineauto=on\""
+msgstr ""
+
+#: plugins/check_ide_smart.c:586
+msgid "-i/--immediate: use \"smartctl --test=offline\""
+msgstr ""
+
+#: plugins/negate.c:96
 #, fuzzy
 msgid "No data returned from command\n"
 msgstr "Keine Daten empfangen %s\n"
 
-#: plugins/negate.c:170
+#: plugins/negate.c:166
 msgid ""
 "Timeout result must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) "
 "or integer (0-3)."
 msgstr ""
 
-#: plugins/negate.c:174
+#: plugins/negate.c:170
 msgid ""
-"Ok must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer (0-"
-"3)."
+"Ok must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer "
+"(0-3)."
 msgstr ""
 
-#: plugins/negate.c:180
+#: plugins/negate.c:176
 msgid ""
 "Warning must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or "
 "integer (0-3)."
 msgstr ""
 
-#: plugins/negate.c:185
+#: plugins/negate.c:181
 msgid ""
 "Critical must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or "
 "integer (0-3)."
 msgstr ""
 
-#: plugins/negate.c:190
+#: plugins/negate.c:186
 msgid ""
 "Unknown must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or "
 "integer (0-3)."
 msgstr ""
 
-#: plugins/negate.c:217
+#: plugins/negate.c:213
 msgid "Require path to command"
 msgstr ""
 
-#: plugins/negate.c:246
+#: plugins/negate.c:224
 msgid ""
 "Negates the status of a plugin (returns OK for CRITICAL and vice-versa)."
 msgstr ""
 
-#: plugins/negate.c:247
+#: plugins/negate.c:225
 msgid "Additional switches can be used to control which state becomes what."
 msgstr ""
 
-#: plugins/negate.c:256
+#: plugins/negate.c:234
 msgid "Keep timeout longer than the plugin timeout to retain CRITICAL status."
 msgstr ""
 
-#: plugins/negate.c:258
+#: plugins/negate.c:236
 msgid "Custom result on Negate timeouts; see below for STATUS definition\n"
 msgstr ""
 
-#: plugins/negate.c:264
+#: plugins/negate.c:242
 #, c-format
 msgid ""
 "    STATUS can be 'OK', 'WARNING', 'CRITICAL' or 'UNKNOWN' without single\n"
 msgstr ""
 
-#: plugins/negate.c:265
+#: plugins/negate.c:243
 #, c-format
 msgid ""
 "    quotes. Numeric values are accepted. If nothing is specified, permutes\n"
 msgstr ""
 
-#: plugins/negate.c:266
+#: plugins/negate.c:244
 #, c-format
 msgid "    OK and CRITICAL.\n"
 msgstr ""
 
-#: plugins/negate.c:268
+#: plugins/negate.c:246
 #, c-format
 msgid ""
 "    Substitute output text as well. Will only substitute text in CAPITALS\n"
 msgstr ""
 
-#: plugins/negate.c:273
+#: plugins/negate.c:251
 msgid "Run check_ping and invert result. Must use full path to plugin"
 msgstr ""
 
-#: plugins/negate.c:275
+#: plugins/negate.c:253
 msgid "This will return OK instead of WARNING and UNKNOWN instead of CRITICAL"
 msgstr ""
 
-#: plugins/negate.c:278
+#: plugins/negate.c:256
 msgid ""
 "This plugin is a wrapper to take the output of another plugin and invert it."
 msgstr ""
 
-#: plugins/negate.c:279
+#: plugins/negate.c:257
 msgid "The full path of the plugin must be provided."
 msgstr ""
 
-#: plugins/negate.c:280
+#: plugins/negate.c:258
 msgid "If the wrapped plugin returns OK, the wrapper will return CRITICAL."
 msgstr ""
 
-#: plugins/negate.c:281
+#: plugins/negate.c:259
 msgid "If the wrapped plugin returns CRITICAL, the wrapper will return OK."
 msgstr ""
 
-#: plugins/negate.c:282
+#: plugins/negate.c:260
 msgid "Otherwise, the output state of the wrapped plugin is unchanged."
 msgstr ""
 
-#: plugins/negate.c:284
+#: plugins/negate.c:262
 msgid ""
 "Using timeout-result, it is possible to override the timeout behaviour or a"
 msgstr ""
 
-#: plugins/negate.c:285
+#: plugins/negate.c:263
 msgid "plugin by setting the negate timeout a bit lower."
 msgstr ""
 
@@ -5552,143 +5969,138 @@ msgstr "CRITICAL - Dokumentendatum ist %d Sekunden in der Zukunft\n"
 msgid "%s - Abnormal timeout after %d seconds\n"
 msgstr "CRITICAL - Dokumentendatum ist %d Sekunden in der Zukunft\n"
 
-#: plugins/netutils.c:79 plugins/netutils.c:281
+#: plugins/netutils.c:79 plugins/netutils.c:292
 msgid "Send failed"
 msgstr ""
 
-#: plugins/netutils.c:96 plugins/netutils.c:296
+#: plugins/netutils.c:96 plugins/netutils.c:307
 #, fuzzy
 msgid "No data was received from host!"
 msgstr "Keine Daten empfangen %s\n"
 
-#: plugins/netutils.c:204 plugins/netutils.c:240
+#: plugins/netutils.c:209 plugins/netutils.c:245
 msgid "Socket creation failed"
 msgstr ""
 
-#: plugins/netutils.c:233
+#: plugins/netutils.c:238
 msgid "Supplied path too long unix domain socket"
 msgstr ""
 
-#: plugins/netutils.c:305
+#: plugins/netutils.c:316
 msgid "Receive failed"
 msgstr ""
 
-#: plugins/netutils.c:331 plugins-root/check_dhcp.c:1342
+#: plugins/netutils.c:342 plugins-root/check_dhcp.c:1310
 #, fuzzy, c-format
 msgid "Invalid hostname/address - %s"
 msgstr ""
 "Ungültige(r) Name/Adresse: %s\n"
 "\n"
 
-#: plugins/popen.c:142
+#: plugins/popen.c:133
 #, fuzzy
 msgid "Could not malloc argv array in popen()"
 msgstr "Konnte addr nicht zuweisen\n"
 
-#: plugins/popen.c:152
+#: plugins/popen.c:143
 #, fuzzy
 msgid "CRITICAL - You need more args!!!"
 msgstr "CRITICAL - Fehler: %s\n"
 
-#: plugins/popen.c:209
+#: plugins/popen.c:201
 #, fuzzy
 msgid "Cannot catch SIGCHLD"
 msgstr "Konnte SIGALRM nicht erhalten"
 
-#: plugins/popen.c:304
+#: plugins/popen.c:287
 #, fuzzy, c-format
 msgid "CRITICAL - Plugin timed out after %d seconds\n"
 msgstr "CRITICAL - Dokumentendatum ist %d Sekunden in der Zukunft\n"
 
-#: plugins/popen.c:307
+#: plugins/popen.c:290
 msgid "CRITICAL - popen timeout received, but no child process"
 msgstr ""
 
-#: plugins/popen.c:323
-msgid "sysconf error for _SC_OPEN_MAX"
-msgstr ""
-
-#: plugins/urlize.c:130
+#: plugins/urlize.c:129
 #, c-format
 msgid ""
 "%s UNKNOWN - No data received from host\n"
 "CMD: %s</A>\n"
 msgstr ""
 
-#: plugins/urlize.c:169
+#: plugins/urlize.c:168
 msgid ""
 "This plugin wraps the text output of another command (plugin) in HTML <A>"
 msgstr ""
 
-#: plugins/urlize.c:170
+#: plugins/urlize.c:169
 msgid ""
 "tags, thus displaying the child plugin's output as a clickable link in "
 "compatible"
 msgstr ""
 
-#: plugins/urlize.c:171
+#: plugins/urlize.c:170
 msgid ""
 "monitoring status screen. This plugin returns the status of the invoked "
 "plugin."
 msgstr ""
 
-#: plugins/urlize.c:181
+#: plugins/urlize.c:180
 msgid ""
 "Pay close attention to quoting to ensure that the shell passes the expected"
 msgstr ""
 
-#: plugins/urlize.c:182
+#: plugins/urlize.c:181
 msgid "data to the plugin. For example, in:"
 msgstr ""
 
-#: plugins/urlize.c:183
+#: plugins/urlize.c:182
 msgid "urlize http://example.com/ check_http -H example.com -r 'two words'"
 msgstr ""
 
-#: plugins/urlize.c:184
+#: plugins/urlize.c:183
 msgid "the shell will remove the single quotes and urlize will see:"
 msgstr ""
 
-#: plugins/urlize.c:185
+#: plugins/urlize.c:184
 msgid "urlize http://example.com/ check_http -H example.com -r two words"
 msgstr ""
 
-#: plugins/urlize.c:186
+#: plugins/urlize.c:185
 msgid "You probably want:"
 msgstr ""
 
-#: plugins/urlize.c:187
+#: plugins/urlize.c:186
 msgid "urlize http://example.com/ \"check_http -H example.com -r 'two words'\""
 msgstr ""
 
-#: plugins/utils.c:174
-#, fuzzy, c-format
-msgid "%s - Plugin timed out after %d seconds\n"
-msgstr "CRITICAL - Dokumentendatum ist %d Sekunden in der Zukunft\n"
-
-#: plugins/utils.c:469
+#: plugins/utils.c:479
 #, fuzzy
 msgid "failed realloc in strpcpy\n"
 msgstr "konnte keinen Speicher für '%s' reservieren\n"
 
-#: plugins/utils.c:511
+#: plugins/utils.c:521
 #, fuzzy
 msgid "failed malloc in strscat\n"
 msgstr "konnte keinen Speicher für '%s' reservieren\n"
 
-#: plugins/utils.c:531
+#: plugins/utils.c:541
 #, fuzzy
 msgid "failed malloc in xvasprintf\n"
 msgstr "konnte keinen Speicher für '%s' reservieren\n"
 
-#: plugins/utils.h:137
+#: plugins/utils.c:819
+msgid "sysconf error for _SC_OPEN_MAX\n"
+msgstr ""
+
+#: plugins/utils.h:127
 #, c-format
 msgid ""
 "       %s (-h | --help) for detailed help\n"
 "       %s (-V | --version) for version information\n"
 msgstr ""
 
-#: plugins/utils.h:141
+#: plugins/utils.h:131
 msgid ""
 "\n"
 "Options:\n"
@@ -5698,7 +6110,7 @@ msgid ""
 "    Print version information\n"
 msgstr ""
 
-#: plugins/utils.h:148
+#: plugins/utils.h:138
 #, c-format
 msgid ""
 " -H, --hostname=ADDRESS\n"
@@ -5707,7 +6119,7 @@ msgid ""
 "    Port number (default: %s)\n"
 msgstr ""
 
-#: plugins/utils.h:154
+#: plugins/utils.h:144
 msgid ""
 " -4, --use-ipv4\n"
 "    Use IPv4 connection\n"
@@ -5715,14 +6127,14 @@ msgid ""
 "    Use IPv6 connection\n"
 msgstr ""
 
-#: plugins/utils.h:160
+#: plugins/utils.h:150
 msgid ""
 " -v, --verbose\n"
 "    Show details for command-line debugging (output may be truncated by\n"
-"\t\tthe monitoring system)\n"
+"    the monitoring system)\n"
 msgstr ""
 
-#: plugins/utils.h:165
+#: plugins/utils.h:155
 msgid ""
 " -w, --warning=DOUBLE\n"
 "    Response time to result in warning status (seconds)\n"
@@ -5730,7 +6142,7 @@ msgid ""
 "    Response time to result in critical status (seconds)\n"
 msgstr ""
 
-#: plugins/utils.h:171
+#: plugins/utils.h:161
 msgid ""
 " -w, --warning=RANGE\n"
 "    Warning range (format: start:end). Alert if outside this range\n"
@@ -5738,14 +6150,21 @@ msgid ""
 "    Critical range\n"
 msgstr ""
 
-#: plugins/utils.h:177
+#: plugins/utils.h:167
 #, c-format
 msgid ""
 " -t, --timeout=INTEGER\n"
 "    Seconds before connection times out (default: %d)\n"
 msgstr ""
 
-#: plugins/utils.h:182
+#: plugins/utils.h:171
+#, c-format
+msgid ""
+" -t, --timeout=INTEGER\n"
+"    Seconds before plugin times out (default: %d)\n"
+msgstr ""
+
+#: plugins/utils.h:176
 msgid ""
 " --extra-opts=[section][@file]\n"
 "    Read options from an ini file. See\n"
@@ -5753,14 +6172,14 @@ msgid ""
 "    for usage and examples.\n"
 msgstr ""
 
-#: plugins/utils.h:190
+#: plugins/utils.h:185
 msgid ""
 " See:\n"
 " https://www.monitoring-plugins.org/doc/guidelines.html#THRESHOLDFORMAT\n"
 " for THRESHOLD format and examples.\n"
 msgstr ""
 
-#: plugins/utils.h:195
+#: plugins/utils.h:190
 msgid ""
 "\n"
 "Send email to help@monitoring-plugins.org if you have questions regarding\n"
@@ -5769,7 +6188,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: plugins/utils.h:200
+#: plugins/utils.h:195
 msgid ""
 "\n"
 "The Monitoring Plugins come with ABSOLUTELY NO WARRANTY. You may "
@@ -5778,410 +6197,416 @@ msgid ""
 "For more information about these matters, see the file named COPYING.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:320
+#: plugins-root/check_dhcp.c:317
 #, c-format
 msgid "Error: Could not get hardware address of interface '%s'\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:342
+#: plugins-root/check_dhcp.c:340
 #, c-format
 msgid "Error: if_nametoindex error - %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:347
+#: plugins-root/check_dhcp.c:345
 #, c-format
 msgid "Error: Couldn't get hardware address from %s. sysctl 1 error - %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:352
+#: plugins-root/check_dhcp.c:350
 #, c-format
 msgid ""
 "Error: Couldn't get hardware address from interface %s. malloc error - %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:357
+#: plugins-root/check_dhcp.c:355
 #, c-format
 msgid "Error: Couldn't get hardware address from %s. sysctl 2 error - %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:388
+#: plugins-root/check_dhcp.c:386
 #, c-format
 msgid ""
 "Error: can't find unit number in interface_name (%s) - expecting TypeNumber "
 "eg lnc0.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:393 plugins-root/check_dhcp.c:405
+#: plugins-root/check_dhcp.c:391 plugins-root/check_dhcp.c:403
 #, c-format
 msgid ""
 "Error: can't read MAC address from DLPI streams interface for device %s unit "
 "%d.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:411
+#: plugins-root/check_dhcp.c:409
 #, c-format
 msgid ""
 "Error: can't get MAC address for this architecture.  Use the --mac option.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:430
+#: plugins-root/check_dhcp.c:428
 #, c-format
 msgid "Error: Cannot determine IP address of interface %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:438
+#: plugins-root/check_dhcp.c:436
 #, c-format
 msgid "Error: Cannot get interface IP address on this platform.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:443
+#: plugins-root/check_dhcp.c:441
 #, c-format
 msgid "Pretending to be relay client %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:528
+#: plugins-root/check_dhcp.c:521
 #, c-format
 msgid "DHCPDISCOVER to %s port %d\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:580
+#: plugins-root/check_dhcp.c:573
 #, c-format
 msgid "Result=ERROR\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:586
+#: plugins-root/check_dhcp.c:579
 #, c-format
 msgid "Result=OK\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:596
+#: plugins-root/check_dhcp.c:589
 #, c-format
 msgid "DHCPOFFER from IP address %s"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:597
+#: plugins-root/check_dhcp.c:590
 #, c-format
 msgid " via %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:604
+#: plugins-root/check_dhcp.c:597
 #, c-format
 msgid ""
 "DHCPOFFER XID (%u) did not match DHCPDISCOVER XID (%u) - ignoring packet\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:626
+#: plugins-root/check_dhcp.c:619
 #, c-format
 msgid "DHCPOFFER hardware address did not match our own - ignoring packet\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:644
+#: plugins-root/check_dhcp.c:637
 #, c-format
 msgid "Total responses seen on the wire: %d\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:645
+#: plugins-root/check_dhcp.c:638
 #, fuzzy, c-format
 msgid "Valid responses for this machine: %d\n"
 msgstr "Keine Antwort vom Host \n"
 
-#: plugins-root/check_dhcp.c:660
+#: plugins-root/check_dhcp.c:653
 #, c-format
 msgid "send_dhcp_packet result: %d\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:693
+#: plugins-root/check_dhcp.c:686
 #, fuzzy, c-format
 msgid "No (more) data received (nfound: %d)\n"
 msgstr "Keine Daten empfangen %s\n"
 
-#: plugins-root/check_dhcp.c:712
+#: plugins-root/check_dhcp.c:699
 #, c-format
 msgid "recvfrom() failed, "
 msgstr ""
 
-#: plugins-root/check_dhcp.c:719
+#: plugins-root/check_dhcp.c:706
 #, c-format
 msgid "receive_dhcp_packet() result: %d\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:720
+#: plugins-root/check_dhcp.c:707
 #, c-format
 msgid "receive_dhcp_packet() source: %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:750
+#: plugins-root/check_dhcp.c:737
 #, c-format
 msgid "Error: Could not create socket!\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:760
+#: plugins-root/check_dhcp.c:747
 #, c-format
 msgid "Error: Could not set reuse address option on DHCP socket!\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:766
+#: plugins-root/check_dhcp.c:753
 #, c-format
 msgid "Error: Could not set broadcast option on DHCP socket!\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:775
+#: plugins-root/check_dhcp.c:762
 #, c-format
 msgid ""
 "Error: Could not bind socket to interface %s.  Check your privileges...\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:786
+#: plugins-root/check_dhcp.c:773
 #, c-format
 msgid ""
 "Error: Could not bind to DHCP socket (port %d)!  Check your privileges...\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:820
+#: plugins-root/check_dhcp.c:807
 #, c-format
 msgid "Requested server address: %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:882
+#: plugins-root/check_dhcp.c:869
 #, c-format
 msgid "Lease Time: Infinite\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:884
+#: plugins-root/check_dhcp.c:871
 #, c-format
 msgid "Lease Time: %lu seconds\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:886
+#: plugins-root/check_dhcp.c:873
 #, c-format
 msgid "Renewal Time: Infinite\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:888
+#: plugins-root/check_dhcp.c:875
 #, c-format
 msgid "Renewal Time: %lu seconds\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:890
+#: plugins-root/check_dhcp.c:877
 #, c-format
 msgid "Rebinding Time: Infinite\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:891
+#: plugins-root/check_dhcp.c:878
 #, c-format
 msgid "Rebinding Time: %lu seconds\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:919
+#: plugins-root/check_dhcp.c:906
 #, c-format
 msgid "Added offer from server @ %s"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:920
+#: plugins-root/check_dhcp.c:907
 #, c-format
 msgid " of IP address %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:987
+#: plugins-root/check_dhcp.c:974
 #, c-format
 msgid "DHCP Server Match: Offerer=%s"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:988
+#: plugins-root/check_dhcp.c:975
 #, c-format
 msgid " Requested=%s"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:990
+#: plugins-root/check_dhcp.c:977
 #, c-format
 msgid " (duplicate)"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:991
+#: plugins-root/check_dhcp.c:978
 #, c-format
 msgid "\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1039
+#: plugins-root/check_dhcp.c:1026
 #, c-format
 msgid "No DHCPOFFERs were received.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1043
+#: plugins-root/check_dhcp.c:1030
 #, c-format
 msgid "Received %d DHCPOFFER(s)"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1046
+#: plugins-root/check_dhcp.c:1033
 #, c-format
 msgid ", %s%d of %d requested servers responded"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1049
+#: plugins-root/check_dhcp.c:1036
 #, c-format
 msgid ", requested address (%s) was %soffered"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1049
+#: plugins-root/check_dhcp.c:1036
 msgid "not "
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1051
+#: plugins-root/check_dhcp.c:1038
 #, c-format
 msgid ", max lease time = "
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1053
+#: plugins-root/check_dhcp.c:1040
 #, c-format
 msgid "Infinity"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1234
+#: plugins-root/check_dhcp.c:1160
+msgid "Got unexpected non-option argument"
+msgstr ""
+
+#: plugins-root/check_dhcp.c:1202
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in check_ctrl: %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1246
+#: plugins-root/check_dhcp.c:1214
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in put_ctrl/putmsg(): %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1259
+#: plugins-root/check_dhcp.c:1227
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in put_both/putmsg().\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1271
+#: plugins-root/check_dhcp.c:1239
 #, c-format
 msgid ""
 "Error: DLPI stream API failed to get MAC in dl_attach_req/open(%s..): %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1295
+#: plugins-root/check_dhcp.c:1263
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in dl_bind/check_ctrl(): %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1374
+#: plugins-root/check_dhcp.c:1342
 #, c-format
 msgid "Hardware address: "
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1390
+#: plugins-root/check_dhcp.c:1358
 msgid "This plugin tests the availability of DHCP servers on a network."
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1402
+#: plugins-root/check_dhcp.c:1370
 msgid "IP address of DHCP server that we must hear from"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1404
+#: plugins-root/check_dhcp.c:1372
 msgid "IP address that should be offered by at least one DHCP server"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1406
+#: plugins-root/check_dhcp.c:1374
 msgid "Seconds to wait for DHCPOFFER before timeout occurs"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1408
+#: plugins-root/check_dhcp.c:1376
 msgid "Interface to to use for listening (i.e. eth0)"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1410
+#: plugins-root/check_dhcp.c:1378
 msgid "MAC address to use in the DHCP request"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1412
+#: plugins-root/check_dhcp.c:1380
 msgid "Unicast testing: mimic a DHCP relay, requires -s"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1295
+#: plugins-root/check_icmp.c:1567
 msgid "specify a target"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1297
+#: plugins-root/check_icmp.c:1569
+msgid "Use IPv4 (default) or IPv6 to communicate with the targets"
+msgstr ""
+
+#: plugins-root/check_icmp.c:1571
 #, fuzzy
 msgid "warning threshold (currently "
 msgstr "Warning threshold  Integer sein"
 
-#: plugins-root/check_icmp.c:1300
+#: plugins-root/check_icmp.c:1574
 #, fuzzy
 msgid "critical threshold (currently "
 msgstr "Critical threshold muss ein Integer sein"
 
-#: plugins-root/check_icmp.c:1303
+#: plugins-root/check_icmp.c:1577
 #, fuzzy
 msgid "specify a source IP address or device name"
 msgstr "Hostname oder Serveradresse muss angegeben werden"
 
-#: plugins-root/check_icmp.c:1305
+#: plugins-root/check_icmp.c:1579
 msgid "number of packets to send (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1308
+#: plugins-root/check_icmp.c:1582
 msgid "max packet interval (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1311
+#: plugins-root/check_icmp.c:1585
 msgid "max target interval (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1314
+#: plugins-root/check_icmp.c:1588
 msgid "number of alive hosts required for success"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1317
+#: plugins-root/check_icmp.c:1591
 msgid "TTL on outgoing packets (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1320
+#: plugins-root/check_icmp.c:1594
 msgid "timeout value (seconds, currently  "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1323
+#: plugins-root/check_icmp.c:1597
 msgid "Number of icmp data bytes to send"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1324
+#: plugins-root/check_icmp.c:1598
 msgid "Packet size will be data bytes + icmp header (currently"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1326
+#: plugins-root/check_icmp.c:1600
 msgid "verbose"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1330
+#: plugins-root/check_icmp.c:1604
 msgid "The -H switch is optional. Naming a host (or several) to check is not."
 msgstr ""
 
-#: plugins-root/check_icmp.c:1332
+#: plugins-root/check_icmp.c:1606
 msgid ""
 "Threshold format for -w and -c is 200.25,60% for 200.25 msec RTA and 60%"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1333
+#: plugins-root/check_icmp.c:1607
 msgid "packet loss.  The default values should work well for most users."
 msgstr ""
 
-#: plugins-root/check_icmp.c:1334
+#: plugins-root/check_icmp.c:1608
 msgid ""
 "You can specify different RTA factors using the standardized abbreviations"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1335
+#: plugins-root/check_icmp.c:1609
 msgid ""
 "us (microseconds), ms (milliseconds, default) or just plain s for seconds."
 msgstr ""
 
-#: plugins-root/check_icmp.c:1341
+#: plugins-root/check_icmp.c:1615
 msgid "The -v switch can be specified several times for increased verbosity."
 msgstr ""
 
-#~ msgid "Critical threshold must be integer"
-#~ msgstr "Critical threshold muss ein Integer sein"
-
-#~ msgid "Warning threshold must be integer"
-#~ msgstr "Warning threshold  Integer sein"
+#, fuzzy, c-format
+#~ msgid "%s - Plugin timed out after %d seconds\n"
+#~ msgstr "CRITICAL - Dokumentendatum ist %d Sekunden in der Zukunft\n"
 
 #, fuzzy
 #~ msgid "Critical Process Count must be an integer!"
@@ -6230,15 +6655,7 @@ msgstr ""
 #~ msgstr "HTTP CRITICAL - Text nicht gefunden%s|%s %s\n"
 
 #, fuzzy
-#~ msgid "HTTP OK %s - %d bytes in %.3f seconds %s|%s %s\n"
-#~ msgstr "HTTP OK %s - %.3f Sekunde Antwortzeit %s%s|%s %s\n"
-
-#, fuzzy
 #~ msgid "HTTP UNKNOWN - could not allocate url\n"
-#~ msgstr "HTTP UNKNOWN - Konnte·url·nicht·zuweisen\n"
-
-#, fuzzy
-#~ msgid "HTTP UNKNOWN - Could not allocate server_url%s\n"
 #~ msgstr "HTTP UNKNOWN - Konnte·url·nicht·zuweisen\n"
 
 #, fuzzy
@@ -6414,9 +6831,6 @@ msgstr ""
 
 #~ msgid "Client Certificate Required\n"
 #~ msgstr "Clientzertifikat benötigt\n"
-
-#~ msgid "Failed"
-#~ msgstr "Fehlgeschlagen"
 
 #~ msgid "CRITICAL -  Cannot create SSL context.\n"
 #~ msgstr "CRITICAL -  Konnte SSL Kontext nicht erzeugen.\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2014-01-19 16:30-0500\n"
+"POT-Creation-Date: 2023-06-12 16:29+0200\n"
 "PO-Revision-Date: 2010-04-21 23:38-0400\n"
 "Last-Translator: Thomas Guyot-Sionnest <dermoth@aei.ca>\n"
 "Language-Team: Nagios Plugin Development Mailing List <nagiosplug-"
@@ -22,98 +22,101 @@ msgstr ""
 "Plural-Forms:  nplurals=2; plural=(n != 1);\n"
 "X-Generator: KBabel 1.11.4\n"
 
-#: plugins/check_by_ssh.c:86 plugins/check_cluster.c:76 plugins/check_dig.c:88
-#: plugins/check_disk.c:194 plugins/check_dns.c:102 plugins/check_dummy.c:52
-#: plugins/check_fping.c:93 plugins/check_game.c:82 plugins/check_hpjd.c:103
-#: plugins/check_http.c:167 plugins/check_ldap.c:109 plugins/check_load.c:122
-#: plugins/check_mrtgtraf.c:83 plugins/check_mysql.c:122
-#: plugins/check_nagios.c:91 plugins/check_nt.c:127 plugins/check_ntp.c:770
-#: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:552
+#: plugins/check_by_ssh.c:88 plugins/check_cluster.c:76 plugins/check_dig.c:91
+#: plugins/check_disk.c:206 plugins/check_dns.c:106 plugins/check_dummy.c:52
+#: plugins/check_fping.c:95 plugins/check_game.c:82 plugins/check_hpjd.c:105
+#: plugins/check_http.c:174 plugins/check_ldap.c:118 plugins/check_load.c:128
+#: plugins/check_mrtgtraf.c:83 plugins/check_mysql.c:124
+#: plugins/check_nagios.c:91 plugins/check_nt.c:127 plugins/check_ntp.c:780
+#: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:557
 #: plugins/check_nwstat.c:173 plugins/check_overcr.c:102
-#: plugins/check_pgsql.c:172 plugins/check_ping.c:95 plugins/check_procs.c:172
-#: plugins/check_radius.c:160 plugins/check_real.c:80 plugins/check_smtp.c:144
-#: plugins/check_snmp.c:240 plugins/check_ssh.c:73 plugins/check_swap.c:110
-#: plugins/check_tcp.c:218 plugins/check_time.c:78 plugins/check_ups.c:122
-#: plugins/check_users.c:77 plugins/negate.c:214 plugins-root/check_dhcp.c:270
+#: plugins/check_pgsql.c:174 plugins/check_ping.c:97 plugins/check_procs.c:176
+#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:145
+#: plugins/check_snmp.c:248 plugins/check_ssh.c:74 plugins/check_swap.c:115
+#: plugins/check_tcp.c:222 plugins/check_time.c:78 plugins/check_ups.c:122
+#: plugins/check_users.c:84 plugins/negate.c:210 plugins-root/check_dhcp.c:270
 msgid "Could not parse arguments"
 msgstr "Impossible de décomposer les arguments"
 
-#: plugins/check_by_ssh.c:90 plugins/check_dig.c:82 plugins/check_dns.c:95
-#: plugins/check_nagios.c:95 plugins/check_pgsql.c:178 plugins/check_ping.c:99
-#: plugins/check_procs.c:188 plugins/check_snmp.c:336 plugins/negate.c:79
+#: plugins/check_by_ssh.c:92 plugins/check_dig.c:85 plugins/check_dns.c:99
+#: plugins/check_nagios.c:95 plugins/check_pgsql.c:180 plugins/check_ping.c:101
+#: plugins/check_procs.c:192 plugins/check_snmp.c:348 plugins/negate.c:78
 msgid "Cannot catch SIGALRM"
 msgstr "Impossible d'obtenir le signal SIGALRM"
 
-#: plugins/check_by_ssh.c:110
+#: plugins/check_by_ssh.c:107
+#, fuzzy, c-format
+msgid "SSH connection failed: %s\n"
+msgstr "L'exécution de la commande à distance %s à échoué\n"
+
+#: plugins/check_by_ssh.c:126
 #, c-format
 msgid "Remote command execution failed: %s\n"
 msgstr "L'exécution de la commande à distance %s à échoué\n"
 
-#: plugins/check_by_ssh.c:122
+#: plugins/check_by_ssh.c:141
 #, c-format
 msgid "%s - check_by_ssh: Remote command '%s' returned status %d\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:134
+#: plugins/check_by_ssh.c:153
 #, c-format
 msgid "SSH WARNING: could not open %s\n"
 msgstr "SSH AVERTISSEMENT: impossible d'ouvrir %s\n"
 
-#: plugins/check_by_ssh.c:143
+#: plugins/check_by_ssh.c:162
 #, c-format
 msgid "%s: Error parsing output\n"
 msgstr "%s: Erreur d'analyse du résultat\n"
 
-#: plugins/check_by_ssh.c:220 plugins/check_disk.c:476
-#: plugins/check_http.c:278 plugins/check_ldap.c:293 plugins/check_pgsql.c:311
-#: plugins/check_procs.c:437 plugins/check_radius.c:308
-#: plugins/check_real.c:356 plugins/check_smtp.c:581 plugins/check_snmp.c:736
-#: plugins/check_ssh.c:138 plugins/check_tcp.c:505 plugins/check_time.c:302
-#: plugins/check_ups.c:556 plugins/negate.c:164
+#: plugins/check_by_ssh.c:242 plugins/check_disk.c:568 plugins/check_http.c:292
+#: plugins/check_ldap.c:334 plugins/check_pgsql.c:314 plugins/check_procs.c:461
+#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:601
+#: plugins/check_snmp.c:789 plugins/check_ssh.c:140 plugins/check_tcp.c:519
+#: plugins/check_time.c:302 plugins/check_ups.c:559 plugins/negate.c:160
 msgid "Timeout interval must be a positive integer"
 msgstr "Le délai d'attente doit être un entier positif"
 
-#: plugins/check_by_ssh.c:230 plugins/check_pgsql.c:341
-#: plugins/check_radius.c:272 plugins/check_real.c:327
-#: plugins/check_smtp.c:506 plugins/check_tcp.c:511 plugins/check_time.c:296
-#: plugins/check_ups.c:518
+#: plugins/check_by_ssh.c:254 plugins/check_pgsql.c:344
+#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:526
+#: plugins/check_tcp.c:525 plugins/check_time.c:296 plugins/check_ups.c:521
 msgid "Port must be a positive integer"
 msgstr "Le numéro du port doit être un entier positif"
 
-#: plugins/check_by_ssh.c:291
+#: plugins/check_by_ssh.c:315
 msgid "skip-stdout argument must be an integer"
 msgstr "Le nombres de lignes à sauter (skip-stdout) doit être un entier"
 
-#: plugins/check_by_ssh.c:299
+#: plugins/check_by_ssh.c:323
 msgid "skip-stderr argument must be an integer"
 msgstr "Le nombres de lignes à sauter (skip-stderr) doit être un entier"
 
-#: plugins/check_by_ssh.c:322
+#: plugins/check_by_ssh.c:349
 #, c-format
 msgid "%s: You must provide a host name\n"
 msgstr "%s: Vous devez fournir un nom d'hôte\n"
 
-#: plugins/check_by_ssh.c:340
+#: plugins/check_by_ssh.c:366
 msgid "No remotecmd"
 msgstr "Pas de commande distante"
 
-#: plugins/check_by_ssh.c:354
+#: plugins/check_by_ssh.c:380
 #, c-format
 msgid "%s: Argument limit of %d exceeded\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:357
+#: plugins/check_by_ssh.c:383
 msgid "Can not (re)allocate 'commargv' buffer\n"
 msgstr "Impossible de réallouer le tampon 'commargv'\n"
 
-#: plugins/check_by_ssh.c:371
+#: plugins/check_by_ssh.c:397
 #, c-format
 msgid ""
 "%s: In passive mode, you must provide a service name for each command.\n"
 msgstr ""
 "%s: En mode passif, vous devez fournir un service pour chaque commande.\n"
 
-#: plugins/check_by_ssh.c:374
+#: plugins/check_by_ssh.c:400
 #, fuzzy, c-format
 msgid ""
 "%s: In passive mode, you must provide the host short name from the "
@@ -122,471 +125,485 @@ msgstr ""
 "%s: En mode passif, vous devez fournir le nom court du hôte mentionné dans "
 "la configuration de nagios.\n"
 
-#: plugins/check_by_ssh.c:388
+#: plugins/check_by_ssh.c:414
 #, c-format
 msgid "This plugin uses SSH to execute commands on a remote host"
 msgstr "Ce plugin utilise SSH pour exécuter des commandes sur un hôte distant"
 
-#: plugins/check_by_ssh.c:403
+#: plugins/check_by_ssh.c:429
 msgid "tell ssh to use Protocol 1 [optional]"
 msgstr "dire à ssh d'utiliser le protocole version 1 [optionnel]"
 
-#: plugins/check_by_ssh.c:405
+#: plugins/check_by_ssh.c:431
 msgid "tell ssh to use Protocol 2 [optional]"
 msgstr "dire à ssh d'utiliser le protocole 2 [optionnel]"
 
-#: plugins/check_by_ssh.c:407
+#: plugins/check_by_ssh.c:433
 msgid "Ignore all or (if specified) first n lines on STDOUT [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:409
+#: plugins/check_by_ssh.c:435
 msgid "Ignore all or (if specified) first n lines on STDERR [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:411
+#: plugins/check_by_ssh.c:437
+msgid "Exit with an warning, if there is an output on STDERR"
+msgstr ""
+
+#: plugins/check_by_ssh.c:439
 msgid ""
 "tells ssh to fork rather than create a tty [optional]. This will always "
 "return OK if ssh is executed"
 msgstr ""
 
-#: plugins/check_by_ssh.c:413
+#: plugins/check_by_ssh.c:441
 msgid "command to execute on the remote machine"
 msgstr "commande à exécuter sur la machine distante"
 
-#: plugins/check_by_ssh.c:415
+#: plugins/check_by_ssh.c:443
 msgid "SSH user name on remote host [optional]"
 msgstr "Nom d'utilisateur ssh sur la machine distante [optionnel]"
 
-#: plugins/check_by_ssh.c:417
+#: plugins/check_by_ssh.c:445
 msgid "identity of an authorized key [optional]"
 msgstr "Identité de la clé autorisée [optionnel]"
 
-#: plugins/check_by_ssh.c:419
+#: plugins/check_by_ssh.c:447
 #, fuzzy
 msgid "external command file for monitoring [optional]"
 msgstr "commande externe pour nagios [optionnel]"
 
-#: plugins/check_by_ssh.c:421
+#: plugins/check_by_ssh.c:449
 #, fuzzy
 msgid "list of monitoring service names, separated by ':' [optional]"
 msgstr "liste des services nagios, séparés par ':' [optionnel] "
 
-#: plugins/check_by_ssh.c:423
+#: plugins/check_by_ssh.c:451
 #, fuzzy
 msgid "short name of host in the monitoring configuration [optional]"
 msgstr "nom court de l'hôte dans la configuration nagios [optionnel]"
 
-#: plugins/check_by_ssh.c:425
+#: plugins/check_by_ssh.c:453
 msgid "Call ssh with '-o OPTION' (may be used multiple times) [optional]"
 msgstr ""
 "appelle ssh avec '-o OPTION' (peut être utilisé plusieurs fois) [optionnel]"
 
-#: plugins/check_by_ssh.c:427
+#: plugins/check_by_ssh.c:455
 #, fuzzy
 msgid "Tell ssh to use this configfile [optional]"
 msgstr "dire à ssh d'utiliser le protocole version 1 [optionnel]"
 
-#: plugins/check_by_ssh.c:429
+#: plugins/check_by_ssh.c:457
 msgid "Tell ssh to suppress warning and diagnostic messages [optional]"
 msgstr ""
 "dire à ssh de supprimer les messages d'erreurs et de diagnostic [optionnel]"
 
-#: plugins/check_by_ssh.c:434
+#: plugins/check_by_ssh.c:461
+msgid "Make connection problems return UNKNOWN instead of CRITICAL"
+msgstr ""
+
+#: plugins/check_by_ssh.c:464
 msgid "The most common mode of use is to refer to a local identity file with"
 msgstr ""
 
-#: plugins/check_by_ssh.c:435
+#: plugins/check_by_ssh.c:465
 msgid "the '-i' option. In this mode, the identity pair should have a null"
 msgstr ""
 
-#: plugins/check_by_ssh.c:436
+#: plugins/check_by_ssh.c:466
 msgid "passphrase and the public key should be listed in the authorized_keys"
 msgstr ""
 
-#: plugins/check_by_ssh.c:437
+#: plugins/check_by_ssh.c:467
 msgid "file of the remote host. Usually the key will be restricted to running"
 msgstr ""
 
-#: plugins/check_by_ssh.c:438
+#: plugins/check_by_ssh.c:468
 msgid "only one command on the remote server. If the remote SSH server tracks"
 msgstr ""
 
-#: plugins/check_by_ssh.c:439
+#: plugins/check_by_ssh.c:469
 msgid "invocation arguments, the one remote program may be an agent that can"
 msgstr ""
 
-#: plugins/check_by_ssh.c:440
+#: plugins/check_by_ssh.c:470
 msgid "execute additional commands as proxy"
 msgstr ""
 
-#: plugins/check_by_ssh.c:442
+#: plugins/check_by_ssh.c:472
 msgid "To use passive mode, provide multiple '-C' options, and provide"
 msgstr "Pour utiliser le mode passif, utilisez plusieurs fois l'option '-C',et"
 
-#: plugins/check_by_ssh.c:443
+#: plugins/check_by_ssh.c:473
 msgid ""
 "all of -O, -s, and -n options (servicelist order must match '-C'options)"
 msgstr ""
 "et les options -O, -s, n (l'ordre des services doit correspondre aux "
 "multiples options '-C)"
 
-#: plugins/check_by_ssh.c:445 plugins/check_cluster.c:261
-#: plugins/check_dig.c:355 plugins/check_disk.c:924 plugins/check_http.c:1560
-#: plugins/check_nagios.c:312 plugins/check_ntp.c:869
-#: plugins/check_ntp_peer.c:705 plugins/check_ntp_time.c:633
-#: plugins/check_procs.c:763 plugins/negate.c:271 plugins/urlize.c:180
+#: plugins/check_by_ssh.c:475 plugins/check_cluster.c:271
+#: plugins/check_dig.c:364 plugins/check_disk.c:1000 plugins/check_http.c:1845
+#: plugins/check_nagios.c:312 plugins/check_ntp.c:879
+#: plugins/check_ntp_peer.c:733 plugins/check_ntp_time.c:642
+#: plugins/check_procs.c:806 plugins/negate.c:249 plugins/urlize.c:179
 msgid "Examples:"
 msgstr "Exemples:"
 
-#: plugins/check_by_ssh.c:460 plugins/check_cluster.c:274
-#: plugins/check_dig.c:367 plugins/check_disk.c:941 plugins/check_dns.c:486
-#: plugins/check_dummy.c:122 plugins/check_fping.c:505
-#: plugins/check_game.c:331 plugins/check_hpjd.c:414 plugins/check_http.c:1590
-#: plugins/check_ldap.c:451 plugins/check_load.c:334 plugins/check_mrtg.c:382
-#: plugins/check_mysql.c:569 plugins/check_nagios.c:323 plugins/check_nt.c:774
-#: plugins/check_ntp.c:888 plugins/check_ntp_peer.c:725
-#: plugins/check_ntp_time.c:642 plugins/check_nwstat.c:1685
-#: plugins/check_overcr.c:467 plugins/check_pgsql.c:578
-#: plugins/check_ping.c:603 plugins/check_procs.c:781
-#: plugins/check_radius.c:385 plugins/check_real.c:451
-#: plugins/check_smtp.c:843 plugins/check_snmp.c:1207 plugins/check_ssh.c:309
-#: plugins/check_swap.c:558 plugins/check_tcp.c:684 plugins/check_time.c:371
-#: plugins/check_ups.c:660 plugins/check_users.c:240
-#: plugins/check_ide_smart.c:640 plugins/negate.c:295 plugins/urlize.c:197
-#: plugins-root/check_dhcp.c:1422 plugins-root/check_icmp.c:1354
+#: plugins/check_by_ssh.c:490 plugins/check_cluster.c:284
+#: plugins/check_dig.c:376 plugins/check_disk.c:1017 plugins/check_dns.c:617
+#: plugins/check_dummy.c:122 plugins/check_fping.c:524 plugins/check_game.c:331
+#: plugins/check_hpjd.c:439 plugins/check_http.c:1883 plugins/check_ldap.c:511
+#: plugins/check_load.c:372 plugins/check_mrtg.c:382 plugins/check_mysql.c:587
+#: plugins/check_nagios.c:323 plugins/check_nt.c:797 plugins/check_ntp.c:898
+#: plugins/check_ntp_peer.c:753 plugins/check_ntp_time.c:651
+#: plugins/check_nwstat.c:1685 plugins/check_overcr.c:467
+#: plugins/check_pgsql.c:551 plugins/check_ping.c:617 plugins/check_procs.c:829
+#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:875
+#: plugins/check_snmp.c:1346 plugins/check_ssh.c:325 plugins/check_swap.c:607
+#: plugins/check_tcp.c:710 plugins/check_time.c:371 plugins/check_ups.c:663
+#: plugins/check_users.c:262 plugins/check_ide_smart.c:606 plugins/negate.c:273
+#: plugins/urlize.c:196 plugins-root/check_dhcp.c:1390
+#: plugins-root/check_icmp.c:1628
 msgid "Usage:"
 msgstr "Utilisation:"
 
-#: plugins/check_cluster.c:230
+#: plugins/check_cluster.c:240
 #, fuzzy, c-format
 msgid "Host/Service Cluster Plugin for Monitoring"
 msgstr "Plugin de Cluster d'Hôte/Service pour Nagios 2"
 
-#: plugins/check_cluster.c:236 plugins/check_nt.c:676
+#: plugins/check_cluster.c:246 plugins/check_nt.c:697
 msgid "Options:"
 msgstr "Options:"
 
-#: plugins/check_cluster.c:239
+#: plugins/check_cluster.c:249
 msgid "Check service cluster status"
 msgstr "Vérifie l'état d'un cluster de services"
 
-#: plugins/check_cluster.c:241
+#: plugins/check_cluster.c:251
 msgid "Check host cluster status"
 msgstr "Vérifie l'état d'un cluster d'hôtes"
 
-#: plugins/check_cluster.c:243
+#: plugins/check_cluster.c:253
 msgid "Optional prepended text output (i.e. \"Host cluster\")"
 msgstr "Texte optionnel accolé à la sortie (i.e. \"Cluster d'hôtes\")"
 
-#: plugins/check_cluster.c:245 plugins/check_cluster.c:248
+#: plugins/check_cluster.c:255 plugins/check_cluster.c:258
 msgid "Specifies the range of hosts or services in cluster that must be in a"
 msgstr "Défini le nombre d'hôtes ou de services du cluster qui doivent être"
 
-#: plugins/check_cluster.c:246
+#: plugins/check_cluster.c:256
 msgid "non-OK state in order to return a WARNING status level"
 msgstr "dans un état non-OK pour retourner un état AVERTISSEMENT"
 
-#: plugins/check_cluster.c:249
+#: plugins/check_cluster.c:259
 msgid "non-OK state in order to return a CRITICAL status level"
 msgstr "dans un état non-OK pour retourner un état CRITIQUE"
 
-#: plugins/check_cluster.c:251
+#: plugins/check_cluster.c:261
 msgid "The status codes of the hosts or services in the cluster, separated by"
 msgstr "Les codes d'état des hôtes ou des services du cluster, séparés par des"
 
-#: plugins/check_cluster.c:252
+#: plugins/check_cluster.c:262
 msgid "commas"
 msgstr "virgules"
 
-#: plugins/check_cluster.c:257 plugins/check_game.c:318
-#: plugins/check_http.c:1542 plugins/check_ldap.c:438 plugins/check_mrtg.c:363
-#: plugins/check_mrtgtraf.c:361 plugins/check_mysql.c:558
-#: plugins/check_nt.c:758 plugins/check_ntp.c:865 plugins/check_ntp_peer.c:696
-#: plugins/check_ntp_time.c:626 plugins/check_nwstat.c:1670
-#: plugins/check_overcr.c:456 plugins/check_snmp.c:1178
-#: plugins/check_swap.c:547 plugins/check_ups.c:642 plugins/negate.c:277
-#: plugins-root/check_icmp.c:1329
+#: plugins/check_cluster.c:267 plugins/check_game.c:318
+#: plugins/check_http.c:1827 plugins/check_ldap.c:497 plugins/check_mrtg.c:363
+#: plugins/check_mrtgtraf.c:361 plugins/check_mysql.c:576
+#: plugins/check_nt.c:781 plugins/check_ntp.c:875 plugins/check_ntp_peer.c:724
+#: plugins/check_ntp_time.c:633 plugins/check_nwstat.c:1670
+#: plugins/check_overcr.c:456 plugins/check_snmp.c:1317
+#: plugins/check_swap.c:596 plugins/check_ups.c:645
+#: plugins/check_ide_smart.c:580 plugins/negate.c:255
+#: plugins-root/check_icmp.c:1603
 msgid "Notes:"
 msgstr "Notes:"
 
-#: plugins/check_cluster.c:263
+#: plugins/check_cluster.c:273
 msgid ""
 "Will alert critical if there are 3 or more service data points in a non-OK"
 msgstr ""
 
-#: plugins/check_cluster.c:264 plugins/check_ups.c:639
+#: plugins/check_cluster.c:274 plugins/check_ups.c:642
 msgid "state."
 msgstr ""
 
-#: plugins/check_dig.c:100 plugins/check_dig.c:102
+#: plugins/check_dig.c:106 plugins/check_dig.c:108
 #, c-format
 msgid "Looking for: '%s'\n"
 msgstr "Recherche de: '%s'\n"
 
-#: plugins/check_dig.c:109
+#: plugins/check_dig.c:115
 msgid "dig returned an error status"
 msgstr "dig à renvoyé un état d'erreur"
 
-#: plugins/check_dig.c:134
+#: plugins/check_dig.c:140
 msgid "Server not found in ANSWER SECTION"
 msgstr "Le serveur n'a pas été trouvé dans l'ANSWER SECTION"
 
-#: plugins/check_dig.c:144
+#: plugins/check_dig.c:150
 msgid "No ANSWER SECTION found"
 msgstr "Pas d' ANSWER SECTION trouvé"
 
-#: plugins/check_dig.c:171
+#: plugins/check_dig.c:177
 msgid "Probably a non-existent host/domain"
 msgstr "Probablement un hôte/domaine inexistant"
 
-#: plugins/check_dig.c:233
+#: plugins/check_dig.c:239
 #, c-format
 msgid "Port must be a positive integer - %s"
 msgstr "Le numéro du port doit être un entier positif - %s"
 
-#: plugins/check_dig.c:244
+#: plugins/check_dig.c:250
 #, c-format
 msgid "Warning interval must be a positive integer - %s"
 msgstr "Le seuil d'avertissement doit être un entier positif - %s"
 
-#: plugins/check_dig.c:252
+#: plugins/check_dig.c:258
 #, c-format
 msgid "Critical interval must be a positive integer - %s"
 msgstr "Le seuil critique doit être un entier positif - %s"
 
-#: plugins/check_dig.c:260
+#: plugins/check_dig.c:266
 #, c-format
 msgid "Timeout interval must be a positive integer - %s"
 msgstr "Le délai d'attente doit être un entier positif - %s"
 
-#: plugins/check_dig.c:325
-#, c-format
-msgid "This plugin test the DNS service on the specified host using dig"
+#: plugins/check_dig.c:334
+#, fuzzy, c-format
+msgid "This plugin tests the DNS service on the specified host using dig"
 msgstr "Ce plugin teste le service DNS sur l'hôte spécifié en utilisant dig"
 
-#: plugins/check_dig.c:338
+#: plugins/check_dig.c:347
 msgid "Force dig to only use IPv4 query transport"
 msgstr ""
 
-#: plugins/check_dig.c:340
+#: plugins/check_dig.c:349
 msgid "Force dig to only use IPv6 query transport"
 msgstr ""
 
-#: plugins/check_dig.c:342
+#: plugins/check_dig.c:351
 msgid "Machine name to lookup"
 msgstr "Nom de machine à rechercher"
 
-#: plugins/check_dig.c:344
+#: plugins/check_dig.c:353
 msgid "Record type to lookup (default: A)"
 msgstr "Type d'enregistrement à rechercher (par défaut: A)"
 
-#: plugins/check_dig.c:346
+#: plugins/check_dig.c:355
 msgid ""
 "An address expected to be in the answer section. If not set, uses whatever"
 msgstr ""
 "Une adresse qui devrait se trouver dans la section réponce. Si omit, utilise"
 
-#: plugins/check_dig.c:347
+#: plugins/check_dig.c:356
 msgid "was in -l"
 msgstr "ce qui est passé au paramètre -l"
 
-#: plugins/check_dig.c:349
+#: plugins/check_dig.c:358
 msgid "Pass STRING as argument(s) to dig"
 msgstr ""
 
-#: plugins/check_disk.c:216
+#: plugins/check_disk.c:241
 #, c-format
 msgid "DISK %s: %s not found\n"
 msgstr "DISK %s: %s non trouvé\n"
 
-#: plugins/check_disk.c:216 plugins/check_disk.c:956 plugins/check_dns.c:241
-#: plugins/check_dummy.c:74 plugins/check_mysql.c:299
+#: plugins/check_disk.c:241 plugins/check_disk.c:1035 plugins/check_dns.c:295
+#: plugins/check_dummy.c:74 plugins/check_mysql.c:313
 #: plugins/check_nagios.c:104 plugins/check_nagios.c:168
-#: plugins/check_nagios.c:172 plugins/check_pgsql.c:601
-#: plugins/check_pgsql.c:618 plugins/check_pgsql.c:627
-#: plugins/check_pgsql.c:642 plugins/check_procs.c:351
+#: plugins/check_nagios.c:172 plugins/check_pgsql.c:575
+#: plugins/check_pgsql.c:592 plugins/check_pgsql.c:601
+#: plugins/check_pgsql.c:616 plugins/check_procs.c:374
 #, c-format
 msgid "CRITICAL"
 msgstr "CRITIQUE"
 
-#: plugins/check_disk.c:550
+#: plugins/check_disk.c:645
 #, c-format
 msgid "unit type %s not known\n"
 msgstr "unité de type %s inconnue\n"
 
-#: plugins/check_disk.c:553
+#: plugins/check_disk.c:648
 #, c-format
 msgid "failed allocating storage for '%s'\n"
 msgstr "Impossible d'allouer de l'espace pour '%s'\n"
 
-#: plugins/check_disk.c:577 plugins/check_disk.c:618 plugins/check_disk.c:626
-#: plugins/check_disk.c:633 plugins/check_disk.c:637 plugins/check_disk.c:677
-#: plugins/check_disk.c:683 plugins/check_disk.c:702 plugins/check_dummy.c:77
-#: plugins/check_dummy.c:80 plugins/check_pgsql.c:643
-#: plugins/check_procs.c:506
+#: plugins/check_disk.c:676 plugins/check_disk.c:724 plugins/check_disk.c:732
+#: plugins/check_disk.c:740 plugins/check_disk.c:744 plugins/check_disk.c:789
+#: plugins/check_disk.c:795 plugins/check_disk.c:818 plugins/check_dummy.c:77
+#: plugins/check_dummy.c:80 plugins/check_pgsql.c:617 plugins/check_procs.c:547
 #, c-format
 msgid "UNKNOWN"
 msgstr "INCONNU"
 
-#: plugins/check_disk.c:577
+#: plugins/check_disk.c:676
 msgid "Must set a threshold value before using -p\n"
 msgstr ""
 
-#: plugins/check_disk.c:618
+#: plugins/check_disk.c:724
 msgid "Must set -E before selecting paths\n"
 msgstr ""
 
-#: plugins/check_disk.c:626
+#: plugins/check_disk.c:732
 msgid "Must set group value before selecting paths\n"
 msgstr ""
 
-#: plugins/check_disk.c:633
+#: plugins/check_disk.c:740
 msgid ""
 "Paths need to be selected before using -i/-I. Use -A to select all paths "
 "explicitly"
 msgstr ""
 
-#: plugins/check_disk.c:637 plugins/check_disk.c:683 plugins/check_procs.c:506
+#: plugins/check_disk.c:744 plugins/check_disk.c:795 plugins/check_procs.c:547
 msgid "Could not compile regular expression"
 msgstr "Impossible de compiler l'expression rationnelle"
 
-#: plugins/check_disk.c:677
+#: plugins/check_disk.c:789
 msgid "Must set a threshold value before using -r/-R\n"
 msgstr ""
 
-#: plugins/check_disk.c:703
+#: plugins/check_disk.c:819
 msgid "Regular expression did not match any path or disk"
 msgstr ""
 
-#: plugins/check_disk.c:749
+#: plugins/check_disk.c:865
 msgid "Unknown argument"
 msgstr "Argument inconnu"
 
-#: plugins/check_disk.c:783
+#: plugins/check_disk.c:899
 #, c-format
 msgid " for %s\n"
 msgstr " pour %s\n"
 
-#: plugins/check_disk.c:857
+#: plugins/check_disk.c:928
 msgid ""
 "This plugin checks the amount of used disk space on a mounted file system"
 msgstr "Ce plugin vérifie la place utilisé sur un système de fichier monté"
 
-#: plugins/check_disk.c:858
+#: plugins/check_disk.c:929
 msgid ""
 "and generates an alert if free space is less than one of the threshold values"
 msgstr ""
 "et génère une alerte si la place disponible est plus petite qu'un des seuils "
 "fourni"
 
-#: plugins/check_disk.c:868
+#: plugins/check_disk.c:939
 msgid "Exit with WARNING status if less than INTEGER units of disk are free"
 msgstr ""
 "Sortir avec un résultat AVERTISSEMENT si moins de X unités de disques sont "
 "libres"
 
-#: plugins/check_disk.c:870
+#: plugins/check_disk.c:941
 msgid "Exit with WARNING status if less than PERCENT of disk space is free"
 msgstr ""
 "Sortir avec un résultat AVERTISSEMENT si moins de X pour-cent du disque est "
 "libre"
 
-#: plugins/check_disk.c:872
+#: plugins/check_disk.c:943
 msgid "Exit with CRITICAL status if less than INTEGER units of disk are free"
 msgstr ""
 "Sortir avec un résultat CRITIQUE si moins de X unités du disque sont libres"
 
-#: plugins/check_disk.c:874
+#: plugins/check_disk.c:945
 #, fuzzy
 msgid "Exit with CRITICAL status if less than PERCENT of disk space is free"
 msgstr ""
 "Sortir avec un résultat CRITIQUE si moins de X pour-cent du disque est libre"
 
-#: plugins/check_disk.c:876
+#: plugins/check_disk.c:947
 msgid "Exit with WARNING status if less than PERCENT of inode space is free"
 msgstr ""
 "Sortir avec un résultat AVERTISSEMENT si moins de X pour-cent des inodes "
 "sont libres"
 
-#: plugins/check_disk.c:878
+#: plugins/check_disk.c:949
 msgid "Exit with CRITICAL status if less than PERCENT of inode space is free"
 msgstr ""
 "Sortir avec un résultat CRITIQUE si moins de X pour-cent des inodes sont "
 "libres"
 
-#: plugins/check_disk.c:880
-msgid "Path or partition (may be repeated)"
-msgstr "Répertoire ou partition (peut être utilisé plusieurs fois)"
+#: plugins/check_disk.c:951
+msgid ""
+"Mount point or block device as emitted by the mount(8) command (may be "
+"repeated)"
+msgstr ""
 
-#: plugins/check_disk.c:882
+#: plugins/check_disk.c:953
 msgid "Ignore device (only works if -p unspecified)"
 msgstr "Ignorer le périphérique (marche seulement lorsque -p est utilisé)"
 
-#: plugins/check_disk.c:884
+#: plugins/check_disk.c:955
 msgid "Clear thresholds"
 msgstr "Effacer les seuils"
 
-#: plugins/check_disk.c:886
+#: plugins/check_disk.c:957
 msgid "For paths or partitions specified with -p, only check for exact paths"
 msgstr ""
 
-#: plugins/check_disk.c:888
+#: plugins/check_disk.c:959
 msgid "Display only devices/mountpoints with errors"
 msgstr "Afficher seulement les périphériques/point de montage avec des erreurs"
 
-#: plugins/check_disk.c:890
+#: plugins/check_disk.c:961
 msgid "Don't account root-reserved blocks into freespace in perfdata"
 msgstr ""
 
-#: plugins/check_disk.c:892
+#: plugins/check_disk.c:963
+msgid "Display inode usage in perfdata"
+msgstr ""
+
+#: plugins/check_disk.c:965
 msgid ""
 "Group paths. Thresholds apply to (free-)space of all partitions together"
 msgstr ""
 
-#: plugins/check_disk.c:894
+#: plugins/check_disk.c:967
 msgid "Same as '--units kB'"
 msgstr "Pareil à '--units kB'"
 
-#: plugins/check_disk.c:896
+#: plugins/check_disk.c:969
 msgid "Only check local filesystems"
 msgstr "Vérifier seulement les systèmes de fichiers locaux"
 
-#: plugins/check_disk.c:898
+#: plugins/check_disk.c:971
 msgid ""
 "Only check local filesystems against thresholds. Yet call stat on remote "
 "filesystems"
 msgstr ""
 
-#: plugins/check_disk.c:899
+#: plugins/check_disk.c:972
 msgid "to test if they are accessible (e.g. to detect Stale NFS Handles)"
 msgstr ""
 
-#: plugins/check_disk.c:901
-msgid "Display the mountpoint instead of the partition"
+#: plugins/check_disk.c:974
+#, fuzzy
+msgid "Display the (block) device instead of the mount point"
 msgstr "Afficher le point de montage au lieu de la partition"
 
-#: plugins/check_disk.c:903
+#: plugins/check_disk.c:976
 msgid "Same as '--units MB'"
 msgstr "Pareil à '--units MB'"
 
-#: plugins/check_disk.c:905
+#: plugins/check_disk.c:978
 msgid "Explicitly select all paths. This is equivalent to -R '.*'"
 msgstr ""
 
-#: plugins/check_disk.c:907
+#: plugins/check_disk.c:980
 msgid ""
 "Case insensitive regular expression for path/partition (may be repeated)"
 msgstr ""
 "Expression rationnelle indépendante de la case pour un répertoire ou une "
 "partition (peut être utilisé plusieurs fois)"
 
-#: plugins/check_disk.c:909
+#: plugins/check_disk.c:982
 msgid "Regular expression for path or partition (may be repeated)"
 msgstr ""
 "Expression rationnelle pour un répertoire ou une partition (peut être "
 "utilisé plusieurs fois)"
 
-#: plugins/check_disk.c:911
+#: plugins/check_disk.c:984
 msgid ""
 "Regular expression to ignore selected path/partition (case insensitive) (may "
 "be repeated)"
@@ -594,200 +611,225 @@ msgstr ""
 "Expression rationnelle pour ignorer un répertoire ou une partition (peut "
 "être utilisé plusieurs fois)"
 
-#: plugins/check_disk.c:913
+#: plugins/check_disk.c:986
 msgid ""
 "Regular expression to ignore selected path or partition (may be repeated)"
 msgstr ""
 "Expression rationnelle pour ignorer un répertoire ou une partition (peut "
 "être utilisé plusieurs fois)"
 
-#: plugins/check_disk.c:916
+#: plugins/check_disk.c:988
+msgid ""
+"Return OK if no filesystem matches, filesystem does not exist or is "
+"inaccessible."
+msgstr ""
+
+#: plugins/check_disk.c:989
+msgid "(Provide this option before -p / -r / --ereg-path if used)"
+msgstr ""
+
+#: plugins/check_disk.c:992
 msgid "Choose bytes, kB, MB, GB, TB (default: MB)"
 msgstr "Choisissez octets, kb, MB, GB, TB (par défaut: MB)"
 
-#: plugins/check_disk.c:919
+#: plugins/check_disk.c:995
 msgid "Ignore all filesystems of indicated type (may be repeated)"
 msgstr ""
 "Ignorer tout les systèmes de fichiers qui correspondent au type indiqué "
 "(peut être utilisé plusieurs fois)"
 
-#: plugins/check_disk.c:921
+#: plugins/check_disk.c:997
 #, fuzzy
 msgid "Check only filesystems of indicated type (may be repeated)"
 msgstr ""
 "Ignorer tout les systèmes de fichiers qui correspondent au type indiqué "
 "(peut être utilisé plusieurs fois)"
 
-#: plugins/check_disk.c:926
+#: plugins/check_disk.c:1002
 msgid "Checks /tmp and /var at 10% and 5%, and / at 100MB and 50MB"
 msgstr "Vérifie /tmp à 10% et /var à 5% et / à 100MB et 50MB"
 
-#: plugins/check_disk.c:928
+#: plugins/check_disk.c:1004
 msgid ""
 "Checks all filesystems not matching -r at 100M and 50M. The fs matching the -"
 "r regex"
 msgstr ""
 
-#: plugins/check_disk.c:929
+#: plugins/check_disk.c:1005
 msgid ""
 "are grouped which means the freespace thresholds are applied to all disks "
 "together"
 msgstr ""
 
-#: plugins/check_disk.c:931
+#: plugins/check_disk.c:1007
 msgid ""
 "Checks /foo for 1000M/500M and /bar for 5/3%. All remaining volumes use "
 "100M/50M"
 msgstr ""
 
-#: plugins/check_disk.c:957
+#: plugins/check_disk.c:1036
 #, c-format
 msgid "%s %s: %s\n"
 msgstr ""
 
-#: plugins/check_disk.c:957
+#: plugins/check_disk.c:1036
 msgid "is not accessible"
 msgstr ""
 
-#: plugins/check_dns.c:116
+#: plugins/check_dns.c:120
 msgid "nslookup returned an error status"
 msgstr "nslookup à retourné un code d'erreur"
 
-#: plugins/check_dns.c:134
+#: plugins/check_dns.c:138
 msgid "Warning plugin error"
 msgstr "Alerte erreur de plugin"
 
-#: plugins/check_dns.c:154
+#: plugins/check_dns.c:156
+#, fuzzy, c-format
+msgid "DNS CRITICAL - '%s' returned empty server string\n"
+msgstr "DNS CRITIQUE - '%s' à retourné un nom d'hôte vide\n"
+
+#: plugins/check_dns.c:161
+#, fuzzy, c-format
+msgid "DNS CRITICAL - No response from DNS %s\n"
+msgstr "Pas de réponse du DNS %s\n"
+
+#: plugins/check_dns.c:180
 #, c-format
 msgid "DNS CRITICAL - '%s' returned empty host name string\n"
 msgstr "DNS CRITIQUE - '%s' à retourné un nom d'hôte vide\n"
 
-#: plugins/check_dns.c:160
+#: plugins/check_dns.c:186
 msgid "Non-authoritative answer:"
 msgstr "Réponse non autoritative:"
 
-#: plugins/check_dns.c:201
+#: plugins/check_dns.c:215
+#, fuzzy, c-format
+msgid "Domain '%s' was not found by the server\n"
+msgstr "Le domaine %s n'a pas été trouvé par le serveur\n"
+
+#: plugins/check_dns.c:234
 #, c-format
 msgid "DNS CRITICAL - '%s' msg parsing exited with no address\n"
 msgstr "DNS CRITIQUE - '%s' n'a pas retourné d'adresse\n"
 
-#: plugins/check_dns.c:216
+#: plugins/check_dns.c:265
 #, c-format
 msgid "expected '%s' but got '%s'"
 msgstr "j'attendais '%s' mais j'ai reçu '%s'"
 
-#: plugins/check_dns.c:223
+#: plugins/check_dns.c:272
+#, fuzzy, c-format
+msgid "Domain '%s' was found by the server: '%s'\n"
+msgstr "Le domaine %s n'a pas été trouvé par le serveur\n"
+
+#: plugins/check_dns.c:282
 #, c-format
 msgid "server %s is not authoritative for %s"
 msgstr "serveur %s n'est pas autoritaire pour %s"
 
-#: plugins/check_dns.c:237 plugins/check_dummy.c:68 plugins/check_nagios.c:182
-#: plugins/check_pgsql.c:638 plugins/check_procs.c:344
+#: plugins/check_dns.c:291 plugins/check_dummy.c:68 plugins/check_nagios.c:182
+#: plugins/check_pgsql.c:612 plugins/check_procs.c:367
 #, c-format
 msgid "OK"
 msgstr "OK"
 
-#: plugins/check_dns.c:239 plugins/check_dummy.c:71 plugins/check_mysql.c:296
-#: plugins/check_nagios.c:182 plugins/check_pgsql.c:607
-#: plugins/check_pgsql.c:612 plugins/check_pgsql.c:640
-#: plugins/check_procs.c:346
+#: plugins/check_dns.c:293 plugins/check_dummy.c:71 plugins/check_mysql.c:310
+#: plugins/check_nagios.c:182 plugins/check_pgsql.c:581
+#: plugins/check_pgsql.c:586 plugins/check_pgsql.c:614
+#: plugins/check_procs.c:369
 #, c-format
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
-#: plugins/check_dns.c:243
+#: plugins/check_dns.c:297
 #, c-format
 msgid "%.3f second response time"
 msgid_plural "%.3f seconds response time"
 msgstr[0] "%.3f secondes de temps de réponse "
 msgstr[1] "%.3f secondes de temps de réponse "
 
-#: plugins/check_dns.c:244
+#: plugins/check_dns.c:298
 #, c-format
 msgid ". %s returns %s"
 msgstr ". %s renvoie %s"
 
-#: plugins/check_dns.c:248
+#: plugins/check_dns.c:318
 #, c-format
 msgid "DNS WARNING - %s\n"
 msgstr "DNS AVERTISSEMENT - %s\n"
 
-#: plugins/check_dns.c:249 plugins/check_dns.c:252 plugins/check_dns.c:255
+#: plugins/check_dns.c:319 plugins/check_dns.c:322 plugins/check_dns.c:325
 msgid " Probably a non-existent host/domain"
 msgstr " Probablement un hôte/domaine inexistant"
 
-#: plugins/check_dns.c:251
+#: plugins/check_dns.c:321
 #, c-format
 msgid "DNS CRITICAL - %s\n"
 msgstr "DNS CRITIQUE - %s\n"
 
-#: plugins/check_dns.c:254
+#: plugins/check_dns.c:324
 #, c-format
 msgid "DNS UNKNOWN - %s\n"
 msgstr "DNS INCONNU - %s\n"
 
-#: plugins/check_dns.c:267
+#: plugins/check_dns.c:368
 msgid "Note: nslookup is deprecated and may be removed from future releases."
 msgstr ""
 "Note: nslookup est obsolète et pourra être retiré dans les prochaines "
 "versions."
 
-#: plugins/check_dns.c:268
+#: plugins/check_dns.c:369
 msgid "Consider using the `dig' or `host' programs instead.  Run nslookup with"
 msgstr ""
 "Veuillez utiliser le programme 'dig' ou 'host' à la place. Faire fonctionner "
 "nslookup avec"
 
-#: plugins/check_dns.c:269
+#: plugins/check_dns.c:370
 msgid "the `-sil[ent]' option to prevent this message from appearing."
 msgstr "L'option '-sil[ent]' empêche l'apparition de ce message."
 
-#: plugins/check_dns.c:274
+#: plugins/check_dns.c:375 plugins/check_dns.c:377
 #, c-format
 msgid "No response from DNS %s\n"
 msgstr "Pas de réponse du DNS %s\n"
 
-#: plugins/check_dns.c:278
+#: plugins/check_dns.c:381
 #, c-format
 msgid "DNS %s has no records\n"
 msgstr "Le DNS %s n'a pas d'enregistrements\n"
 
-#: plugins/check_dns.c:286
+#: plugins/check_dns.c:389
 #, c-format
 msgid "Connection to DNS %s was refused\n"
 msgstr "La connexion au DNS %s à été refusée\n"
 
-#: plugins/check_dns.c:290
+#: plugins/check_dns.c:393
 #, c-format
 msgid "Query was refused by DNS server at %s\n"
 msgstr "La requête à été refusée par le serveur DNS %s\n"
 
-#: plugins/check_dns.c:294
+#: plugins/check_dns.c:397
 #, c-format
 msgid "No information returned by DNS server at %s\n"
 msgstr "Pas d'information renvoyée par le serveur DNS %s\n"
 
-#: plugins/check_dns.c:300
-#, c-format
-msgid "Domain %s was not found by the server\n"
-msgstr "Le domaine %s n'a pas été trouvé par le serveur\n"
-
-#: plugins/check_dns.c:304
+#: plugins/check_dns.c:401
 msgid "Network is unreachable\n"
 msgstr "Le réseau est inaccessible\n"
 
-#: plugins/check_dns.c:308
+#: plugins/check_dns.c:405
 #, c-format
 msgid "DNS failure for %s\n"
 msgstr "DNS à échoué pour %s\n"
 
-#: plugins/check_dns.c:372 plugins/check_dns.c:380 plugins/check_dns.c:387
-#: plugins/check_dns.c:392 plugins/check_dns.c:414 plugins/check_dns.c:422
+#: plugins/check_dns.c:471 plugins/check_dns.c:479 plugins/check_dns.c:486
+#: plugins/check_dns.c:491 plugins/check_dns.c:533 plugins/check_dns.c:541
 #: plugins/check_game.c:211 plugins/check_game.c:219
 msgid "Input buffer overflow\n"
 msgstr "Le tampon d'entrée a débordé\n"
 
-#: plugins/check_dns.c:450
+#: plugins/check_dns.c:576
 msgid ""
 "This plugin uses the nslookup program to obtain the IP address for the given "
 "host/domain query."
@@ -795,11 +837,11 @@ msgstr ""
 "Ce plugin utilise le programme nslookup pour obtenir l'adresse IP de l'hôte/"
 "domaine à interroger."
 
-#: plugins/check_dns.c:451
+#: plugins/check_dns.c:577
 msgid "An optional DNS server to use may be specified."
 msgstr "Un serveur DNS à utiliser peut être indiqué."
 
-#: plugins/check_dns.c:452
+#: plugins/check_dns.c:578
 msgid ""
 "If no DNS server is specified, the default server(s) specified in /etc/"
 "resolv.conf will be used."
@@ -807,53 +849,65 @@ msgstr ""
 "Si aucun serveur DNS n'est spécifié, les serveurs spécifiés dans /etc/resolv."
 "conf seront utilisé."
 
-#: plugins/check_dns.c:462
+#: plugins/check_dns.c:588
 msgid "The name or address you want to query"
 msgstr "Le nom ou l'adresse que vous voulez interroger"
 
-#: plugins/check_dns.c:464
+#: plugins/check_dns.c:590
 msgid "Optional DNS server you want to use for the lookup"
 msgstr "Serveur DNS que vous voulez utiliser pour la recherche"
 
-#: plugins/check_dns.c:466
+#: plugins/check_dns.c:592
+#, fuzzy
 msgid ""
-"Optional IP-ADDRESS you expect the DNS server to return. HOST must end with"
+"Optional IP-ADDRESS/CIDR you expect the DNS server to return. HOST must end"
 msgstr ""
 "Adresse IP que le serveur DNS doit retourner. Les hôtes doivent se terminer "
 
-#: plugins/check_dns.c:467
+#: plugins/check_dns.c:593
+#, fuzzy
 msgid ""
-"a dot (.). This option can be repeated multiple times (Returns OK if any"
+"with a dot (.). This option can be repeated multiple times (Returns OK if any"
 msgstr "avec un point (.). Cette option peut être répétée (Retourne OK si une"
 
-#: plugins/check_dns.c:468
-msgid ""
-"value match). If multiple addresses are returned at once, you have to match"
+#: plugins/check_dns.c:594
+msgid "value matches)."
 msgstr ""
-"valeur correspond). Si plusieurs adresses sont retournées en même temps,"
 
-#: plugins/check_dns.c:469
+#: plugins/check_dns.c:596
 msgid ""
-"the whole string of addresses separated with commas (sorted alphabetically)."
+"Expect the DNS server to return NXDOMAIN (i.e. the domain was not found)"
 msgstr ""
-"vous devrez toutes les inscrire séparées pas des virgules (en ordre "
-"alphabétique)"
 
-#: plugins/check_dns.c:471
+#: plugins/check_dns.c:597
+msgid "Cannot be used together with -a"
+msgstr ""
+
+#: plugins/check_dns.c:599
 msgid "Optionally expect the DNS server to be authoritative for the lookup"
 msgstr "Serveur DNS qui doit normalement être autoritaire pour la recherche"
 
-#: plugins/check_dns.c:473
+#: plugins/check_dns.c:601
 msgid "Return warning if elapsed time exceeds value. Default off"
 msgstr ""
 "Renvoie une alerte si le temps écoulé dépasse la valeur indiquée. Désactivé "
 "par défaut"
 
-#: plugins/check_dns.c:475
+#: plugins/check_dns.c:603
 msgid "Return critical if elapsed time exceeds value. Default off"
 msgstr ""
 "Renvoie critique si le temps utilisé dépasse la valeur indiquée. Désactivé "
 "par défaut"
+
+#: plugins/check_dns.c:605
+msgid ""
+"Return critical if the list of expected addresses does not match all "
+"addresses"
+msgstr ""
+
+#: plugins/check_dns.c:606
+msgid "returned. Default off"
+msgstr ""
 
 #: plugins/check_dummy.c:62
 msgid "Arguments to check_dummy must be an integer"
@@ -874,126 +928,131 @@ msgstr ""
 msgid "of the <state> argument with optional text"
 msgstr "du paramètre <state> avec un texte optionnel"
 
-#: plugins/check_fping.c:125 plugins/check_hpjd.c:128 plugins/check_ping.c:438
-#: plugins/check_swap.c:175 plugins/check_users.c:94 plugins/urlize.c:110
+#: plugins/check_fping.c:127 plugins/check_hpjd.c:134 plugins/check_ping.c:444
+#: plugins/check_swap.c:193 plugins/check_users.c:130 plugins/urlize.c:109
 #, c-format
 msgid "Could not open pipe: %s\n"
 msgstr "Impossible d'ouvrir le pipe: %s\n"
 
-#: plugins/check_fping.c:131 plugins/check_hpjd.c:134 plugins/check_load.c:153
-#: plugins/check_swap.c:181 plugins/check_users.c:100 plugins/urlize.c:116
+#: plugins/check_fping.c:133 plugins/check_hpjd.c:140 plugins/check_load.c:159
+#: plugins/check_swap.c:199 plugins/check_users.c:136 plugins/urlize.c:115
 #, c-format
 msgid "Could not open stderr for %s\n"
 msgstr "Impossible d'ouvrir la sortie d'erreur standard pour %s\n"
 
-#: plugins/check_fping.c:157
+#: plugins/check_fping.c:161
 #, fuzzy
 msgid "FPING UNKNOWN - IP address not found\n"
 msgstr "PING INCONNU - Hôte non trouvé (%s)\n"
 
-#: plugins/check_fping.c:160
+#: plugins/check_fping.c:164
 msgid "FPING UNKNOWN - invalid commandline argument\n"
 msgstr ""
 
-#: plugins/check_fping.c:163
+#: plugins/check_fping.c:167
 #, fuzzy
 msgid "FPING UNKNOWN - failed system call\n"
 msgstr "PING INCONNU - Hôte non trouvé (%s)\n"
 
-#: plugins/check_fping.c:187
+#: plugins/check_fping.c:194
+#, fuzzy, c-format
+msgid "FPING %s - %s (rta=%f ms)|%s\n"
+msgstr "FPING %s - %s (perte=%.0f%% )|%s\n"
+
+#: plugins/check_fping.c:202
 #, c-format
 msgid "FPING UNKNOWN - %s not found\n"
 msgstr "PING INCONNU - Hôte non trouvé (%s)\n"
 
-#: plugins/check_fping.c:191
+#: plugins/check_fping.c:206
 #, c-format
 msgid "FPING CRITICAL - %s is unreachable\n"
 msgstr "PING CRITIQUE - Hôte inaccessible (%s)\n"
 
-#: plugins/check_fping.c:196
+#: plugins/check_fping.c:211
 #, fuzzy, c-format
 msgid "FPING UNKNOWN - %s parameter error\n"
 msgstr "PING INCONNU - Hôte non trouvé (%s)\n"
 
-#: plugins/check_fping.c:200 plugins/check_fping.c:240
+#: plugins/check_fping.c:215 plugins/check_fping.c:255
 #, c-format
 msgid "FPING CRITICAL - %s is down\n"
 msgstr "FPING CRITIQUE - %s est en panne\n"
 
-#: plugins/check_fping.c:227
+#: plugins/check_fping.c:242
 #, c-format
 msgid "FPING %s - %s (loss=%.0f%%, rta=%f ms)|%s %s\n"
 msgstr "FPING %s - %s (perte=%.0f%%, rta=%f ms)|%s %s\n"
 
-#: plugins/check_fping.c:253
+#: plugins/check_fping.c:268
 #, c-format
 msgid "FPING %s - %s (loss=%.0f%% )|%s\n"
 msgstr "FPING %s - %s (perte=%.0f%% )|%s\n"
 
-#: plugins/check_fping.c:326 plugins/check_fping.c:332
-#: plugins/check_hpjd.c:338 plugins/check_hpjd.c:361 plugins/check_mysql.c:371
-#: plugins/check_mysql.c:455 plugins/check_ntp.c:709
-#: plugins/check_ntp_peer.c:497 plugins/check_ntp_time.c:496
-#: plugins/check_pgsql.c:335 plugins/check_ping.c:295 plugins/check_ping.c:418
-#: plugins/check_radius.c:264 plugins/check_real.c:314
-#: plugins/check_real.c:376 plugins/check_smtp.c:499 plugins/check_smtp.c:641
-#: plugins/check_ssh.c:157 plugins/check_time.c:240 plugins/check_time.c:315
-#: plugins/check_ups.c:504 plugins/check_ups.c:573
+#: plugins/check_fping.c:345 plugins/check_fping.c:351 plugins/check_hpjd.c:345
+#: plugins/check_hpjd.c:376 plugins/check_mysql.c:389 plugins/check_mysql.c:476
+#: plugins/check_ntp.c:719 plugins/check_ntp_peer.c:497
+#: plugins/check_ntp_time.c:498 plugins/check_pgsql.c:338
+#: plugins/check_ping.c:301 plugins/check_ping.c:424 plugins/check_radius.c:279
+#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:519
+#: plugins/check_smtp.c:667 plugins/check_ssh.c:162 plugins/check_time.c:240
+#: plugins/check_time.c:315 plugins/check_ups.c:507 plugins/check_ups.c:576
 msgid "Invalid hostname/address"
 msgstr "Adresse/Nom d'hôte invalide"
 
-#: plugins/check_fping.c:345 plugins/check_ldap.c:353 plugins/check_ping.c:246
+#: plugins/check_fping.c:364 plugins/check_ldap.c:400 plugins/check_ping.c:252
+#: plugins-root/check_icmp.c:474
 msgid "IPv6 support not available\n"
 msgstr "Support IPv6 non disponible\n"
 
-#: plugins/check_fping.c:378
+#: plugins/check_fping.c:397
 msgid "Packet size must be a positive integer"
 msgstr "La taille du paquet doit être un entier positif"
 
-#: plugins/check_fping.c:384
+#: plugins/check_fping.c:403
 msgid "Packet count must be a positive integer"
 msgstr "Le nombre de paquets doit être un entier positif"
 
-#: plugins/check_fping.c:390
+#: plugins/check_fping.c:409
 msgid "Target timeout must be a positive integer"
 msgstr "Le seuil d'avertissement doit être un entier positif"
 
-#: plugins/check_fping.c:396
+#: plugins/check_fping.c:415
 msgid "Interval must be a positive integer"
 msgstr "Le délai d'attente doit être un entier positif"
 
-#: plugins/check_fping.c:402 plugins/check_ntp.c:733
-#: plugins/check_ntp_peer.c:524 plugins/check_ntp_time.c:523
-#: plugins/check_radius.c:314 plugins/check_time.c:319
+#: plugins/check_fping.c:421 plugins/check_ntp.c:743
+#: plugins/check_ntp_peer.c:524 plugins/check_ntp_time.c:528
+#: plugins/check_radius.c:329 plugins/check_time.c:319
 msgid "Hostname was not supplied"
 msgstr "Le nom de l'hôte n'a pas été spécifié"
 
-#: plugins/check_fping.c:422
+#: plugins/check_fping.c:441
 #, c-format
 msgid "%s: Only one threshold may be packet loss (%s)\n"
 msgstr ""
 "%s: Seulement un seuil peut être utilisé pour les pertes de paquets (%s)\n"
 
-#: plugins/check_fping.c:426
+#: plugins/check_fping.c:445
 #, c-format
 msgid "%s: Only one threshold must be packet loss (%s)\n"
 msgstr ""
 "%s: Seulement un seuil doit être utilisé pour les pertes de paquets (%s)\n"
 
-#: plugins/check_fping.c:458
+#: plugins/check_fping.c:475
 msgid ""
 "This plugin will use the fping command to ping the specified host for a fast "
 "check"
 msgstr ""
 "Ce plugin va utiliser la commande fping pour pinger l'hôte de manière rapide."
 
-#: plugins/check_fping.c:460
+#: plugins/check_fping.c:477
 msgid "Note that it is necessary to set the suid flag on fping."
 msgstr ""
 "Veuillez noter qu'il est nécessaire de mettre le bit suid sur le programme "
 "fping."
 
-#: plugins/check_fping.c:472
+#: plugins/check_fping.c:489
 msgid ""
 "name or IP Address of host to ping (IP Address bypasses name lookup, "
 "reducing system load)"
@@ -1001,39 +1060,43 @@ msgstr ""
 "nom ou adresse IP des hôtes à pinger (l'indication d'un adresse IP évite une "
 "recherche sur le nom, ce qui réduit la charge système)"
 
-#: plugins/check_fping.c:474 plugins/check_ping.c:575
+#: plugins/check_fping.c:491 plugins/check_ping.c:589
 msgid "warning threshold pair"
 msgstr "Valeurs pour le seuil d'avertissement"
 
-#: plugins/check_fping.c:476 plugins/check_ping.c:577
+#: plugins/check_fping.c:493 plugins/check_ping.c:591
 msgid "critical threshold pair"
 msgstr "Valeurs pour le seuil critique"
 
-#: plugins/check_fping.c:478
+#: plugins/check_fping.c:495
+msgid "Return OK after first successful reply"
+msgstr ""
+
+#: plugins/check_fping.c:497
 msgid "size of ICMP packet"
 msgstr "taille du paquet ICMP"
 
-#: plugins/check_fping.c:480
+#: plugins/check_fping.c:499
 msgid "number of ICMP packets to send"
 msgstr "nombre de paquets ICMP à envoyer"
 
-#: plugins/check_fping.c:482
+#: plugins/check_fping.c:501
 msgid "Target timeout (ms)"
 msgstr ""
 
-#: plugins/check_fping.c:484
+#: plugins/check_fping.c:503
 msgid "Interval (ms) between sending packets"
 msgstr ""
 
-#: plugins/check_fping.c:486
+#: plugins/check_fping.c:505
 msgid "name or IP Address of sourceip"
 msgstr ""
 
-#: plugins/check_fping.c:488
+#: plugins/check_fping.c:507
 msgid "source interface name"
 msgstr ""
 
-#: plugins/check_fping.c:491
+#: plugins/check_fping.c:510
 #, c-format
 msgid ""
 "THRESHOLD is <rta>,<pl>%% where <rta> is the round trip average travel time "
@@ -1042,18 +1105,18 @@ msgstr ""
 "Le seuil est <rta>,<pl>%% ou <rta> est le temps moyen pour l'aller retour "
 "(ms)"
 
-#: plugins/check_fping.c:492
+#: plugins/check_fping.c:511
 msgid ""
 "which triggers a WARNING or CRITICAL state, and <pl> is the percentage of"
 msgstr ""
 "qui déclenche résultat AVERTISSEMENT ou CRITIQUE, et <pl> est le pourcentage "
 "de"
 
-#: plugins/check_fping.c:493
+#: plugins/check_fping.c:512
 msgid "packet loss to trigger an alarm state."
 msgstr "paquets perdu pour déclencher une alarme."
 
-#: plugins/check_fping.c:496
+#: plugins/check_fping.c:515
 msgid "IPv4 is used by default. Specify -6 to use IPv6."
 msgstr ""
 
@@ -1113,782 +1176,893 @@ msgstr ""
 "Si vous n'avez pas le programme installé, vous devrez le télécharger depuis"
 
 #: plugins/check_game.c:321
-msgid ""
-"http://www.activesw.com/people/steve/qstat.html before you can use this "
-"plugin."
+#, fuzzy
+msgid "https://github.com/multiplay/qstat before you can use this plugin."
 msgstr ""
 "http://www.activesw.com/people/steve/qstat.html avant de pouvoir utiliser ce "
 "plugin."
 
-#: plugins/check_hpjd.c:239
+#: plugins/check_hpjd.c:245
 msgid "Paper Jam"
 msgstr "Bourrage Papier"
 
-#: plugins/check_hpjd.c:243
+#: plugins/check_hpjd.c:250
 msgid "Out of Paper"
 msgstr "Plus de Papier"
 
-#: plugins/check_hpjd.c:248
+#: plugins/check_hpjd.c:255
 msgid "Printer Offline"
 msgstr "Imprimante hors ligne"
 
-#: plugins/check_hpjd.c:253
+#: plugins/check_hpjd.c:260
 msgid "Peripheral Error"
 msgstr "Erreur du périphérique"
 
-#: plugins/check_hpjd.c:257
+#: plugins/check_hpjd.c:264
 msgid "Intervention Required"
 msgstr "Intervention Requise"
 
-#: plugins/check_hpjd.c:261
+#: plugins/check_hpjd.c:268
 msgid "Toner Low"
 msgstr "Toner Faible"
 
-#: plugins/check_hpjd.c:265
+#: plugins/check_hpjd.c:272
 msgid "Insufficient Memory"
 msgstr "Mémoire Insuffisante"
 
-#: plugins/check_hpjd.c:269
+#: plugins/check_hpjd.c:276
 msgid "A Door is Open"
 msgstr "Une porte est ouverte"
 
-#: plugins/check_hpjd.c:273
+#: plugins/check_hpjd.c:280
 msgid "Output Tray is Full"
 msgstr "Le bac de sortie est plein"
 
-#: plugins/check_hpjd.c:277
+#: plugins/check_hpjd.c:284
 msgid "Data too Slow for Engine"
 msgstr "Le données arrivent trop lentement pour l'imprimante"
 
-#: plugins/check_hpjd.c:281
+#: plugins/check_hpjd.c:288
 msgid "Unknown Paper Error"
 msgstr "Erreur de papier inconnue"
 
-#: plugins/check_hpjd.c:286
+#: plugins/check_hpjd.c:293
 #, c-format
 msgid "Printer ok - (%s)\n"
 msgstr "Imprimante ok - (%s)\n"
 
-#: plugins/check_hpjd.c:391
+#: plugins/check_hpjd.c:353
+#, fuzzy
+msgid "Port must be a positive short integer"
+msgstr "Le numéro du port doit être un entier positif"
+
+#: plugins/check_hpjd.c:410
 msgid "This plugin tests the STATUS of an HP printer with a JetDirect card."
 msgstr "Ce plugin teste l'état d'une imprimante HP avec une carte JetDirect."
 
-#: plugins/check_hpjd.c:392
+#: plugins/check_hpjd.c:411
 msgid "Net-snmp must be installed on the computer running the plugin."
 msgstr "Net-snmp doit être installé sur l'ordinateur qui exécute le plugin."
 
-#: plugins/check_hpjd.c:402
+#: plugins/check_hpjd.c:421
 msgid "The SNMP community name "
 msgstr "Le nom de la communauté SNMP "
 
-#: plugins/check_hpjd.c:403
+#: plugins/check_hpjd.c:422 plugins/check_hpjd.c:426
 #, c-format
 msgid "(default=%s)"
 msgstr "(défaut=%s)"
 
-#: plugins/check_http.c:189
+#: plugins/check_hpjd.c:425
+#, fuzzy
+msgid "Specify the port to check "
+msgstr "Nom de l'hôte à vérifier"
+
+#: plugins/check_hpjd.c:429
+#, fuzzy
+msgid "Disable paper check "
+msgstr "Variable a vérifier"
+
+#: plugins/check_http.c:196
 msgid "file does not exist or is not readable"
 msgstr ""
 
-#: plugins/check_http.c:310 plugins/check_http.c:315 plugins/check_http.c:321
-#: plugins/check_smtp.c:600 plugins/check_tcp.c:576 plugins/check_tcp.c:580
-#: plugins/check_tcp.c:586
+#: plugins/check_http.c:324 plugins/check_http.c:329 plugins/check_http.c:335
+#: plugins/check_smtp.c:615 plugins/check_tcp.c:590 plugins/check_tcp.c:595
+#: plugins/check_tcp.c:601
 msgid "Invalid certificate expiration period"
 msgstr "Période d'expiration du certificat invalide"
 
-#: plugins/check_http.c:348
+#: plugins/check_http.c:378
 msgid ""
-"Invalid option - Valid values for SSL Version are 1 (TLSv1), 2 (SSLv2) or 3 "
-"(SSLv3)"
+"Invalid option - Valid SSL/TLS versions: 2, 3, 1, 1.1, 1.2 (with optional "
+"'+' suffix)"
 msgstr ""
 
-#: plugins/check_http.c:354 plugins/check_tcp.c:599
+#: plugins/check_http.c:384 plugins/check_tcp.c:614 plugins/check_tcp.c:623
 msgid "Invalid option - SSL is not available"
 msgstr "Option invalide - SSL n'est pas disponible"
 
-#: plugins/check_http.c:375
+#: plugins/check_http.c:392
+msgid "Invalid max_redirs count"
+msgstr ""
+
+#: plugins/check_http.c:412
 msgid "Invalid onredirect option"
 msgstr ""
 
-#: plugins/check_http.c:377
+#: plugins/check_http.c:414
 #, c-format
 msgid "option f:%d \n"
 msgstr "option f:%d \n"
 
-#: plugins/check_http.c:398
+#: plugins/check_http.c:449
 msgid "Invalid port number"
 msgstr "Numéro de port invalide"
 
-#: plugins/check_http.c:450
+#: plugins/check_http.c:507
 #, c-format
 msgid "Could Not Compile Regular Expression: %s"
 msgstr "Impossible de compiler l'expression rationnelle: %s"
 
-#: plugins/check_http.c:464 plugins/check_ntp.c:722
-#: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:512
-#: plugins/check_smtp.c:621 plugins/check_ssh.c:149 plugins/check_tcp.c:477
+#: plugins/check_http.c:521 plugins/check_ntp.c:732
+#: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:517
+#: plugins/check_smtp.c:647 plugins/check_ssh.c:151 plugins/check_tcp.c:491
 msgid "IPv6 support not available"
 msgstr "Support IPv6 non disponible"
 
-#: plugins/check_http.c:529 plugins/check_ping.c:422
+#: plugins/check_http.c:589 plugins/check_ping.c:428
 msgid "You must specify a server address or host name"
 msgstr "Vous devez spécifier une adresse ou un nom d'hôte"
 
-#: plugins/check_http.c:543
+#: plugins/check_http.c:606
 msgid ""
 "If you use a client certificate you must also specify a private key file"
 msgstr ""
 
-#: plugins/check_http.c:667 plugins/check_http.c:835
+#: plugins/check_http.c:733 plugins/check_http.c:901
 msgid "HTTP UNKNOWN - Memory allocation error\n"
 msgstr "HTTP INCONNU - Impossible d'allouer la mémoire\n"
 
-#: plugins/check_http.c:739
+#: plugins/check_http.c:805
 #, c-format
 msgid "%sServer date unknown, "
 msgstr "%sDate du serveur inconnue, "
 
-#: plugins/check_http.c:742
+#: plugins/check_http.c:808
 #, c-format
 msgid "%sDocument modification date unknown, "
 msgstr "%sDate de modification du document inconnue, "
 
-#: plugins/check_http.c:749
+#: plugins/check_http.c:815
 #, c-format
 msgid "%sServer date \"%100s\" unparsable, "
 msgstr "%sDate du serveur \"%100s\" illisible, "
 
-#: plugins/check_http.c:752
+#: plugins/check_http.c:818
 #, c-format
 msgid "%sDocument date \"%100s\" unparsable, "
 msgstr "%sDate du document \"%100s\" illisible, "
 
-#: plugins/check_http.c:755
+#: plugins/check_http.c:821
 #, c-format
 msgid "%sDocument is %d seconds in the future, "
 msgstr "%sLa date du document est %d secondes dans le futur, "
 
-#: plugins/check_http.c:760
+#: plugins/check_http.c:826
 #, c-format
 msgid "%sLast modified %.1f days ago, "
 msgstr "%sDernière modification %.1f jours auparavant, "
 
-#: plugins/check_http.c:763
+#: plugins/check_http.c:829
 #, c-format
 msgid "%sLast modified %d:%02d:%02d ago, "
 msgstr "%sDernière modification %d:%02d:%02d auparavant, "
 
-#: plugins/check_http.c:876
+#: plugins/check_http.c:943
 msgid "HTTP CRITICAL - Unable to open TCP socket\n"
 msgstr "HTTP CRITIQUE - Impossible d'ouvrir un socket TCP\n"
 
-#: plugins/check_http.c:995
+#: plugins/check_http.c:1103
+#, fuzzy
+msgid "HTTP UNKNOWN - Could not allocate memory for full_page\n"
+msgstr "HTTP INCONNU - Impossible d'allouer une adresse\n"
+
+#: plugins/check_http.c:1120
 msgid "HTTP CRITICAL - Error on receive\n"
 msgstr "HTTP CRITIQUE - Erreur dans la réception\n"
 
-#: plugins/check_http.c:1005
+#: plugins/check_http.c:1125
 msgid "HTTP CRITICAL - No data received from host\n"
 msgstr "HTTP CRITIQUE - Pas de données reçues de l'hôte\n"
 
-#: plugins/check_http.c:1056
+#: plugins/check_http.c:1176
 #, c-format
 msgid "Invalid HTTP response received from host: %s\n"
 msgstr "Réponse HTTP reçue de l'hôte invalide: %s\n"
 
-#: plugins/check_http.c:1060
+#: plugins/check_http.c:1180
 #, c-format
 msgid "Invalid HTTP response received from host on port %d: %s\n"
 msgstr "Réponse HTTP reçue de l'hôte sur le port %d invalide: %s\n"
 
-#: plugins/check_http.c:1069
+#: plugins/check_http.c:1183 plugins/check_http.c:1376
+#, c-format
+msgid ""
+"%s\n"
+"%s"
+msgstr ""
+
+#: plugins/check_http.c:1191
 #, c-format
 msgid "Status line output matched \"%s\" - "
 msgstr "La ligne d'état correspond à \"%s\" - "
 
-#: plugins/check_http.c:1080
+#: plugins/check_http.c:1202
 #, c-format
 msgid "HTTP CRITICAL: Invalid Status Line (%s)\n"
 msgstr "HTTP CRITIQUE: Ligne d'état non valide (%s)\n"
 
-#: plugins/check_http.c:1087
+#: plugins/check_http.c:1209
 #, c-format
 msgid "HTTP CRITICAL: Invalid Status (%s)\n"
 msgstr "HTTP CRITIQUE: Etat Invalide (%s)\n"
 
-#: plugins/check_http.c:1091 plugins/check_http.c:1096
-#: plugins/check_http.c:1106 plugins/check_http.c:1110
+#: plugins/check_http.c:1213 plugins/check_http.c:1218
+#: plugins/check_http.c:1228 plugins/check_http.c:1232
 #, c-format
 msgid "%s - "
 msgstr ""
 
-#: plugins/check_http.c:1129
+#: plugins/check_http.c:1260
 #, fuzzy, c-format
 msgid "%sheader '%s' not found on '%s://%s:%d%s', "
 msgstr "%schaîne non trouvée, "
 
-#: plugins/check_http.c:1141
+#: plugins/check_http.c:1303
 #, fuzzy, c-format
 msgid "%sstring '%s' not found on '%s://%s:%d%s', "
 msgstr "%schaîne non trouvée, "
 
-#: plugins/check_http.c:1154
+#: plugins/check_http.c:1317
 #, c-format
 msgid "%spattern not found, "
 msgstr "%sexpression non trouvée, "
 
-#: plugins/check_http.c:1156
+#: plugins/check_http.c:1319
 #, c-format
 msgid "%spattern found, "
 msgstr "%sexpression trouvée, "
 
-#: plugins/check_http.c:1162
+#: plugins/check_http.c:1325
 #, c-format
 msgid "%sExecute Error: %s, "
 msgstr "%sErreur d'exécution: %s, "
 
-#: plugins/check_http.c:1178
+#: plugins/check_http.c:1341
 #, c-format
 msgid "%spage size %d too large, "
 msgstr "%sla taille de la page est trop grande (%d), "
 
-#: plugins/check_http.c:1181
+#: plugins/check_http.c:1344
 #, c-format
 msgid "%spage size %d too small, "
 msgstr "%sla taille de la page est trop petite (%d), "
 
-#: plugins/check_http.c:1194
+#: plugins/check_http.c:1357
 #, fuzzy, c-format
 msgid "%s - %d bytes in %.3f second response time %s|%s %s %s %s %s %s %s"
 msgstr "%s - %d octets en %.3f secondes de temps de réponse %s|%s %s"
 
-#: plugins/check_http.c:1206
+#: plugins/check_http.c:1369
 #, c-format
 msgid "%s - %d bytes in %.3f second response time %s|%s %s"
 msgstr "%s - %d octets en %.3f secondes de temps de réponse %s|%s %s"
 
-#: plugins/check_http.c:1244
+#: plugins/check_http.c:1499
 msgid "HTTP UNKNOWN - Could not allocate addr\n"
 msgstr "HTTP INCONNU - Impossible d'allouer une adresse\n"
 
-#: plugins/check_http.c:1248 plugins/check_http.c:1279
+#: plugins/check_http.c:1504 plugins/check_http.c:1535
 msgid "HTTP UNKNOWN - Could not allocate URL\n"
 msgstr "HTTP INCONNU - Impossible d'allouer l'URL\n"
 
-#: plugins/check_http.c:1257
+#: plugins/check_http.c:1513
 #, c-format
 msgid "HTTP UNKNOWN - Could not find redirect location - %s%s\n"
 msgstr ""
 "HTTP INCONNU - Impossible de trouver l'endroit de la redirection - %s%s\n"
 
-#: plugins/check_http.c:1272
+#: plugins/check_http.c:1528
 #, c-format
 msgid "HTTP UNKNOWN - Empty redirect location%s\n"
 msgstr "HTTP INCONNU - endroit de redirection vide%s\n"
 
-#: plugins/check_http.c:1322
+#: plugins/check_http.c:1590
 #, c-format
 msgid "HTTP UNKNOWN - Could not parse redirect location - %s%s\n"
 msgstr ""
 "HTTP INCONNU - Impossible de définir l'endroit de la redirection - %s%s\n"
 
-#: plugins/check_http.c:1332
+#: plugins/check_http.c:1600
 #, c-format
 msgid "HTTP WARNING - maximum redirection depth %d exceeded - %s://%s:%d%s%s\n"
 msgstr ""
 "HTTP AVERTISSEMENT - le niveau maximum de redirection %d à été dépassé - "
 "%s://%s:%d%s%s\n"
 
-#: plugins/check_http.c:1340
-#, c-format
-msgid "HTTP WARNING - redirection creates an infinite loop - %s://%s:%d%s%s\n"
+#: plugins/check_http.c:1608
+#, fuzzy, c-format
+msgid "HTTP CRITICAL - redirection creates an infinite loop - %s://%s:%d%s%s\n"
 msgstr ""
-"HTTP AVERTISSEMENT - la redirection crée une boucle infinie - %s://%s:%d%s"
-"%s\n"
+"HTTP AVERTISSEMENT - la redirection crée une boucle infinie - %s://%s:"
+"%d%s%s\n"
 
-#: plugins/check_http.c:1361
+#: plugins/check_http.c:1629
 #, c-format
 msgid "HTTP UNKNOWN - Redirection to port above %d - %s://%s:%d%s%s\n"
 msgstr "HTTP INCONNU - Redirection à un port supérieur à %d - %s://%s:%d%s%s\n"
 
-#: plugins/check_http.c:1366
+#: plugins/check_http.c:1637
 #, c-format
 msgid "Redirection to %s://%s:%d%s\n"
 msgstr "Redirection vers %s://%s:%d%s\n"
 
-#: plugins/check_http.c:1440
+#: plugins/check_http.c:1712
 msgid "This plugin tests the HTTP service on the specified host. It can test"
 msgstr ""
 "Ce plugin teste le service HTTP sur l'hôte spécifié. Il peut tester les"
 
-#: plugins/check_http.c:1441
+#: plugins/check_http.c:1713
 msgid "normal (http) and secure (https) servers, follow redirects, search for"
 msgstr ""
 "serveurs normaux (http) et sécurisés (https), suivre les redirections, "
 "rechercher des"
 
-#: plugins/check_http.c:1442
+#: plugins/check_http.c:1714
 msgid "strings and regular expressions, check connection times, and report on"
 msgstr ""
 "chaînes de caractères et expressions rationnelles, vérifier le temps de "
 "réponse"
 
-#: plugins/check_http.c:1443
+#: plugins/check_http.c:1715
 msgid "certificate expiration times."
 msgstr "et rapporter la date d'expiration du certificat."
 
-#: plugins/check_http.c:1449
+#: plugins/check_http.c:1722
+#, c-format
+msgid "In the first form, make an HTTP request."
+msgstr ""
+
+#: plugins/check_http.c:1723
+#, c-format
+msgid ""
+"In the second form, connect to the server and check the TLS certificate."
+msgstr ""
+
+#: plugins/check_http.c:1725
 #, c-format
 msgid "NOTE: One or both of -H and -I must be specified"
 msgstr "NOTE: les paramètres -H et -I peuvent être spécifiés"
 
-#: plugins/check_http.c:1457
+#: plugins/check_http.c:1733
 msgid "Host name argument for servers using host headers (virtual host)"
 msgstr ""
 
-#: plugins/check_http.c:1458
+#: plugins/check_http.c:1734
 msgid "Append a port to include it in the header (eg: example.com:5000)"
 msgstr ""
 
-#: plugins/check_http.c:1460
+#: plugins/check_http.c:1736
 msgid ""
 "IP address or name (use numeric address if possible to bypass DNS lookup)."
 msgstr ""
 
-#: plugins/check_http.c:1462
+#: plugins/check_http.c:1738
 msgid "Port number (default: "
 msgstr "Numéro du port (défaut: "
 
-#: plugins/check_http.c:1469
+#: plugins/check_http.c:1745
 msgid ""
 "Connect via SSL. Port defaults to 443. VERSION is optional, and prevents"
 msgstr ""
 
-#: plugins/check_http.c:1470
-msgid "auto-negotiation (1 = TLSv1, 2 = SSLv2, 3 = SSLv3)."
+#: plugins/check_http.c:1746
+msgid "auto-negotiation (2 = SSLv2, 3 = SSLv3, 1 = TLSv1, 1.1 = TLSv1.1,"
 msgstr ""
 
-#: plugins/check_http.c:1472
+#: plugins/check_http.c:1747
+msgid "1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."
+msgstr ""
+
+#: plugins/check_http.c:1749
 msgid "Enable SSL/TLS hostname extension support (SNI)"
 msgstr ""
 
-#: plugins/check_http.c:1474
+#: plugins/check_http.c:1751
 msgid ""
 "Minimum number of days a certificate has to be valid. Port defaults to 443"
 msgstr ""
 "Nombre de jours minimum pour que le certificat soit valide. Port par défaut "
 "443"
 
-#: plugins/check_http.c:1475
-msgid "(when this option is used the URL is not checked.)"
+#: plugins/check_http.c:1752
+msgid ""
+"(when this option is used the URL is not checked by default. You can use"
 msgstr ""
 
-#: plugins/check_http.c:1477
+#: plugins/check_http.c:1753
+msgid " --continue-after-certificate to override this behavior)"
+msgstr ""
+
+#: plugins/check_http.c:1755
+msgid ""
+"Allows the HTTP check to continue after performing the certificate check."
+msgstr ""
+
+#: plugins/check_http.c:1756
+msgid "Does nothing unless -C is used."
+msgstr ""
+
+#: plugins/check_http.c:1758
 msgid "Name of file that contains the client certificate (PEM format)"
 msgstr ""
 
-#: plugins/check_http.c:1478
+#: plugins/check_http.c:1759
 msgid "to be used in establishing the SSL session"
 msgstr ""
 
-#: plugins/check_http.c:1480
+#: plugins/check_http.c:1761
 msgid "Name of file containing the private key (PEM format)"
 msgstr ""
 
-#: plugins/check_http.c:1481
+#: plugins/check_http.c:1762
 msgid "matching the client certificate"
 msgstr ""
 
-#: plugins/check_http.c:1485
+#: plugins/check_http.c:1766
 msgid "Comma-delimited list of strings, at least one of them is expected in"
 msgstr ""
 "Liste the chaines de charactères séparées par des virgules, au moins une "
 "d'elles"
 
-#: plugins/check_http.c:1486
+#: plugins/check_http.c:1767
 msgid "the first (status) line of the server response (default: "
 msgstr "est attendue dans la première ligne de réponse du serveur (défaut: "
 
-#: plugins/check_http.c:1488
+#: plugins/check_http.c:1769
 msgid ""
 "If specified skips all other status line logic (ex: 3xx, 4xx, 5xx processing)"
 msgstr ""
 "Si spécifié, surpasse toute autre logique de status (ex: 3xx, 4xx, 5xx)"
 
-#: plugins/check_http.c:1490
+#: plugins/check_http.c:1771
 #, fuzzy
 msgid "String to expect in the response headers"
 msgstr "Chaîne de caractères à attendre en réponse"
 
-#: plugins/check_http.c:1492
+#: plugins/check_http.c:1773
 msgid "String to expect in the content"
 msgstr "Chaîne de caractère attendue dans le contenu"
 
-#: plugins/check_http.c:1494
+#: plugins/check_http.c:1775
 msgid "URL to GET or POST (default: /)"
 msgstr "URL pour le GET ou le POST (défaut: /)"
 
-#: plugins/check_http.c:1496
+#: plugins/check_http.c:1777
 msgid "URL encoded http POST data"
 msgstr ""
 
-#: plugins/check_http.c:1498
+#: plugins/check_http.c:1779
 msgid "Set HTTP method."
 msgstr ""
 
-#: plugins/check_http.c:1500
+#: plugins/check_http.c:1781
 msgid "Don't wait for document body: stop reading after headers."
 msgstr ""
 "Ne pas attendre pour le corps du document: arrêter de lire après les entêtes"
 
-#: plugins/check_http.c:1501
+#: plugins/check_http.c:1782
 msgid "(Note that this still does an HTTP GET or POST, not a HEAD.)"
 msgstr "(Veuillez noter qu'un HTTP GET ou POST est effectué, pas un HEAD.)"
 
-#: plugins/check_http.c:1503
+#: plugins/check_http.c:1784
 msgid "Warn if document is more than SECONDS old. the number can also be of"
 msgstr ""
 
-#: plugins/check_http.c:1504
+#: plugins/check_http.c:1785
 msgid "the form \"10m\" for minutes, \"10h\" for hours, or \"10d\" for days."
 msgstr ""
 
-#: plugins/check_http.c:1506
+#: plugins/check_http.c:1787
 msgid "specify Content-Type header media type when POSTing\n"
 msgstr ""
 
-#: plugins/check_http.c:1509
+#: plugins/check_http.c:1790
 msgid "Allow regex to span newlines (must precede -r or -R)"
 msgstr ""
 
-#: plugins/check_http.c:1511
+#: plugins/check_http.c:1792
 msgid "Search page for regex STRING"
 msgstr ""
 
-#: plugins/check_http.c:1513
+#: plugins/check_http.c:1794
 msgid "Search page for case-insensitive regex STRING"
 msgstr ""
 
-#: plugins/check_http.c:1515
+#: plugins/check_http.c:1796
 msgid "Return CRITICAL if found, OK if not\n"
 msgstr ""
 
-#: plugins/check_http.c:1518
+#: plugins/check_http.c:1799
 msgid "Username:password on sites with basic authentication"
 msgstr ""
 
-#: plugins/check_http.c:1520
+#: plugins/check_http.c:1801
 msgid "Username:password on proxy-servers with basic authentication"
 msgstr ""
 
-#: plugins/check_http.c:1522
+#: plugins/check_http.c:1803
 msgid "String to be sent in http header as \"User Agent\""
 msgstr ""
 
-#: plugins/check_http.c:1524
+#: plugins/check_http.c:1805
 msgid ""
 "Any other tags to be sent in http header. Use multiple times for additional "
 "headers"
 msgstr ""
 
-#: plugins/check_http.c:1526
+#: plugins/check_http.c:1807
 msgid "Print additional performance data"
 msgstr ""
 
-#: plugins/check_http.c:1528
+#: plugins/check_http.c:1809
+msgid "Print body content below status line"
+msgstr ""
+
+#: plugins/check_http.c:1811
 msgid "Wrap output in HTML link (obsoleted by urlize)"
 msgstr ""
 
-#: plugins/check_http.c:1530
+#: plugins/check_http.c:1813
 msgid "How to handle redirected pages. sticky is like follow but stick to the"
 msgstr ""
 
-#: plugins/check_http.c:1531
+#: plugins/check_http.c:1814
 msgid "specified IP address. stickyport also ensures port stays the same."
 msgstr ""
 
-#: plugins/check_http.c:1533
+#: plugins/check_http.c:1816
+#, fuzzy
+msgid "Maximal number of redirects (default: "
+msgstr "PROCS   - nombre de  processus (défaut)"
+
+#: plugins/check_http.c:1819
 msgid "Minimum page size required (bytes) : Maximum page size required (bytes)"
 msgstr ""
 
-#: plugins/check_http.c:1543
+#: plugins/check_http.c:1828
 msgid "This plugin will attempt to open an HTTP connection with the host."
 msgstr "Ce plugin va essayer d'ouvrir un connexion SMTP avec l'hôte."
 
-#: plugins/check_http.c:1544
+#: plugins/check_http.c:1829
 msgid ""
 "Successful connects return STATE_OK, refusals and timeouts return "
 "STATE_CRITICAL"
 msgstr ""
 
-#: plugins/check_http.c:1545
+#: plugins/check_http.c:1830
 msgid ""
 "other errors return STATE_UNKNOWN.  Successful connects, but incorrect "
 "response"
 msgstr ""
 
-#: plugins/check_http.c:1546
+#: plugins/check_http.c:1831
 msgid ""
 "messages from the host result in STATE_WARNING return values.  If you are"
 msgstr ""
 
-#: plugins/check_http.c:1547
+#: plugins/check_http.c:1832
 msgid ""
 "checking a virtual server that uses 'host headers' you must supply the FQDN"
 msgstr ""
 
-#: plugins/check_http.c:1548
+#: plugins/check_http.c:1833
 msgid "(fully qualified domain name) as the [host_name] argument."
 msgstr ""
 
-#: plugins/check_http.c:1552
+#: plugins/check_http.c:1837
 msgid "This plugin can also check whether an SSL enabled web server is able to"
 msgstr ""
 
-#: plugins/check_http.c:1553
+#: plugins/check_http.c:1838
 msgid "serve content (optionally within a specified time) or whether the X509 "
 msgstr ""
 
-#: plugins/check_http.c:1554
+#: plugins/check_http.c:1839
 msgid "certificate is still valid for the specified number of days."
 msgstr ""
 
-#: plugins/check_http.c:1556
+#: plugins/check_http.c:1841
 #, fuzzy
 msgid "Please note that this plugin does not check if the presented server"
 msgstr "Ce plugin vérifie le service ntp sur l'hôte"
 
-#: plugins/check_http.c:1557
+#: plugins/check_http.c:1842
 msgid "certificate matches the hostname of the server, or if the certificate"
 msgstr ""
 
-#: plugins/check_http.c:1558
+#: plugins/check_http.c:1843
 msgid "has a valid chain of trust to one of the locally installed CAs."
 msgstr ""
 
-#: plugins/check_http.c:1562
+#: plugins/check_http.c:1847
 msgid ""
 "When the 'www.verisign.com' server returns its content within 5 seconds,"
 msgstr ""
 
-#: plugins/check_http.c:1563
+#: plugins/check_http.c:1848 plugins/check_http.c:1867
 msgid ""
 "a STATE_OK will be returned. When the server returns its content but exceeds"
 msgstr ""
 
-#: plugins/check_http.c:1564
+#: plugins/check_http.c:1849 plugins/check_http.c:1868
 msgid ""
 "the 5-second threshold, a STATE_WARNING will be returned. When an error "
 "occurs,"
 msgstr ""
 
-#: plugins/check_http.c:1565
+#: plugins/check_http.c:1850
 msgid "a STATE_CRITICAL will be returned."
 msgstr ""
 
-#: plugins/check_http.c:1568
+#: plugins/check_http.c:1853
 msgid ""
 "When the certificate of 'www.verisign.com' is valid for more than 14 days,"
 msgstr ""
 
-#: plugins/check_http.c:1569 plugins/check_http.c:1575
+#: plugins/check_http.c:1854 plugins/check_http.c:1860
 msgid ""
 "a STATE_OK is returned. When the certificate is still valid, but for less "
 "than"
 msgstr ""
 
-#: plugins/check_http.c:1570
+#: plugins/check_http.c:1855
 msgid ""
 "14 days, a STATE_WARNING is returned. A STATE_CRITICAL will be returned when"
 msgstr ""
 
-#: plugins/check_http.c:1571
+#: plugins/check_http.c:1856
 msgid "the certificate is expired."
 msgstr "le certificat est expiré."
 
-#: plugins/check_http.c:1574
+#: plugins/check_http.c:1859
 msgid ""
 "When the certificate of 'www.verisign.com' is valid for more than 30 days,"
 msgstr ""
 
-#: plugins/check_http.c:1576
+#: plugins/check_http.c:1861
 msgid "30 days, but more than 14 days, a STATE_WARNING is returned."
 msgstr ""
 
-#: plugins/check_http.c:1577
+#: plugins/check_http.c:1862
 msgid ""
 "A STATE_CRITICAL will be returned when certificate expires in less than 14 "
 "days"
 msgstr ""
 
-#: plugins/check_ldap.c:133
+#: plugins/check_http.c:1865
+msgid ""
+"check_http -I 192.168.100.35 -p 80 -u https://www.verisign.com/ -S -j "
+"CONNECT -H www.verisign.com "
+msgstr ""
+
+#: plugins/check_http.c:1866
+msgid ""
+"all these options are needed: -I <proxy> -p <proxy-port> -u <check-url> -"
+"S(sl) -j CONNECT -H <webserver>"
+msgstr ""
+
+#: plugins/check_http.c:1869
+msgid ""
+"a STATE_CRITICAL will be returned. By adding a colon to the method you can "
+"set the method used"
+msgstr ""
+
+#: plugins/check_http.c:1870
+msgid "inside the proxied connection: -j CONNECT:POST"
+msgstr ""
+
+#: plugins/check_ldap.c:142
 #, c-format
 msgid "Could not connect to the server at port %i\n"
 msgstr "Impossible de se connecter au serveur port %i\n"
 
-#: plugins/check_ldap.c:142
+#: plugins/check_ldap.c:151
 #, c-format
 msgid "Could not set protocol version %d\n"
 msgstr "Impossible d'utiliser le protocole version %d\n"
 
-#: plugins/check_ldap.c:157
+#: plugins/check_ldap.c:166
 #, c-format
 msgid "Could not init TLS at port %i!\n"
 msgstr "Impossible d'initialiser TLS sur le port %i!\n"
 
-#: plugins/check_ldap.c:161
+#: plugins/check_ldap.c:170
 #, c-format
 msgid "TLS not supported by the libraries!\n"
 msgstr "TLS n'est pas supporté!\n"
 
-#: plugins/check_ldap.c:181
+#: plugins/check_ldap.c:190
 #, c-format
 msgid "Could not init startTLS at port %i!\n"
 msgstr "Impossible d'initialiser startTLS sur le port %i!\n"
 
-#: plugins/check_ldap.c:185
+#: plugins/check_ldap.c:194
 #, c-format
 msgid "startTLS not supported by the library, needs LDAPv3!\n"
 msgstr ""
 "startTLS n'est pas supporté par la librairie LDAP, j'ai besoin de LDAPv3!\n"
 
-#: plugins/check_ldap.c:195
+#: plugins/check_ldap.c:204
 #, c-format
 msgid "Could not bind to the LDAP server\n"
 msgstr "Impossible de se connecter au serveur LDAP\n"
 
-#: plugins/check_ldap.c:204
+#: plugins/check_ldap.c:213
 #, c-format
 msgid "Could not search/find objectclasses in %s\n"
 msgstr "Impossible de chercher/trouver les objectclasses dans %s\n"
 
-#: plugins/check_ldap.c:227
+#: plugins/check_ldap.c:252
+#, fuzzy, c-format
+msgid "LDAP %s - found %d entries in %.3f seconds|%s %s\n"
+msgstr "%s - %d octets en %.3f secondes de temps de réponse %s|%s %s"
+
+#: plugins/check_ldap.c:265
 #, c-format
 msgid "LDAP %s - %.3f seconds response time|%s\n"
 msgstr "LDAP %s - %.3f secondes de temps de réponse|%s\n"
 
-#: plugins/check_ldap.c:339 plugins/check_ldap.c:347
+#: plugins/check_ldap.c:386 plugins/check_ldap.c:394
 #, c-format
 msgid "%s cannot be combined with %s"
 msgstr ""
 
-#: plugins/check_ldap.c:379
+#: plugins/check_ldap.c:426
 msgid "Please specify the host name\n"
 msgstr "Veuillez spécifier le nom de l'hôte\n"
 
-#: plugins/check_ldap.c:382
+#: plugins/check_ldap.c:429
 msgid "Please specify the LDAP base\n"
 msgstr "Veuillez spécifier la base LDAP\n"
 
-#: plugins/check_ldap.c:411
+#: plugins/check_ldap.c:465
 msgid "ldap attribute to search (default: \"(objectclass=*)\""
 msgstr ""
 
-#: plugins/check_ldap.c:413
+#: plugins/check_ldap.c:467
 msgid "ldap base (eg. ou=my unit, o=my org, c=at"
 msgstr ""
 
-#: plugins/check_ldap.c:415
+#: plugins/check_ldap.c:469
 msgid "ldap bind DN (if required)"
 msgstr ""
 
-#: plugins/check_ldap.c:417
-msgid "ldap password (if required)"
+#: plugins/check_ldap.c:471
+msgid ""
+"ldap password (if required, or set the password through environment variable "
+"'LDAP_PASSWORD')"
 msgstr ""
 
-#: plugins/check_ldap.c:419
+#: plugins/check_ldap.c:473
 msgid "use starttls mechanism introduced in protocol version 3"
 msgstr "utiliser le fonctionnement starttls du protocole version 3"
 
-#: plugins/check_ldap.c:421
+#: plugins/check_ldap.c:475
 msgid "use ldaps (ldap v2 ssl method). this also sets the default port to"
 msgstr ""
 
-#: plugins/check_ldap.c:425
+#: plugins/check_ldap.c:479
 msgid "use ldap protocol version 2"
 msgstr "utiliser le protocole ldap version 2"
 
-#: plugins/check_ldap.c:427
+#: plugins/check_ldap.c:481
 msgid "use ldap protocol version 3"
 msgstr "utiliser le protocole ldap version 3"
 
-#: plugins/check_ldap.c:428
+#: plugins/check_ldap.c:482
 msgid "default protocol version:"
 msgstr "version du protocole par défaut:"
 
-#: plugins/check_ldap.c:439
+#: plugins/check_ldap.c:488
+#, fuzzy
+msgid "Number of found entries to result in warning status"
+msgstr "Décalage résultant en un avertissement (secondes)"
+
+#: plugins/check_ldap.c:490
+#, fuzzy
+msgid "Number of found entries to result in critical status"
+msgstr "Décalage résultant en un état critique (secondes)"
+
+#: plugins/check_ldap.c:498
 msgid "If this plugin is called via 'check_ldaps', method 'STARTTLS' will be"
 msgstr ""
 
-#: plugins/check_ldap.c:440
+#: plugins/check_ldap.c:499
 #, c-format
 msgid ""
 " implied (using default port %i) unless --port=636 is specified. In that "
 "case\n"
 msgstr ""
 
-#: plugins/check_ldap.c:441
+#: plugins/check_ldap.c:500
 msgid "'SSL on connect' will be used no matter how the plugin was called."
 msgstr ""
 
-#: plugins/check_ldap.c:442
+#: plugins/check_ldap.c:501
 msgid ""
 "This detection is deprecated, please use 'check_ldap' with the '--starttls' "
 "or '--ssl' flags"
 msgstr ""
 
-#: plugins/check_ldap.c:443
+#: plugins/check_ldap.c:502
 msgid "to define the behaviour explicitly instead."
 msgstr ""
 
-#: plugins/check_load.c:87
+#: plugins/check_ldap.c:503
+msgid "The parameters --warn-entries and --crit-entries are optional."
+msgstr ""
+
+#: plugins/check_load.c:93
 msgid "Warning threshold must be float or float triplet!\n"
 msgstr "Le seuil d'alerte doit être un nombre à virgule flottante!\n"
 
-#: plugins/check_load.c:132 plugins/check_load.c:148
+#: plugins/check_load.c:138 plugins/check_load.c:154
 #, c-format
 msgid "Error opening %s\n"
 msgstr "Erreur à l'ouverture de %s\n"
 
-#: plugins/check_load.c:163
+#: plugins/check_load.c:169
 #, fuzzy, c-format
-msgid "could not parse load from uptime: %s\n"
+msgid "could not parse load from uptime %s: %d\n"
 msgstr "Lecture des arguments impossible\n"
 
-#: plugins/check_load.c:169
+#: plugins/check_load.c:175
 #, c-format
 msgid "Error code %d returned in %s\n"
 msgstr "Le code erreur %d à été retourné par %s\n"
 
-#: plugins/check_load.c:184
+#: plugins/check_load.c:183
 #, c-format
 msgid "Error in getloadavg()\n"
 msgstr "Erreur dans la fonction getloadavg()\n"
 
-#: plugins/check_load.c:187 plugins/check_load.c:189
+#: plugins/check_load.c:186 plugins/check_load.c:188
 #, c-format
 msgid "Error processing %s\n"
 msgstr "Erreur lors de l'utilisation de %s\n"
 
-#: plugins/check_load.c:198
+#: plugins/check_load.c:197 plugins/check_load.c:212
 #, c-format
 msgid "load average: %.2f, %.2f, %.2f"
 msgstr "Charge moyenne: %.2f, %.2f, %.2f"
 
-#: plugins/check_load.c:291
+#: plugins/check_load.c:327
 #, c-format
 msgid "Critical threshold for %d-minute load average is not specified\n"
 msgstr ""
 "Le seuil critique pour la charge système après %d minutes n'est pas "
 "spécifié\n"
 
-#: plugins/check_load.c:293
+#: plugins/check_load.c:329
 #, c-format
 msgid "Warning threshold for %d-minute load average is not specified\n"
 msgstr ""
 "Le seuil d'avertissement pour la charge système après %d minutes n'est pas "
 "spécifié\n"
 
-#: plugins/check_load.c:295
+#: plugins/check_load.c:331
 #, c-format
 msgid ""
 "Parameter inconsistency: %d-minute \"warning load\" is greater than "
@@ -1897,26 +2071,44 @@ msgstr ""
 "Arguments Incorrects: %d-minute \"alerte charge système\" est plus grand que "
 "\"alerte critique charge système\"\n"
 
-#: plugins/check_load.c:311
+#: plugins/check_load.c:346
 #, c-format
 msgid "This plugin tests the current system load average."
 msgstr "Ce plugin teste la charge système actuelle."
 
-#: plugins/check_load.c:321
+#: plugins/check_load.c:356
 msgid "Exit with WARNING status if load average exceeds WLOADn"
 msgstr ""
 "Sortir avec un résultat AVERTISSEMENT si la charge moyenne dépasse WLOAD"
 
-#: plugins/check_load.c:323
+#: plugins/check_load.c:358
 msgid "Exit with CRITICAL status if load average exceed CLOADn"
 msgstr "Sortir avec un résultat CRITIQUE si la charge moyenne excède CLOAD"
 
-#: plugins/check_load.c:324
+#: plugins/check_load.c:359
 msgid "the load average format is the same used by \"uptime\" and \"w\""
 msgstr ""
 
-#: plugins/check_load.c:326
+#: plugins/check_load.c:361
 msgid "Divide the load averages by the number of CPUs (when possible)"
+msgstr ""
+
+#: plugins/check_load.c:363
+msgid "Number of processes to show when printing the top consuming processes."
+msgstr ""
+
+#: plugins/check_load.c:364
+msgid "NUMBER_OF_PROCS=0 disables this feature. Default value is 0"
+msgstr ""
+
+#: plugins/check_load.c:401
+#, c-format
+msgid "'%s' exited with non-zero status.\n"
+msgstr ""
+
+#: plugins/check_load.c:405
+#, c-format
+msgid "some error occurred getting procs list.\n"
 msgstr ""
 
 #: plugins/check_mrtg.c:75
@@ -2096,8 +2288,8 @@ msgid "Unable to process MRTG log file"
 msgstr "Impossible de traiter le fichier de log de MRTG"
 
 #: plugins/check_mrtgtraf.c:194
-#, c-format
-msgid "%s. In = %0.1f %s, %s. Out = %0.1f %s|%s %s\n"
+#, fuzzy, c-format
+msgid "%s. In = %0.1f %s/s, %s. Out = %0.1f %s/s|%s %s\n"
 msgstr "%s. Entrée = %0.1f %s, %s. Sortie = %0.1f %s|%s %s\n"
 
 #: plugins/check_mrtgtraf.c:207
@@ -2181,133 +2373,137 @@ msgstr ""
 msgid "Usage"
 msgstr "Utilisation"
 
-#: plugins/check_mysql.c:171
+#: plugins/check_mysql.c:185
 #, fuzzy, c-format
 msgid "status store_result error: %s\n"
 msgstr "erreur slave store_result: %s\n"
 
-#: plugins/check_mysql.c:202
+#: plugins/check_mysql.c:216
 #, c-format
 msgid "slave query error: %s\n"
 msgstr "erreur de requête de l'esclave: %s\n"
 
-#: plugins/check_mysql.c:209
+#: plugins/check_mysql.c:223
 #, c-format
 msgid "slave store_result error: %s\n"
 msgstr "erreur slave store_result: %s\n"
 
-#: plugins/check_mysql.c:215
+#: plugins/check_mysql.c:229
 msgid "No slaves defined"
 msgstr "Pas d'esclave spécifié"
 
-#: plugins/check_mysql.c:223
+#: plugins/check_mysql.c:237
 #, c-format
 msgid "slave fetch row error: %s\n"
 msgstr "erreur esclave lecture d'une ligne: %s\n"
 
-#: plugins/check_mysql.c:228
+#: plugins/check_mysql.c:242
 #, c-format
 msgid "Slave running: %s"
 msgstr "L'esclave fonctionne: %s"
 
-#: plugins/check_mysql.c:505
+#: plugins/check_mysql.c:520
 msgid "This program tests connections to a MySQL server"
 msgstr "Ce plugin teste une connexion vers un serveur MySQL"
 
-#: plugins/check_mysql.c:516
+#: plugins/check_mysql.c:531
+msgid "Ignore authentication failure and check for mysql connectivity only"
+msgstr ""
+
+#: plugins/check_mysql.c:534
 msgid "Use the specified socket (has no effect if -H is used)"
 msgstr ""
 
-#: plugins/check_mysql.c:519
+#: plugins/check_mysql.c:537
 msgid "Check database with indicated name"
 msgstr ""
 
-#: plugins/check_mysql.c:521
+#: plugins/check_mysql.c:539
 msgid "Read from the specified client options file"
 msgstr ""
 
-#: plugins/check_mysql.c:523
+#: plugins/check_mysql.c:541
 msgid "Use a client options group"
 msgstr ""
 
-#: plugins/check_mysql.c:525
+#: plugins/check_mysql.c:543
 msgid "Connect using the indicated username"
 msgstr ""
 
-#: plugins/check_mysql.c:527
+#: plugins/check_mysql.c:545
 msgid "Use the indicated password to authenticate the connection"
 msgstr ""
 
-#: plugins/check_mysql.c:528
+#: plugins/check_mysql.c:546
 msgid "IMPORTANT: THIS FORM OF AUTHENTICATION IS NOT SECURE!!!"
 msgstr ""
 
-#: plugins/check_mysql.c:529
+#: plugins/check_mysql.c:547
 msgid "Your clear-text password could be visible as a process table entry"
 msgstr ""
 
-#: plugins/check_mysql.c:531
+#: plugins/check_mysql.c:549
 msgid "Check if the slave thread is running properly."
 msgstr ""
 
-#: plugins/check_mysql.c:533
+#: plugins/check_mysql.c:551
 msgid "Exit with WARNING status if slave server is more than INTEGER seconds"
 msgstr ""
 "Sortir avec un résultat AVERTISSEMENT si le serveur esclave est plus de X "
 
-#: plugins/check_mysql.c:534 plugins/check_mysql.c:537
+#: plugins/check_mysql.c:552 plugins/check_mysql.c:555
 msgid "behind master"
 msgstr "secondes en retard sur le maître"
 
-#: plugins/check_mysql.c:536
+#: plugins/check_mysql.c:554
 msgid "Exit with CRITICAL status if slave server is more then INTEGER seconds"
 msgstr "Sortir avec un résultat CRITIQUE si le serveur esclave est plus de X "
 
-#: plugins/check_mysql.c:539
-msgid "Use ssl encryptation"
+#: plugins/check_mysql.c:557
+msgid "Use ssl encryption"
 msgstr ""
 
-#: plugins/check_mysql.c:541
+#: plugins/check_mysql.c:559
 msgid "Path to CA signing the cert"
 msgstr ""
 
-#: plugins/check_mysql.c:543
+#: plugins/check_mysql.c:561
 msgid "Path to SSL certificate"
 msgstr ""
 
-#: plugins/check_mysql.c:545
+#: plugins/check_mysql.c:563
 msgid "Path to private SSL key"
 msgstr ""
 
-#: plugins/check_mysql.c:547
+#: plugins/check_mysql.c:565
 msgid "Path to CA directory"
 msgstr ""
 
-#: plugins/check_mysql.c:549
+#: plugins/check_mysql.c:567
 msgid "List of valid SSL ciphers"
 msgstr ""
 
-#: plugins/check_mysql.c:553
+#: plugins/check_mysql.c:571
 msgid ""
 "There are no required arguments. By default, the local database is checked"
 msgstr ""
 "Il n'y a pas d'arguments nécessaires. Par défaut la base de donnée locale "
 "est testée"
 
-#: plugins/check_mysql.c:554
+#: plugins/check_mysql.c:572
 msgid ""
 "using the default unix socket. You can force TCP on localhost by using an"
 msgstr ""
 
-#: plugins/check_mysql.c:555
+#: plugins/check_mysql.c:573
 msgid "IP address or FQDN ('localhost' will use the socket as well)."
 msgstr ""
 
-#: plugins/check_mysql.c:559
+#: plugins/check_mysql.c:577
 msgid "You must specify -p with an empty string to force an empty password,"
 msgstr ""
 
-#: plugins/check_mysql.c:560
+#: plugins/check_mysql.c:578
 msgid "overriding any my.cnf settings."
 msgstr ""
 
@@ -2329,7 +2525,7 @@ msgid "Cannot parse Nagios log file for valid time"
 msgstr ""
 "Impossible de trouver une date/heure valide dans le fichier de log de Nagios"
 
-#: plugins/check_nagios.c:183 plugins/check_procs.c:356
+#: plugins/check_nagios.c:183 plugins/check_procs.c:379
 #, c-format
 msgid "%d process"
 msgid_plural "%d processes"
@@ -2400,7 +2596,7 @@ msgstr ""
 msgid "Wrong client version - running: %s, required: %s"
 msgstr "Mauvaise version du client utilisée: %s, nécessaire: %s"
 
-#: plugins/check_nt.c:153 plugins/check_nt.c:218
+#: plugins/check_nt.c:153 plugins/check_nt.c:239
 msgid "missing -l parameters"
 msgstr "Arguments -l manquants"
 
@@ -2426,523 +2622,550 @@ msgstr " '%lu Charge moyenne minimale'=%lu%%;%lu;%lu;0;100"
 msgid "not enough values for -l parameters"
 msgstr "pas assez de valeur pour l'argument -l"
 
-#: plugins/check_nt.c:206
-#, c-format
-msgid "System Uptime - %u day(s) %u hour(s) %u minute(s)"
-msgstr "Système démarré - %u jour(s) %u heure(s) %u minute(s)"
-
-#: plugins/check_nt.c:220
+#: plugins/check_nt.c:208 plugins/check_nt.c:241
 msgid "wrong -l argument"
 msgstr "Argument -l erroné"
 
-#: plugins/check_nt.c:236
+#: plugins/check_nt.c:225
+#, fuzzy, c-format
+msgid "System Uptime - %u day(s) %u hour(s) %u minute(s) |uptime=%lu"
+msgstr "Système démarré - %u jour(s) %u heure(s) %u minute(s)"
+
+#: plugins/check_nt.c:257
 #, c-format
 msgid "%s:\\ - total: %.2f Gb - used: %.2f Gb (%.0f%%) - free %.2f Gb (%.0f%%)"
 msgstr ""
 "%s:\\ - total: %.2f Gb - utilisé: %.2f Gb (%.0f%%) - libre %.2f Gb (%.0f%%)"
 
-#: plugins/check_nt.c:239
+#: plugins/check_nt.c:260
 #, c-format
 msgid "'%s:\\ Used Space'=%.2fGb;%.2f;%.2f;0.00;%.2f"
 msgstr "'%s:\\ Espace Utilisé'=%.2fGb;%.2f;%.2f;0.00;%.2f"
 
-#: plugins/check_nt.c:253
+#: plugins/check_nt.c:274
 msgid "Free disk space : Invalid drive"
 msgstr "Espace disque libre : Lecteur invalide"
 
-#: plugins/check_nt.c:263
+#: plugins/check_nt.c:284
 msgid "No service/process specified"
 msgstr "Pas de service/processus spécifié"
 
-#: plugins/check_nt.c:271 plugins/check_nt.c:284 plugins/check_nt.c:288
-#: plugins/check_nt.c:622
+#: plugins/check_nt.c:292 plugins/check_nt.c:305 plugins/check_nt.c:309
+#: plugins/check_nt.c:643
 msgid "could not fetch information from server\n"
 msgstr "Impossible d'obtenir l'information depuis le serveur\n"
 
-#: plugins/check_nt.c:296
-#, c-format
+#: plugins/check_nt.c:317
+#, fuzzy, c-format
 msgid ""
-"Memory usage: total:%.2f Mb - used: %.2f Mb (%.0f%%) - free: %.2f Mb (%.0f%%)"
+"Memory usage: total:%.2f MB - used: %.2f MB (%.0f%%) - free: %.2f MB (%.0f%%)"
 msgstr ""
 "Mémoire utilisée: total:%.2f Mb - utilisée: %.2f Mb (%.0f%%) - libre: %.2f "
 "Mb (%.0f%%)"
 
-#: plugins/check_nt.c:299
-#, c-format
-msgid "'Memory usage'=%.2fMb;%.2f;%.2f;0.00;%.2f"
+#: plugins/check_nt.c:320
+#, fuzzy, c-format
+msgid "'Memory usage'=%.2fMB;%.2f;%.2f;0.00;%.2f"
 msgstr "'Mémoire utilisée'=%.2fMb;%.2f;%.2f;0.00;%.2f"
 
-#: plugins/check_nt.c:335 plugins/check_nt.c:420 plugins/check_nt.c:450
+#: plugins/check_nt.c:356 plugins/check_nt.c:441 plugins/check_nt.c:471
 msgid "No counter specified"
 msgstr "Pas de compteur spécifié"
 
-#: plugins/check_nt.c:367
+#: plugins/check_nt.c:388
 msgid "Minimum value contains non-numbers"
 msgstr "La valeur minimum contient des caractères non numériques"
 
-#: plugins/check_nt.c:371
+#: plugins/check_nt.c:392
 msgid "Maximum value contains non-numbers"
 msgstr "La valeur maximum contient des caractères non numériques"
 
-#: plugins/check_nt.c:378
+#: plugins/check_nt.c:399
 msgid "No unit counter specified"
 msgstr "Pas de compteur spécifié"
 
-#: plugins/check_nt.c:465
+#: plugins/check_nt.c:486
 msgid "Please specify a variable to check"
 msgstr "Veuillez préciser une variable a vérifier"
 
-#: plugins/check_nt.c:549
+#: plugins/check_nt.c:570
 msgid "Server port must be an integer\n"
 msgstr "Le port du serveur doit être un nombre entier\n"
 
-#: plugins/check_nt.c:603
+#: plugins/check_nt.c:624
 msgid "You must provide a server address or host name"
 msgstr "Vous devez spécifier une adresse ou un nom d'hôte"
 
-#: plugins/check_nt.c:609
+#: plugins/check_nt.c:630
 msgid "None"
 msgstr "Aucun"
 
-#: plugins/check_nt.c:666
+#: plugins/check_nt.c:687
 msgid "This plugin collects data from the NSClient service running on a"
 msgstr ""
 "Ce plugin collecte les données depuis le service NSClient tournant sur un"
 
-#: plugins/check_nt.c:667
+#: plugins/check_nt.c:688
 msgid "Windows NT/2000/XP/2003 server."
 msgstr "Serveur Windows NT/2000/XP/2003."
 
-#: plugins/check_nt.c:678
+#: plugins/check_nt.c:699
 msgid "Name of the host to check"
 msgstr "Nom de l'hôte à vérifier"
 
-#: plugins/check_nt.c:680
+#: plugins/check_nt.c:701
 msgid "Optional port number (default: "
 msgstr "Numéro de port optionnel (défaut: "
 
-#: plugins/check_nt.c:683
+#: plugins/check_nt.c:704
 msgid "Password needed for the request"
 msgstr "Mot de passe nécessaire pour la requête"
 
-#: plugins/check_nt.c:685 plugins/check_nwstat.c:1661
+#: plugins/check_nt.c:706 plugins/check_nwstat.c:1661
 #: plugins/check_overcr.c:432
 msgid "Threshold which will result in a warning status"
 msgstr ""
 
-#: plugins/check_nt.c:687 plugins/check_nwstat.c:1663
+#: plugins/check_nt.c:708 plugins/check_nwstat.c:1663
 #: plugins/check_overcr.c:434
 msgid "Threshold which will result in a critical status"
 msgstr ""
 
-#: plugins/check_nt.c:689
+#: plugins/check_nt.c:710
 msgid "Seconds before connection attempt times out (default: "
 msgstr ""
 
-#: plugins/check_nt.c:691
+#: plugins/check_nt.c:712
 msgid "Parameters passed to specified check (see below)"
 msgstr ""
 
-#: plugins/check_nt.c:693
+#: plugins/check_nt.c:714
 msgid "Display options (currently only SHOWALL works)"
 msgstr ""
 
-#: plugins/check_nt.c:695
+#: plugins/check_nt.c:716
 msgid "Return UNKNOWN on timeouts"
 msgstr ""
 
-#: plugins/check_nt.c:698
+#: plugins/check_nt.c:719
 msgid "Print this help screen"
 msgstr "Afficher l'écran d'aide"
 
-#: plugins/check_nt.c:700
+#: plugins/check_nt.c:721
 msgid "Print version information"
 msgstr "Afficher la version"
 
-#: plugins/check_nt.c:702
+#: plugins/check_nt.c:723
 msgid "Variable to check"
 msgstr "Variable a vérifier"
 
-#: plugins/check_nt.c:703
+#: plugins/check_nt.c:724
 msgid "Valid variables are:"
 msgstr "Les variables valides sont"
 
-#: plugins/check_nt.c:705
+#: plugins/check_nt.c:726
 msgid "Get the NSClient version"
 msgstr "Obtenir la version de NSClient"
 
-#: plugins/check_nt.c:706
+#: plugins/check_nt.c:727
 msgid "If -l <version> is specified, will return warning if versions differ."
 msgstr ""
 "si l'argument -l <version> est spécifié, une alerte AVERTISSEMENT sera "
 "renvoyée, si les versions sont différentes."
 
-#: plugins/check_nt.c:708
+#: plugins/check_nt.c:729
 msgid "Average CPU load on last x minutes."
 msgstr "Moyenne de la charge CPU sur les dernières x minutes."
 
-#: plugins/check_nt.c:709
+#: plugins/check_nt.c:730
 msgid "Request a -l parameter with the following syntax:"
 msgstr "Demande un paramètre -l avec la syntaxe suivante:"
 
-#: plugins/check_nt.c:710
+#: plugins/check_nt.c:731
 msgid "-l <minutes range>,<warning threshold>,<critical threshold>."
 msgstr "-l <plage de minutes>,<seuil d'avertissement>,<seuil critique>."
 
-#: plugins/check_nt.c:711
+#: plugins/check_nt.c:732
 msgid "<minute range> should be less than 24*60."
 msgstr "<plage de minutes> devrait être inférieur à 24*60."
 
-#: plugins/check_nt.c:712
+#: plugins/check_nt.c:733
 msgid ""
 "Thresholds are percentage and up to 10 requests can be done in one shot."
 msgstr ""
 "Les seuils sonts en pourcentage et un maximum de 10 requêtes peuvent être "
 "effectuées à la fois."
 
-#: plugins/check_nt.c:715
+#: plugins/check_nt.c:736
 msgid "Get the uptime of the machine."
 msgstr "Obtenir le temps de service de la machine."
 
-#: plugins/check_nt.c:716
-msgid "No specific parameters. No warning or critical threshold"
-msgstr "Pas d'argument spécifique. Pas de seuil d'avertissement ou critique"
+#: plugins/check_nt.c:737
+msgid "-l <unit> "
+msgstr ""
 
-#: plugins/check_nt.c:718
+#: plugins/check_nt.c:738
+msgid "<unit> = seconds, minutes, hours, or days. (default: minutes)"
+msgstr ""
+
+#: plugins/check_nt.c:739
+#, fuzzy
+msgid "Thresholds will use the unit specified above."
+msgstr "Ce plugin va vérifier l'heure sur l'hôte spécifié."
+
+#: plugins/check_nt.c:741
 msgid "Size and percentage of disk use."
 msgstr "Taille et pourcentage de l'utilisation disque."
 
-#: plugins/check_nt.c:719
+#: plugins/check_nt.c:742
 msgid "Request a -l parameter containing the drive letter only."
 msgstr "Demande un paramètre -l contennant uniquement la lettre du lecteur."
 
-#: plugins/check_nt.c:720 plugins/check_nt.c:723
+#: plugins/check_nt.c:743 plugins/check_nt.c:746
 msgid "Warning and critical thresholds can be specified with -w and -c."
 msgstr "Les seuils d'alerte et critiques peuvent être spécifiés avec -w et -c."
 
-#: plugins/check_nt.c:722
+#: plugins/check_nt.c:745
 msgid "Memory use."
 msgstr "Mémoire utilisée."
 
-#: plugins/check_nt.c:725
+#: plugins/check_nt.c:748
 msgid "Check the state of one or several services."
 msgstr "Vérifier l'état d'un ou plusieurs services."
 
-#: plugins/check_nt.c:726 plugins/check_nt.c:735
+#: plugins/check_nt.c:749 plugins/check_nt.c:758
 msgid "Request a -l parameters with the following syntax:"
 msgstr "Demande un paramètre -l avec la syntaxe suivante:"
 
-#: plugins/check_nt.c:727
+#: plugins/check_nt.c:750
 msgid "-l <service1>,<service2>,<service3>,..."
 msgstr "-l <service1>,<service2>,<service3>,..."
 
-#: plugins/check_nt.c:728
+#: plugins/check_nt.c:751
 msgid "You can specify -d SHOWALL in case you want to see working services"
 msgstr "Vous pouvez spécifier -d SHOWALL pour voir les services fonctionnant"
 
-#: plugins/check_nt.c:729
+#: plugins/check_nt.c:752
 msgid "in the returned string."
 msgstr "dans la chaîne de caractère renvoyée."
 
-#: plugins/check_nt.c:731
+#: plugins/check_nt.c:754
 msgid "Check if one or several process are running."
 msgstr "Vérifie si un ou plusieurs processus sont démarrés."
 
-#: plugins/check_nt.c:732
+#: plugins/check_nt.c:755
 msgid "Same syntax as SERVICESTATE."
 msgstr "Même syntaxe que SERVICESTATE."
 
-#: plugins/check_nt.c:734
+#: plugins/check_nt.c:757
 msgid "Check any performance counter of Windows NT/2000."
 msgstr "Vérifier n'importe quel compteur de performance sur Windows NT/2000."
 
-#: plugins/check_nt.c:736
+#: plugins/check_nt.c:759
 msgid "-l \"\\\\<performance object>\\\\counter\",\"<description>"
 msgstr "-l \"\\\\<catégorie>\\\\compteur\",\"<description>"
 
-#: plugins/check_nt.c:737
+#: plugins/check_nt.c:760
 msgid "The <description> parameter is optional and is given to a printf "
 msgstr "Le paramètre <description> est optionnel et est passé à la fonction "
 
-#: plugins/check_nt.c:738
+#: plugins/check_nt.c:761
 msgid "output command which requires a float parameter."
 msgstr "de sortie printf qui demande un paramètre de type float."
 
-#: plugins/check_nt.c:739
+#: plugins/check_nt.c:762
 #, c-format
 msgid "If <description> does not include \"%%\", it is used as a label."
 msgstr "Si <description> n'inclus pas \"%%\", il est utilisé comme étiquette."
 
-#: plugins/check_nt.c:740 plugins/check_nt.c:755
+#: plugins/check_nt.c:763 plugins/check_nt.c:778
 msgid "Some examples:"
 msgstr "Exemples:"
 
-#: plugins/check_nt.c:744
+#: plugins/check_nt.c:767
 msgid "Check any performance counter object of Windows NT/2000."
 msgstr "Vérifie n'importe quel compteur de performance de Windows NT/2000."
 
-#: plugins/check_nt.c:745
+#: plugins/check_nt.c:768
 msgid ""
 "Syntax: check_nt -H <hostname> -p <port> -v INSTANCES -l <counter object>"
 msgstr ""
 
-#: plugins/check_nt.c:746
+#: plugins/check_nt.c:769
 msgid "<counter object> is a Windows Perfmon Counter object (eg. Process),"
 msgstr ""
 
-#: plugins/check_nt.c:747
+#: plugins/check_nt.c:770
 msgid "if it is two words, it should be enclosed in quotes"
 msgstr ""
 
-#: plugins/check_nt.c:748
+#: plugins/check_nt.c:771
 msgid "The returned results will be a comma-separated list of instances on "
 msgstr ""
 
-#: plugins/check_nt.c:749
+#: plugins/check_nt.c:772
 msgid " the selected computer for that object."
 msgstr ""
 
-#: plugins/check_nt.c:750
+#: plugins/check_nt.c:773
 msgid ""
 "The purpose of this is to be run from command line to determine what "
 "instances"
 msgstr ""
 
-#: plugins/check_nt.c:751
+#: plugins/check_nt.c:774
 msgid ""
 " are available for monitoring without having to log onto the Windows server"
 msgstr ""
 
-#: plugins/check_nt.c:752
+#: plugins/check_nt.c:775
 msgid "  to run Perfmon directly."
 msgstr ""
 
-#: plugins/check_nt.c:753
+#: plugins/check_nt.c:776
 msgid ""
 "It can also be used in scripts that automatically create the monitoring "
 "service"
 msgstr ""
 
-#: plugins/check_nt.c:754
+#: plugins/check_nt.c:777
 msgid " configuration files."
 msgstr ""
 
-#: plugins/check_nt.c:756
+#: plugins/check_nt.c:779
 msgid "check_nt -H 192.168.1.1 -p 1248 -v INSTANCES -l Process"
 msgstr ""
 
-#: plugins/check_nt.c:759
+#: plugins/check_nt.c:782
 msgid ""
 "- The NSClient service should be running on the server to get any information"
 msgstr ""
 "- Le service NSClient doit rouler sur le serveur pour obtenir les "
 "informations"
 
-#: plugins/check_nt.c:761
+#: plugins/check_nt.c:784
 msgid "- Critical thresholds should be lower than warning thresholds"
 msgstr ""
 "- Les seuils critiques doivent être plus bas que les seuils d'avertissement"
 
-#: plugins/check_nt.c:762
+#: plugins/check_nt.c:785
 msgid "- Default port 1248 is sometimes in use by other services. The error"
 msgstr ""
 "- Le port par défaut 1248 est parfois utilisé par d'autres services. L'erreur"
 
-#: plugins/check_nt.c:763
+#: plugins/check_nt.c:786
 msgid ""
 "output when this happens contains \"Cannot map xxxxx to protocol number\"."
 msgstr "qui en résulte contiens \"Cannot map xxxxx to protocol number\"."
 
-#: plugins/check_nt.c:764
+#: plugins/check_nt.c:787
 msgid "One fix for this is to change the port to something else on check_nt "
 msgstr ""
 "Une possibilité pour corriger ce problème est de changer le port dans "
 "check_nt "
 
-#: plugins/check_nt.c:765
+#: plugins/check_nt.c:788
 msgid "and on the client service it's connecting to."
 msgstr "et dans le service auquel il se connecte."
 
-#: plugins/check_ntp.c:807 plugins/check_ntp_peer.c:612
-#: plugins/check_ntp_time.c:571
+#: plugins/check_ntp.c:629
+#, c-format
+msgid "jitter response too large (%lu bytes)\n"
+msgstr ""
+
+#: plugins/check_ntp.c:817 plugins/check_ntp_peer.c:619
+#: plugins/check_ntp_time.c:576
 msgid "NTP CRITICAL:"
 msgstr "NTP CRITIQUE:"
 
-#: plugins/check_ntp.c:810 plugins/check_ntp_peer.c:615
-#: plugins/check_ntp_time.c:574
+#: plugins/check_ntp.c:820 plugins/check_ntp_peer.c:622
+#: plugins/check_ntp_time.c:579
 msgid "NTP WARNING:"
 msgstr "NTP AVERTISSEMENT:"
 
-#: plugins/check_ntp.c:813 plugins/check_ntp_peer.c:618
-#: plugins/check_ntp_time.c:577
+#: plugins/check_ntp.c:823 plugins/check_ntp_peer.c:625
+#: plugins/check_ntp_time.c:582
 msgid "NTP OK:"
 msgstr "NTP OK:"
 
-#: plugins/check_ntp.c:816 plugins/check_ntp_peer.c:621
-#: plugins/check_ntp_time.c:580
+#: plugins/check_ntp.c:826 plugins/check_ntp_peer.c:628
+#: plugins/check_ntp_time.c:585
 msgid "NTP UNKNOWN:"
 msgstr "NTP INCONNU:"
 
-#: plugins/check_ntp.c:820 plugins/check_ntp_peer.c:630
-#: plugins/check_ntp_time.c:584
+#: plugins/check_ntp.c:830 plugins/check_ntp_peer.c:637
+#: plugins/check_ntp_time.c:589
 msgid "Offset unknown"
 msgstr "Décalage inconnu"
 
-#: plugins/check_ntp.c:823 plugins/check_ntp_peer.c:633
-#: plugins/check_ntp_time.c:587
+#: plugins/check_ntp.c:833 plugins/check_ntp_peer.c:640
+#: plugins/check_ntp_peer.c:642 plugins/check_ntp_peer.c:644
+#: plugins/check_ntp_time.c:592
 msgid "Offset"
 msgstr "Décalage"
 
-#: plugins/check_ntp.c:844 plugins/check_ntp_peer.c:662
+#: plugins/check_ntp.c:854 plugins/check_ntp_peer.c:690
 msgid "This plugin checks the selected ntp server"
 msgstr "Ce plugin vérifie le service ntp sur l'hôte"
 
-#: plugins/check_ntp.c:854 plugins/check_ntp_peer.c:674
-#: plugins/check_ntp_time.c:614
+#: plugins/check_ntp.c:864 plugins/check_ntp_peer.c:702
+#: plugins/check_ntp_time.c:619
 msgid "Offset to result in warning status (seconds)"
 msgstr "Décalage résultant en un avertissement (secondes)"
 
-#: plugins/check_ntp.c:856 plugins/check_ntp_peer.c:676
-#: plugins/check_ntp_time.c:616
+#: plugins/check_ntp.c:866 plugins/check_ntp_peer.c:704
+#: plugins/check_ntp_time.c:621
 msgid "Offset to result in critical status (seconds)"
 msgstr "Décalage résultant en un état critique (secondes)"
 
-#: plugins/check_ntp.c:858 plugins/check_ntp_peer.c:682
+#: plugins/check_ntp.c:868 plugins/check_ntp_peer.c:710
 msgid "Warning threshold for jitter"
 msgstr "Seuil d'avertissement pour la variation (jitter)"
 
-#: plugins/check_ntp.c:860 plugins/check_ntp_peer.c:684
+#: plugins/check_ntp.c:870 plugins/check_ntp_peer.c:712
 msgid "Critical threshold for jitter"
 msgstr "Seuil critique pour la variation (jitter)"
 
-#: plugins/check_ntp.c:870
+#: plugins/check_ntp.c:880
 msgid "Normal offset check:"
 msgstr "Vérification normale du décalage:"
 
-#: plugins/check_ntp.c:873 plugins/check_ntp_peer.c:709
+#: plugins/check_ntp.c:883 plugins/check_ntp_peer.c:737
 msgid ""
 "Check jitter too, avoiding critical notifications if jitter isn't available"
 msgstr ""
 "Vérifier aussi la variation (jitter) en évitant les notifications s'il n'est "
 "pas dispoible"
 
-#: plugins/check_ntp.c:874 plugins/check_ntp_peer.c:710
+#: plugins/check_ntp.c:884 plugins/check_ntp_peer.c:738
 msgid "(See Notes above for more details on thresholds formats):"
 msgstr ""
 "(Voir les Notes ci-dessus pour plus de détails sur le format des seuils)"
 
-#: plugins/check_ntp.c:879 plugins/check_ntp.c:886
+#: plugins/check_ntp.c:889 plugins/check_ntp.c:896
 msgid "WARNING: check_ntp is deprecated. Please use check_ntp_peer or"
 msgstr "ATTENTION: check_ntp est périmé, utilisez plutôt check_ntp_peer"
 
-#: plugins/check_ntp.c:880 plugins/check_ntp.c:887
+#: plugins/check_ntp.c:890 plugins/check_ntp.c:897
 msgid "check_ntp_time instead."
 msgstr "ou check_ntp_time."
 
-#: plugins/check_ntp_peer.c:625
+#: plugins/check_ntp_peer.c:632
 msgid "Server not synchronized"
 msgstr "Le serveur n'est pas synchronisé"
 
-#: plugins/check_ntp_peer.c:627
+#: plugins/check_ntp_peer.c:634
 msgid "Server has the LI_ALARM bit set"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:672
+#: plugins/check_ntp_peer.c:700
 msgid ""
 "Returns UNKNOWN instead of CRITICAL or WARNING if server isn't synchronized"
 msgstr ""
 "Retourne INCONNU au lieu de CRITIQUE ou AVERTISSEMENT si le serveur n'est "
 "pas synchronisé"
 
-#: plugins/check_ntp_peer.c:678
+#: plugins/check_ntp_peer.c:706
 #, fuzzy
 msgid "Warning threshold for stratum of server's synchronization peer"
 msgstr "Seuil d'avertissement pour le stratum"
 
-#: plugins/check_ntp_peer.c:680
+#: plugins/check_ntp_peer.c:708
 #, fuzzy
 msgid "Critical threshold for stratum of server's synchronization peer"
 msgstr "Seuil critique pour le stratum"
 
-#: plugins/check_ntp_peer.c:686
+#: plugins/check_ntp_peer.c:714
 msgid "Warning threshold for number of usable time sources (\"truechimers\")"
 msgstr ""
 "Seuil d'avertissement pour le nombre de sources de temps utilisable "
 "(\"truechimers\")"
 
-#: plugins/check_ntp_peer.c:688
+#: plugins/check_ntp_peer.c:716
 msgid "Critical threshold for number of usable time sources (\"truechimers\")"
 msgstr ""
-"Seuil critique pour le nombre de sources de temps utilisable (\"truechimers"
-"\")"
+"Seuil critique pour le nombre de sources de temps utilisable "
+"(\"truechimers\")"
 
-#: plugins/check_ntp_peer.c:693
+#: plugins/check_ntp_peer.c:721
 msgid "This plugin checks an NTP server independent of any commandline"
 msgstr "Ce plugin vérifie un serveur NTP sans recours aux programmes de"
 
-#: plugins/check_ntp_peer.c:694
+#: plugins/check_ntp_peer.c:722
 msgid "programs or external libraries."
 msgstr "la ligne de commande ou libraries externes"
 
-#: plugins/check_ntp_peer.c:697
+#: plugins/check_ntp_peer.c:725
 msgid "Use this plugin to check the health of an NTP server. It supports"
 msgstr ""
 "Utilisez ce plugin pour vérifier le service NTP sur l'hôte. Il supporte la"
 
-#: plugins/check_ntp_peer.c:698
+#: plugins/check_ntp_peer.c:726
 msgid "checking the offset with the sync peer, the jitter and stratum. This"
 msgstr ""
 "vérification du décalage avec le pair se synchronisation, la variation "
 "(jitter) et le stratum."
 
-#: plugins/check_ntp_peer.c:699
+#: plugins/check_ntp_peer.c:727
 msgid "plugin will not check the clock offset between the local host and NTP"
 msgstr ""
 "Ce plugin ne vérifie pas le décalage entre le serveur local et le serveur"
 
-#: plugins/check_ntp_peer.c:700
+#: plugins/check_ntp_peer.c:728
 msgid "server; please use check_ntp_time for that purpose."
 msgstr "NTP; utilisez plutôt check_ntp_time à cette fin."
 
-#: plugins/check_ntp_peer.c:706
+#: plugins/check_ntp_peer.c:734
 msgid "Simple NTP server check:"
 msgstr "Vérification simple du serveur NTP:"
 
-#: plugins/check_ntp_peer.c:713
+#: plugins/check_ntp_peer.c:741
 msgid "Only check the number of usable time sources (\"truechimers\"):"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:716
+#: plugins/check_ntp_peer.c:744
 msgid "Check only stratum:"
 msgstr "Vérification du stratum seulement:"
 
-#: plugins/check_ntp_time.c:602
+#: plugins/check_ntp_time.c:607
 msgid "This plugin checks the clock offset with the ntp server"
 msgstr "Ce plugin vérifie le décalage de l'horloge avec le serveur ntp"
 
-#: plugins/check_ntp_time.c:612
+#: plugins/check_ntp_time.c:617
 msgid "Returns UNKNOWN instead of CRITICAL if offset cannot be found"
 msgstr "Retourne INCONNU au lieu de CRITIQUE si le décalage est inconnu"
 
-#: plugins/check_ntp_time.c:621
+#: plugins/check_ntp_time.c:623
+msgid "Expected offset of the ntp server relative to local server (seconds)"
+msgstr ""
+
+#: plugins/check_ntp_time.c:628
 msgid "This plugin checks the clock offset between the local host and a"
 msgstr "Ce plugin vérifie le décalage de l'horloge entre se serveur local et"
 
-#: plugins/check_ntp_time.c:622
+#: plugins/check_ntp_time.c:629
 msgid "remote NTP server. It is independent of any commandline programs or"
 msgstr "le serveur NTP distant. Il ne fait aucun recours aux programmes de"
 
-#: plugins/check_ntp_time.c:623
+#: plugins/check_ntp_time.c:630
 msgid "external libraries."
 msgstr "la ligne de commande ou libraries externes."
 
-#: plugins/check_ntp_time.c:627
+#: plugins/check_ntp_time.c:634
 msgid "If you'd rather want to monitor an NTP server, please use"
 msgstr "Si vous voulez plutôt surveiller un serveur NTP, veuillez"
 
-#: plugins/check_ntp_time.c:628
+#: plugins/check_ntp_time.c:635
 msgid "check_ntp_peer."
 msgstr "utiliser check_ntp_peer."
+
+#: plugins/check_ntp_time.c:636
+msgid "--time-offset is useful for compensating for servers with known"
+msgstr ""
+
+#: plugins/check_ntp_time.c:637
+msgid "and expected clock skew."
+msgstr ""
 
 #: plugins/check_nwstat.c:194
 #, c-format
@@ -3517,608 +3740,644 @@ msgid ""
 "higher than the warning threshold value, EXCEPT with the uptime variable"
 msgstr "plus grand que le seuil d'alerte SAUF pour l'option uptime"
 
-#: plugins/check_pgsql.c:222
+#: plugins/check_pgsql.c:224
 #, c-format
 msgid "CRITICAL - no connection to '%s' (%s).\n"
 msgstr "CRITIQUE - pas de connexion à '%s' (%s).\n"
 
-#: plugins/check_pgsql.c:250
+#: plugins/check_pgsql.c:252
 #, fuzzy, c-format
 msgid " %s - database %s (%f sec.)|%s\n"
 msgstr " %s - base de données %s (%d sec.)|%s\n"
 
-#: plugins/check_pgsql.c:317 plugins/check_time.c:277 plugins/check_time.c:289
-#: plugins/check_users.c:181
+#: plugins/check_pgsql.c:320 plugins/check_time.c:277 plugins/check_time.c:289
+#: plugins/check_users.c:228
 msgid "Critical threshold must be a positive integer"
 msgstr "Le seuil critique doit être un entier positif"
 
-#: plugins/check_pgsql.c:323 plugins/check_time.c:258 plugins/check_time.c:282
-#: plugins/check_users.c:187 plugins/check_users.c:197
-#: plugins/check_users.c:203
+#: plugins/check_pgsql.c:326 plugins/check_time.c:258 plugins/check_time.c:282
+#: plugins/check_users.c:226
 msgid "Warning threshold must be a positive integer"
 msgstr "Le seuil d'avertissement doit être un entier positif"
 
-#: plugins/check_pgsql.c:347
-msgid "Database name is not valid"
+#: plugins/check_pgsql.c:350
+#, fuzzy
+msgid "Database name exceeds the maximum length"
 msgstr "Le nom de la base de données est invalide"
 
-#: plugins/check_pgsql.c:353
+#: plugins/check_pgsql.c:356
 msgid "User name is not valid"
 msgstr "Le nom de l'utilisateur est invalide"
 
-#: plugins/check_pgsql.c:504
+#: plugins/check_pgsql.c:471
 #, c-format
 msgid "Test whether a PostgreSQL Database is accepting connections."
 msgstr "Teste si une base de données Postgresql accepte les connections."
 
-#: plugins/check_pgsql.c:516
+#: plugins/check_pgsql.c:483
 msgid "Database to check "
 msgstr ""
 
-#: plugins/check_pgsql.c:517
-#, c-format
-msgid "(default: %s)"
-msgstr ""
+#: plugins/check_pgsql.c:484
+#, fuzzy, c-format
+msgid "(default: %s)\n"
+msgstr "(Défaut: %d)\n"
 
-#: plugins/check_pgsql.c:519
+#: plugins/check_pgsql.c:486
 msgid "Login name of user"
 msgstr "Le nom d'un utilisateur"
 
-#: plugins/check_pgsql.c:521
+#: plugins/check_pgsql.c:488
 msgid "Password (BIG SECURITY ISSUE)"
 msgstr ""
 
-#: plugins/check_pgsql.c:523
+#: plugins/check_pgsql.c:490
 msgid "Connection parameters (keyword = value), see below"
 msgstr ""
 
-#: plugins/check_pgsql.c:530
+#: plugins/check_pgsql.c:497
 msgid "SQL query to run. Only first column in first row will be read"
 msgstr ""
 
-#: plugins/check_pgsql.c:532
+#: plugins/check_pgsql.c:499
+msgid "A name for the query, this string is used instead of the query"
+msgstr ""
+
+#: plugins/check_pgsql.c:500
+msgid "in the long output of the plugin"
+msgstr ""
+
+#: plugins/check_pgsql.c:502
 #, fuzzy
 msgid "SQL query value to result in warning status (double)"
 msgstr "Décalage résultant en un avertissement (secondes)"
 
-#: plugins/check_pgsql.c:534
+#: plugins/check_pgsql.c:504
 #, fuzzy
 msgid "SQL query value to result in critical status (double)"
 msgstr "Décalage résultant en un état critique (secondes)"
 
-#: plugins/check_pgsql.c:539
+#: plugins/check_pgsql.c:509
 msgid "All parameters are optional."
 msgstr ""
 
-#: plugins/check_pgsql.c:540
+#: plugins/check_pgsql.c:510
 msgid ""
 "This plugin tests a PostgreSQL DBMS to determine whether it is active and"
 msgstr ""
 
-#: plugins/check_pgsql.c:541
+#: plugins/check_pgsql.c:511
 msgid "accepting queries. In its current operation, it simply connects to the"
 msgstr ""
 
-#: plugins/check_pgsql.c:542
+#: plugins/check_pgsql.c:512
 msgid ""
 "specified database, and then disconnects. If no database is specified, it"
 msgstr ""
 
-#: plugins/check_pgsql.c:543
+#: plugins/check_pgsql.c:513
 msgid ""
 "connects to the template1 database, which is present in every functioning"
 msgstr ""
 
-#: plugins/check_pgsql.c:544
+#: plugins/check_pgsql.c:514
 msgid "PostgreSQL DBMS."
 msgstr ""
 
-#: plugins/check_pgsql.c:546
+#: plugins/check_pgsql.c:516
 msgid "If a query is specified using the -q option, it will be executed after"
 msgstr ""
 
-#: plugins/check_pgsql.c:547
+#: plugins/check_pgsql.c:517
 msgid "connecting to the server. The result from the query has to be numeric."
 msgstr ""
 
-#: plugins/check_pgsql.c:548
+#: plugins/check_pgsql.c:518
 msgid ""
 "Multiple SQL commands, separated by semicolon, are allowed but the result "
 msgstr ""
 
-#: plugins/check_pgsql.c:549
+#: plugins/check_pgsql.c:519
 msgid "of the last command is taken into account only. The value of the first"
 msgstr ""
 
-#: plugins/check_pgsql.c:550
-msgid "column in the first row is used as the check result."
+#: plugins/check_pgsql.c:520
+msgid ""
+"column in the first row is used as the check result. If a second column is"
 msgstr ""
 
-#: plugins/check_pgsql.c:552
+#: plugins/check_pgsql.c:521
+msgid "present in the result set, this is added to the plugin output with a"
+msgstr ""
+
+#: plugins/check_pgsql.c:522
+msgid ""
+"prefix of \"Extra Info:\". This information can be displayed in the system"
+msgstr ""
+
+#: plugins/check_pgsql.c:523
+msgid "executing the plugin."
+msgstr ""
+
+#: plugins/check_pgsql.c:525
 msgid ""
 "See the chapter \"Monitoring Database Activity\" of the PostgreSQL manual"
 msgstr ""
 
-#: plugins/check_pgsql.c:553
+#: plugins/check_pgsql.c:526
 msgid ""
 "for details about how to access internal statistics of the database server."
 msgstr ""
 
-#: plugins/check_pgsql.c:555
+#: plugins/check_pgsql.c:528
 msgid ""
 "For a list of available connection parameters which may be used with the -o"
 msgstr ""
 
-#: plugins/check_pgsql.c:556
+#: plugins/check_pgsql.c:529
 msgid ""
 "command line option, see the documentation for PQconnectdb() in the chapter"
 msgstr ""
 
-#: plugins/check_pgsql.c:557
+#: plugins/check_pgsql.c:530
 msgid ""
 "\"libpq - C Library\" of the PostgreSQL manual. For example, this may be"
 msgstr ""
 
-#: plugins/check_pgsql.c:558
+#: plugins/check_pgsql.c:531
 msgid ""
 "used to specify a service name in pg_service.conf to be used for additional"
 msgstr ""
 
-#: plugins/check_pgsql.c:559
+#: plugins/check_pgsql.c:532
 msgid "connection parameters: -o 'service=<name>' or to specify the SSL mode:"
 msgstr ""
 
-#: plugins/check_pgsql.c:560
+#: plugins/check_pgsql.c:533
 msgid "-o 'sslmode=require'."
 msgstr ""
 
-#: plugins/check_pgsql.c:562
+#: plugins/check_pgsql.c:535
 msgid ""
 "The plugin will connect to a local postmaster if no host is specified. To"
 msgstr ""
 "Ce plugin va se connecter sur un postmaster local si aucun hôte n'est "
 "spécifié."
 
-#: plugins/check_pgsql.c:563
+#: plugins/check_pgsql.c:536
 msgid ""
 "connect to a remote host, be sure that the remote postmaster accepts TCP/IP"
 msgstr ""
 
-#: plugins/check_pgsql.c:564
+#: plugins/check_pgsql.c:537
 msgid "connections (start the postmaster with the -i option)."
 msgstr ""
 
-#: plugins/check_pgsql.c:566
+#: plugins/check_pgsql.c:539
 msgid ""
 "Typically, the monitoring user (unless the --logname option is used) should "
 "be"
 msgstr ""
 
-#: plugins/check_pgsql.c:567
+#: plugins/check_pgsql.c:540
 msgid ""
 "able to connect to the database without a password. The plugin can also send"
 msgstr ""
 
-#: plugins/check_pgsql.c:568
+#: plugins/check_pgsql.c:541
 msgid "a password, but no effort is made to obscure or encrypt the password."
 msgstr ""
 
-#: plugins/check_pgsql.c:601
+#: plugins/check_pgsql.c:575
 #, c-format
 msgid "QUERY %s - %s: %s.\n"
 msgstr ""
 
-#: plugins/check_pgsql.c:601
+#: plugins/check_pgsql.c:575
 msgid "Error with query"
 msgstr ""
 
-#: plugins/check_pgsql.c:607
+#: plugins/check_pgsql.c:581
 #, fuzzy
 msgid "No rows returned"
 msgstr "Pas de données valides reçues"
 
-#: plugins/check_pgsql.c:612
+#: plugins/check_pgsql.c:586
 #, fuzzy
 msgid "No columns returned"
 msgstr "Pas de données valides reçues"
 
-#: plugins/check_pgsql.c:618
+#: plugins/check_pgsql.c:592
 #, fuzzy
 msgid "No data returned"
 msgstr "Pas de données valides reçues"
 
-#: plugins/check_pgsql.c:627
+#: plugins/check_pgsql.c:601
 msgid "Is not a numeric"
 msgstr ""
 
-#: plugins/check_pgsql.c:644
+#: plugins/check_pgsql.c:619
+#, fuzzy, c-format
+msgid "%s returned %f"
+msgstr ". %s renvoie %s"
+
+#: plugins/check_pgsql.c:622
 #, fuzzy, c-format
 msgid "'%s' returned %f"
 msgstr ". %s renvoie %s"
 
-#: plugins/check_ping.c:141
+#: plugins/check_ping.c:143
 msgid "CRITICAL - Could not interpret output from ping command\n"
 msgstr "CRITIQUE - Impossible d'interpréter le réponse de la commande ping\n"
 
-#: plugins/check_ping.c:157
+#: plugins/check_ping.c:159
 #, c-format
 msgid "PING %s - %sPacket loss = %d%%"
 msgstr "PING %s - %s Paquets perdus = %d%%"
 
-#: plugins/check_ping.c:160
+#: plugins/check_ping.c:162
 #, c-format
 msgid "PING %s - %sPacket loss = %d%%, RTA = %2.2f ms"
 msgstr "PING %s - %s Paquets perdus = %d%%, RTA = %2.2f ms"
 
-#: plugins/check_ping.c:257
+#: plugins/check_ping.c:263
 msgid "Could not realloc() addresses\n"
 msgstr "Impossible de réallouer les adresses\n"
 
-#: plugins/check_ping.c:272 plugins/check_ping.c:352
+#: plugins/check_ping.c:278 plugins/check_ping.c:358
 #, c-format
 msgid "<max_packets> (%s) must be a non-negative number\n"
 msgstr "<max_packets> (%s) doit être un nombre positif\n"
 
-#: plugins/check_ping.c:306
+#: plugins/check_ping.c:312
 #, c-format
 msgid "<wpl> (%s) must be an integer percentage\n"
 msgstr "<wpl> (%s) doit être un pourcentage entier\n"
 
-#: plugins/check_ping.c:317
+#: plugins/check_ping.c:323
 #, c-format
 msgid "<cpl> (%s) must be an integer percentage\n"
 msgstr "<cpl> (%s) doit être un pourcentage entier\n"
 
-#: plugins/check_ping.c:328
+#: plugins/check_ping.c:334
 #, c-format
 msgid "<wrta> (%s) must be a non-negative number\n"
 msgstr "<wrta> (%s) doit être un nombre positif\n"
 
-#: plugins/check_ping.c:339
+#: plugins/check_ping.c:345
 #, c-format
 msgid "<crta> (%s) must be a non-negative number\n"
 msgstr "<crta> (%s) doit être un nombre positif\n"
 
-#: plugins/check_ping.c:372
+#: plugins/check_ping.c:378
 #, c-format
 msgid ""
 "%s: Warning threshold must be integer or percentage!\n"
 "\n"
 msgstr "%s: Le seuil d'avertissement doit être un entier ou un pourcentage!\n"
 
-#: plugins/check_ping.c:385
+#: plugins/check_ping.c:391
 #, c-format
 msgid "<wrta> was not set\n"
 msgstr "<wrta> n'a pas été indiqué\n"
 
-#: plugins/check_ping.c:389
+#: plugins/check_ping.c:395
 #, c-format
 msgid "<crta> was not set\n"
 msgstr "<crta> n'a pas été indiqué\n"
 
-#: plugins/check_ping.c:393
+#: plugins/check_ping.c:399
 #, c-format
 msgid "<wpl> was not set\n"
 msgstr " <wpl> n'a pas été indiqué\n"
 
-#: plugins/check_ping.c:397
+#: plugins/check_ping.c:403
 #, c-format
 msgid "<cpl> was not set\n"
 msgstr "<cpl> n'a pas été indiqué\n"
 
-#: plugins/check_ping.c:401
+#: plugins/check_ping.c:407
 #, c-format
 msgid "<wrta> (%f) cannot be larger than <crta> (%f)\n"
 msgstr "<wrta> (%f) ne peut pas être plus large que <crta> (%f)\n"
 
-#: plugins/check_ping.c:405
+#: plugins/check_ping.c:411
 #, c-format
 msgid "<wpl> (%d) cannot be larger than <cpl> (%d)\n"
 msgstr "<wpl> (%d) ne peut pas être plus large que <cpl> (%d)\n"
 
-#: plugins/check_ping.c:442
+#: plugins/check_ping.c:448
 #, c-format
 msgid "Cannot open stderr for %s\n"
 msgstr "Impossible d'ouvrir le canal d'erreur standard pour %s\n"
 
-#: plugins/check_ping.c:492 plugins/check_ping.c:494
+#: plugins/check_ping.c:505 plugins/check_ping.c:507
 msgid "System call sent warnings to stderr "
 msgstr ""
 "Les appel système enverront leurs messages d'avertissement vers le canal "
 "d'erreur standard"
 
-#: plugins/check_ping.c:519
+#: plugins/check_ping.c:533
 #, fuzzy, c-format
 msgid "CRITICAL - Network Unreachable (%s)\n"
 msgstr "CRITIQUE - Le réseau est inaccessible (%s)"
 
-#: plugins/check_ping.c:521
+#: plugins/check_ping.c:535
 #, fuzzy, c-format
 msgid "CRITICAL - Host Unreachable (%s)\n"
 msgstr "CRITIQUE - Hôte inaccessible (%s)"
 
-#: plugins/check_ping.c:523
+#: plugins/check_ping.c:537
 #, fuzzy, c-format
 msgid "CRITICAL - Bogus ICMP: Port Unreachable (%s)\n"
 msgstr "CRITIQUE - Paquet ICMP incorrect: Port inaccessible (%s)"
 
-#: plugins/check_ping.c:525
+#: plugins/check_ping.c:539
 #, fuzzy, c-format
 msgid "CRITICAL - Bogus ICMP: Protocol Unreachable (%s)\n"
 msgstr "CRITIQUE - Paquet ICMP incorrect: Protocole inaccessible (%s)"
 
-#: plugins/check_ping.c:527
+#: plugins/check_ping.c:541
 #, fuzzy, c-format
 msgid "CRITICAL - Network Prohibited (%s)\n"
 msgstr "CRITIQUE - L'accès au réseau est interdit (%s)"
 
-#: plugins/check_ping.c:529
+#: plugins/check_ping.c:543
 #, fuzzy, c-format
 msgid "CRITICAL - Host Prohibited (%s)\n"
 msgstr "CRITIQUE - L'accès a l'hôte est interdit (%s)"
 
-#: plugins/check_ping.c:531
+#: plugins/check_ping.c:545
 #, fuzzy, c-format
 msgid "CRITICAL - Packet Filtered (%s)\n"
 msgstr "CRITIQUE - Paquet filtré (%s)"
 
-#: plugins/check_ping.c:533
+#: plugins/check_ping.c:547
 #, fuzzy, c-format
 msgid "CRITICAL - Host not found (%s)\n"
 msgstr "CRITIQUE - Hôte non trouvé (%s)"
 
-#: plugins/check_ping.c:535
+#: plugins/check_ping.c:549
 #, fuzzy, c-format
 msgid "CRITICAL - Time to live exceeded (%s)\n"
 msgstr "CRITIQUE - La durée de vie du paquet est dépassée (%s)"
 
-#: plugins/check_ping.c:537
+#: plugins/check_ping.c:551
 #, fuzzy, c-format
 msgid "CRITICAL - Destination Unreachable (%s)\n"
 msgstr "CRITIQUE - Hôte inaccessible (%s)"
 
-#: plugins/check_ping.c:544
+#: plugins/check_ping.c:558
 #, fuzzy
 msgid "Unable to realloc warn_text\n"
 msgstr "Impossible de réattribuer le texte d'avertissement"
 
-#: plugins/check_ping.c:561
+#: plugins/check_ping.c:575
 #, c-format
 msgid "Use ping to check connection statistics for a remote host."
 msgstr ""
 "Utilise ping pour vérifier les statistiques de connections d'un hôte distant."
 
-#: plugins/check_ping.c:573
+#: plugins/check_ping.c:587
 msgid "host to ping"
 msgstr "hôte à tester"
 
-#: plugins/check_ping.c:579
+#: plugins/check_ping.c:593
 msgid "number of ICMP ECHO packets to send"
 msgstr "nombre de paquets ICMP à envoyer"
 
-#: plugins/check_ping.c:580
+#: plugins/check_ping.c:594
 #, c-format
 msgid "(Default: %d)\n"
 msgstr "(Défaut: %d)\n"
 
-#: plugins/check_ping.c:582
+#: plugins/check_ping.c:596
 msgid "show HTML in the plugin output (obsoleted by urlize)"
 msgstr ""
 
-#: plugins/check_ping.c:587
+#: plugins/check_ping.c:601
 msgid "THRESHOLD is <rta>,<pl>% where <rta> is the round trip average travel"
 msgstr ""
 "Le seuil est <rta>,<pl>% où <rta> est le temps moyen pour l'aller retour (ms)"
 
-#: plugins/check_ping.c:588
+#: plugins/check_ping.c:602
 msgid "time (ms) which triggers a WARNING or CRITICAL state, and <pl> is the"
 msgstr "qui déclenche un résultat AVERTISSEMENT ou CRITIQUE, et <pl> est le "
 
-#: plugins/check_ping.c:589
+#: plugins/check_ping.c:603
 msgid "percentage of packet loss to trigger an alarm state."
 msgstr "pourcentage de paquets perdus pour déclencher une alarme."
 
-#: plugins/check_ping.c:592
+#: plugins/check_ping.c:606
 msgid ""
 "This plugin uses the ping command to probe the specified host for packet loss"
 msgstr ""
 "Ce plugin utilise la commande ping pour vérifier l'hôte spécifié pour les "
 "pertes de paquets"
 
-#: plugins/check_ping.c:593
+#: plugins/check_ping.c:607
 msgid ""
 "(percentage) and round trip average (milliseconds). It can produce HTML "
 "output"
 msgstr ""
 
-#: plugins/check_ping.c:594
+#: plugins/check_ping.c:608
 msgid ""
 "linking to a traceroute CGI contributed by Ian Cass. The CGI can be found in"
 msgstr ""
 
-#: plugins/check_ping.c:595
+#: plugins/check_ping.c:609
 msgid "the contrib area of the downloads section at http://www.nagios.org/"
 msgstr ""
 
-#: plugins/check_procs.c:193
+#: plugins/check_procs.c:197
 #, c-format
 msgid "CMD: %s\n"
 msgstr "Commande: %s\n"
 
-#: plugins/check_procs.c:198
+#: plugins/check_procs.c:202
 msgid "System call sent warnings to stderr"
 msgstr ""
 "L'appel système à retourné des avertissement vers le canal d'erreur standard"
 
-#: plugins/check_procs.c:326
+#: plugins/check_procs.c:349
 #, c-format
 msgid "Not parseable: %s"
 msgstr "Impossible de parcourir les arguments: %s"
 
-#: plugins/check_procs.c:331
+#: plugins/check_procs.c:354
 #, c-format
 msgid "Unable to read output\n"
 msgstr "Impossible de lire les données en entrée\n"
 
-#: plugins/check_procs.c:348
+#: plugins/check_procs.c:371
 #, c-format
 msgid "%d warn out of "
 msgstr "%d avertissements sur"
 
-#: plugins/check_procs.c:353
+#: plugins/check_procs.c:376
 #, c-format
 msgid "%d crit, %d warn out of "
 msgstr "%d crit, %d alertes sur "
 
-#: plugins/check_procs.c:359
+#: plugins/check_procs.c:382
 #, c-format
 msgid " with %s"
 msgstr " avec %s"
 
-#: plugins/check_procs.c:453
+#: plugins/check_procs.c:477
 msgid "Parent Process ID must be an integer!"
 msgstr "L'identifiant du processus parent doit être un entier!"
 
-#: plugins/check_procs.c:459 plugins/check_procs.c:586
+#: plugins/check_procs.c:483 plugins/check_procs.c:627
 #, c-format
 msgid "%s%sSTATE = %s"
 msgstr "%s%sETAT = %s"
 
-#: plugins/check_procs.c:468
+#: plugins/check_procs.c:492
 msgid "UID was not found"
 msgstr "L'UID n'a pas été trouvé"
 
-#: plugins/check_procs.c:474
+#: plugins/check_procs.c:498
 msgid "User name was not found"
 msgstr "L'utilisateur n'a pas été trouvé"
 
-#: plugins/check_procs.c:489
+#: plugins/check_procs.c:513
 #, c-format
 msgid "%s%scommand name '%s'"
 msgstr "%s%snom de la commande '%s'"
 
-#: plugins/check_procs.c:524
+#: plugins/check_procs.c:522
+#, c-format
+msgid "%s%sexclude progs '%s'"
+msgstr ""
+
+#: plugins/check_procs.c:565
 msgid "RSS must be an integer!"
 msgstr "RSS doit être un entier!"
 
-#: plugins/check_procs.c:531
+#: plugins/check_procs.c:572
 msgid "VSZ must be an integer!"
 msgstr "VSZ doit être un entier!"
 
-#: plugins/check_procs.c:539
+#: plugins/check_procs.c:580
 msgid "PCPU must be a float!"
 msgstr "PCPU doit être un nombre en virgule flottante!"
 
-#: plugins/check_procs.c:563
+#: plugins/check_procs.c:604
 msgid "Metric must be one of PROCS, VSZ, RSS, CPU, ELAPSED!"
 msgstr "Metric doit être l'un des PROCS, VSZ, RSS, CPU, ELAPSED!"
 
-#: plugins/check_procs.c:694
+#: plugins/check_procs.c:735
 msgid ""
 "Checks all processes and generates WARNING or CRITICAL states if the "
 "specified"
 msgstr ""
 
-#: plugins/check_procs.c:695
+#: plugins/check_procs.c:736
 msgid ""
 "metric is outside the required threshold ranges. The metric defaults to "
 "number"
 msgstr ""
 
-#: plugins/check_procs.c:696
+#: plugins/check_procs.c:737
 msgid ""
 "of processes.  Search filters can be applied to limit the processes to check."
 msgstr ""
 
-#: plugins/check_procs.c:705
+#: plugins/check_procs.c:746
 msgid "Generate warning state if metric is outside this range"
 msgstr ""
 
-#: plugins/check_procs.c:707
+#: plugins/check_procs.c:748
 msgid "Generate critical state if metric is outside this range"
 msgstr ""
 
-#: plugins/check_procs.c:709
+#: plugins/check_procs.c:750
 msgid "Check thresholds against metric. Valid types:"
 msgstr ""
 
-#: plugins/check_procs.c:710
+#: plugins/check_procs.c:751
 msgid "PROCS   - number of processes (default)"
 msgstr "PROCS   - nombre de  processus (défaut)"
 
-#: plugins/check_procs.c:711
+#: plugins/check_procs.c:752
 msgid "VSZ     - virtual memory size"
 msgstr "VSZ     - taille mémoire virtuelle"
 
-#: plugins/check_procs.c:712
+#: plugins/check_procs.c:753
 msgid "RSS     - resident set memory size"
 msgstr ""
 
-#: plugins/check_procs.c:713
+#: plugins/check_procs.c:754
 msgid "CPU     - percentage CPU"
 msgstr "CPU     - pourcentage du processeur"
 
-#: plugins/check_procs.c:716
+#: plugins/check_procs.c:757
 msgid "ELAPSED - time elapsed in seconds"
 msgstr "ELAPSED - temps écoulé en secondes"
 
-#: plugins/check_procs.c:721
+#: plugins/check_procs.c:762
 msgid "Extra information. Up to 3 verbosity levels"
 msgstr "informations supplémentaires. Jusqu'à 3 niveaux de verbosité"
 
-#: plugins/check_procs.c:724
+#: plugins/check_procs.c:765
 msgid "Filter own process the traditional way by PID instead of /proc/pid/exe"
 msgstr ""
 
-#: plugins/check_procs.c:729
+#: plugins/check_procs.c:770
 msgid "Only scan for processes that have, in the output of `ps`, one or"
 msgstr ""
 
-#: plugins/check_procs.c:730
+#: plugins/check_procs.c:771
 msgid "more of the status flags you specify (for example R, Z, S, RS,"
 msgstr ""
 
-#: plugins/check_procs.c:731
+#: plugins/check_procs.c:772
 msgid "RSZDT, plus others based on the output of your 'ps' command)."
 msgstr ""
 
-#: plugins/check_procs.c:733
+#: plugins/check_procs.c:774
 msgid "Only scan for children of the parent process ID indicated."
 msgstr ""
 
-#: plugins/check_procs.c:735
+#: plugins/check_procs.c:776
 msgid "Only scan for processes with VSZ higher than indicated."
 msgstr ""
 
-#: plugins/check_procs.c:737
+#: plugins/check_procs.c:778
 msgid "Only scan for processes with RSS higher than indicated."
 msgstr ""
 
-#: plugins/check_procs.c:739
+#: plugins/check_procs.c:780
 msgid "Only scan for processes with PCPU higher than indicated."
 msgstr ""
 
-#: plugins/check_procs.c:741
+#: plugins/check_procs.c:782
 msgid "Only scan for processes with user name or ID indicated."
 msgstr ""
 
-#: plugins/check_procs.c:743
+#: plugins/check_procs.c:784
 msgid "Only scan for processes with args that contain STRING."
 msgstr ""
 
-#: plugins/check_procs.c:745
+#: plugins/check_procs.c:786
 msgid "Only scan for processes with args that contain the regex STRING."
 msgstr ""
 
-#: plugins/check_procs.c:747
+#: plugins/check_procs.c:788
 msgid "Only scan for exact matches of COMMAND (without path)."
 msgstr ""
 
-#: plugins/check_procs.c:749
+#: plugins/check_procs.c:790
+msgid "Exclude processes which match this comma separated list"
+msgstr ""
+
+#: plugins/check_procs.c:792
 msgid "Only scan for non kernel threads (works on Linux only)."
 msgstr ""
 
-#: plugins/check_procs.c:751
+#: plugins/check_procs.c:794
 #, c-format
 msgid ""
 "\n"
@@ -4133,7 +4392,7 @@ msgstr ""
 "est à l'intérieur du seuil\n"
 "\n"
 
-#: plugins/check_procs.c:756
+#: plugins/check_procs.c:799
 #, c-format
 msgid ""
 "This plugin checks the number of currently running processes and\n"
@@ -4150,165 +4409,186 @@ msgstr ""
 "état actuel (ex: 'Z'), ou par le nombre de processus en cours d'exécution\n"
 "\n"
 
-#: plugins/check_procs.c:765
+#: plugins/check_procs.c:808
 msgid "Warning if not two processes with command name portsentry."
 msgstr ""
 
-#: plugins/check_procs.c:766
+#: plugins/check_procs.c:809
 msgid "Critical if < 2 or > 1024 processes"
 msgstr ""
 
-#: plugins/check_procs.c:768
+#: plugins/check_procs.c:811
+msgid "Critical if not at least 1 process with command sshd"
+msgstr ""
+
+#: plugins/check_procs.c:813
+msgid "Warning if > 1024 processes with command name sshd."
+msgstr ""
+
+#: plugins/check_procs.c:814
+msgid "Critical if < 1 processes with command name sshd."
+msgstr ""
+
+#: plugins/check_procs.c:816
 msgid "Warning alert if > 10 processes with command arguments containing"
 msgstr ""
 
-#: plugins/check_procs.c:769
+#: plugins/check_procs.c:817
 msgid "'/usr/local/bin/perl' and owned by root"
 msgstr ""
 
-#: plugins/check_procs.c:771
+#: plugins/check_procs.c:819
 msgid "Alert if VSZ of any processes over 50K or 100K"
 msgstr ""
 
-#: plugins/check_procs.c:773
-#, c-format
-msgid "Alert if CPU of any processes over 10%% or 20%%"
+#: plugins/check_procs.c:821
+msgid "Alert if CPU of any processes over 10% or 20%"
 msgstr ""
 
-#: plugins/check_radius.c:165
-msgid "Config file error"
+#: plugins/check_radius.c:181
+#, fuzzy
+msgid "Config file error\n"
 msgstr "Erreur dans le fichier de configuration"
 
-#: plugins/check_radius.c:174
-msgid "Out of Memory?"
+#: plugins/check_radius.c:190
+#, fuzzy
+msgid "Out of Memory?\n"
 msgstr "Manque de Mémoire?"
 
-#: plugins/check_radius.c:178
-msgid "Invalid NAS-Identifier"
+#: plugins/check_radius.c:194
+#, fuzzy
+msgid "Invalid NAS-Identifier\n"
 msgstr "NAS-Identifier invalide"
 
-#: plugins/check_radius.c:183 plugins/check_radius.c:185
-#: plugins/check_radius.c:191
-msgid "Invalid NAS-IP-Address"
+#: plugins/check_radius.c:199 plugins/check_smtp.c:155
+#, c-format
+msgid "gethostname() failed!\n"
+msgstr "La commande gethostname() à échoué\n"
+
+#: plugins/check_radius.c:203 plugins/check_radius.c:206
+#, fuzzy
+msgid "Invalid NAS-IP-Address\n"
 msgstr "NAS-IP-Address invalide"
 
-#: plugins/check_radius.c:188
-msgid "Can't find local IP for NAS-IP-Address"
-msgstr "Impossible de trouver une addresse IP locale pour le NAS-IP-Address"
-
-#: plugins/check_radius.c:202
-msgid "Timeout"
+#: plugins/check_radius.c:217
+#, fuzzy
+msgid "Timeout\n"
 msgstr "Temps dépassé"
 
-#: plugins/check_radius.c:204
-msgid "Auth Error"
+#: plugins/check_radius.c:219
+#, fuzzy
+msgid "Auth Error\n"
 msgstr "Erreur d'authentification"
 
-#: plugins/check_radius.c:206
-msgid "Auth Failed"
+#: plugins/check_radius.c:221
+#, fuzzy
+msgid "Auth Failed\n"
 msgstr "L'authentification à échoué"
 
-#: plugins/check_radius.c:208
-msgid "Bad Response"
+#: plugins/check_radius.c:223
+#, fuzzy
+msgid "Bad Response\n"
 msgstr "Réponse invalide"
 
-#: plugins/check_radius.c:212
-msgid "Auth OK"
+#: plugins/check_radius.c:227
+#, fuzzy
+msgid "Auth OK\n"
 msgstr "L'authentification à réussi"
 
-#: plugins/check_radius.c:213
+#: plugins/check_radius.c:228
 #, c-format
 msgid "Unexpected result code %d"
 msgstr "Résultat inattendu: %d"
 
-#: plugins/check_radius.c:302
+#: plugins/check_radius.c:317
 msgid "Number of retries must be a positive integer"
 msgstr "Le nombre d'essai doit être un entier positif"
 
-#: plugins/check_radius.c:316
+#: plugins/check_radius.c:331
 msgid "User not specified"
 msgstr "L'utilisateur n'a pas été spécifié"
 
-#: plugins/check_radius.c:318
+#: plugins/check_radius.c:333
 msgid "Password not specified"
 msgstr "Le mot de passe n'a pas été spécifié"
 
-#: plugins/check_radius.c:320
+#: plugins/check_radius.c:335
 msgid "Configuration file not specified"
 msgstr "Le fichier de configuration n'a pas été spécifié"
 
-#: plugins/check_radius.c:338
+#: plugins/check_radius.c:353
 msgid "Tests to see if a RADIUS server is accepting connections."
 msgstr "Teste si un serveur RADIUS accepte les connections."
 
-#: plugins/check_radius.c:350
+#: plugins/check_radius.c:365
 msgid "The user to authenticate"
 msgstr ""
 
-#: plugins/check_radius.c:352
+#: plugins/check_radius.c:367
 msgid "Password for authentication (SECURITY RISK)"
 msgstr ""
 
-#: plugins/check_radius.c:354
+#: plugins/check_radius.c:369
 msgid "NAS identifier"
 msgstr ""
 
-#: plugins/check_radius.c:356
+#: plugins/check_radius.c:371
 msgid "NAS IP Address"
 msgstr "Adresse IP NAS"
 
-#: plugins/check_radius.c:358
+#: plugins/check_radius.c:373
 msgid "Configuration file"
 msgstr "Fichier de configuration"
 
-#: plugins/check_radius.c:360
+#: plugins/check_radius.c:375
 msgid "Response string to expect from the server"
 msgstr ""
 
-#: plugins/check_radius.c:362
+#: plugins/check_radius.c:377
 msgid "Number of times to retry a failed connection"
 msgstr ""
 
-#: plugins/check_radius.c:367
+#: plugins/check_radius.c:382
 msgid ""
 "This plugin tests a RADIUS server to see if it is accepting connections."
 msgstr ""
 "Ce plugin teste un serveur RADIUS afin de vérifier si il accepte les "
 "connections."
 
-#: plugins/check_radius.c:368
+#: plugins/check_radius.c:383
 msgid ""
 "The server to test must be specified in the invocation, as well as a user"
 msgstr ""
 
-#: plugins/check_radius.c:369
+#: plugins/check_radius.c:384
 msgid ""
 "name and password. A configuration file may also be present. The format of"
 msgstr ""
 
-#: plugins/check_radius.c:370
+#: plugins/check_radius.c:385
 msgid ""
 "the configuration file is described in the radiusclient library sources."
 msgstr ""
 
-#: plugins/check_radius.c:371
+#: plugins/check_radius.c:386
 msgid "The password option presents a substantial security issue because the"
 msgstr ""
 
-#: plugins/check_radius.c:372
+#: plugins/check_radius.c:387
 msgid ""
 "password can possibly be determined by careful watching of the command line"
 msgstr ""
 
-#: plugins/check_radius.c:373
-msgid "in a process listing. This risk is exacerbated because the monitor will"
+#: plugins/check_radius.c:388
+msgid "in a process listing. This risk is exacerbated because the plugin will"
 msgstr ""
 
-#: plugins/check_radius.c:374
-msgid "run the plugin at regular predictable intervals. Please be sure that"
+#: plugins/check_radius.c:389
+msgid ""
+"typically be executed at regular predictable intervals. Please be sure that"
 msgstr ""
 
-#: plugins/check_radius.c:375
+#: plugins/check_radius.c:390
 msgid "the password used does not allow access to sensitive system resources."
 msgstr ""
 
@@ -4322,760 +4602,868 @@ msgstr "Impossible de se connecter à %s sur le port %d\n"
 msgid "No data received from %s\n"
 msgstr "Pas de données reçues de %s\n"
 
-#: plugins/check_real.c:118 plugins/check_real.c:191
+#: plugins/check_real.c:118 plugins/check_real.c:192
 msgid "Invalid REAL response received from host"
 msgstr "Réponses REAL invalide reçue de l'hôte"
 
-#: plugins/check_real.c:120 plugins/check_real.c:193
+#: plugins/check_real.c:120 plugins/check_real.c:194
 #, c-format
 msgid "Invalid REAL response received from host on port %d\n"
 msgstr "Réponses REAL invalide reçue de l'hôte sur le port %d\n"
 
-#: plugins/check_real.c:184 plugins/check_tcp.c:311
+#: plugins/check_real.c:185 plugins/check_tcp.c:315
 #, c-format
 msgid "No data received from host\n"
 msgstr "Pas de données reçues de l'hôte\n"
 
-#: plugins/check_real.c:247
+#: plugins/check_real.c:248
 #, c-format
 msgid "REAL %s - %d second response time\n"
 msgstr "REAL %s - %d secondes de temps de réponse\n"
 
-#: plugins/check_real.c:336 plugins/check_ups.c:536
+#: plugins/check_real.c:337 plugins/check_ups.c:539
 msgid "Warning time must be a positive integer"
 msgstr "Le seuil d'avertissement doit être un entier positif"
 
-#: plugins/check_real.c:345 plugins/check_ups.c:527
+#: plugins/check_real.c:346 plugins/check_ups.c:530
 msgid "Critical time must be a positive integer"
 msgstr "Le seuil critique doit être un entier positif"
 
-#: plugins/check_real.c:381
+#: plugins/check_real.c:382
 msgid "You must provide a server to check"
 msgstr "Vous devez fournir un serveur à vérifier"
 
-#: plugins/check_real.c:413
+#: plugins/check_real.c:414
 msgid "This plugin tests the REAL service on the specified host."
 msgstr "Ce plugin teste le service REAL sur l'hôte spécifié."
 
-#: plugins/check_real.c:425
+#: plugins/check_real.c:426
 msgid "Connect to this url"
 msgstr ""
 
-#: plugins/check_real.c:427
+#: plugins/check_real.c:428
 #, c-format
 msgid "String to expect in first line of server response (default: %s)\n"
 msgstr ""
 "Texte attendu dans la première ligne de réponse du serveur (défaut: %s)\n"
 
-#: plugins/check_real.c:437
+#: plugins/check_real.c:438
 msgid "This plugin will attempt to open an RTSP connection with the host."
 msgstr "Ce plugin va essayer d'ouvrir un connexion RTSP avec l'hôte."
 
-#: plugins/check_real.c:438 plugins/check_smtp.c:830
+#: plugins/check_real.c:439 plugins/check_smtp.c:862
 msgid "Successful connects return STATE_OK, refusals and timeouts return"
-msgstr ""
-
-#: plugins/check_real.c:439
-msgid ""
-"STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful connects,"
 msgstr ""
 
 #: plugins/check_real.c:440
 msgid ""
-"but incorrect response messages from the host result in STATE_WARNING return"
+"STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful connects,"
 msgstr ""
 
 #: plugins/check_real.c:441
+msgid ""
+"but incorrect response messages from the host result in STATE_WARNING return"
+msgstr ""
+
+#: plugins/check_real.c:442
 msgid "values."
 msgstr ""
 
-#: plugins/check_smtp.c:150 plugins/check_swap.c:265 plugins/check_swap.c:271
+#: plugins/check_smtp.c:151 plugins/check_swap.c:283 plugins/check_swap.c:289
 #, c-format
 msgid "malloc() failed!\n"
 msgstr "l'allocation mémoire à échoué!\n"
 
-#: plugins/check_smtp.c:154
-#, c-format
-msgid "gethostname() failed!\n"
-msgstr "La commande gethostname() à échoué\n"
-
-#: plugins/check_smtp.c:189 plugins/check_smtp.c:213
+#: plugins/check_smtp.c:199 plugins/check_smtp.c:211
 #, c-format
 msgid "recv() failed\n"
 msgstr "La commande recv() à échoué\n"
 
-#: plugins/check_smtp.c:200
-#, c-format
-msgid "Invalid SMTP response received from host: %s\n"
-msgstr "Réponse SMTP reçue de l'hôte invalide: %s\n"
-
-#: plugins/check_smtp.c:202
-#, c-format
-msgid "Invalid SMTP response received from host on port %d: %s\n"
-msgstr "Réponse SMTP reçue de l'hôte sur le port %d invalide: %s\n"
-
-#: plugins/check_smtp.c:223
+#: plugins/check_smtp.c:221
 #, c-format
 msgid "WARNING - TLS not supported by server\n"
 msgstr "AVERTISSEMENT: - TLS n'est pas supporté par ce serveur\n"
 
-#: plugins/check_smtp.c:235
+#: plugins/check_smtp.c:233
 #, c-format
 msgid "Server does not support STARTTLS\n"
 msgstr "Le serveur ne supporte pas STARTTLS\n"
 
-#: plugins/check_smtp.c:241
+#: plugins/check_smtp.c:239
 #, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr "CRITIQUE - Impossible de créer le contexte SSL.\n"
 
-#: plugins/check_smtp.c:261
+#: plugins/check_smtp.c:259
 msgid "SMTP UNKNOWN - Cannot send EHLO command via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:266
+#: plugins/check_smtp.c:264
 #, c-format
 msgid "sent %s"
 msgstr "envoyé %s"
 
-#: plugins/check_smtp.c:268
+#: plugins/check_smtp.c:266
 msgid "SMTP UNKNOWN - Cannot read EHLO response via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:303 plugins/check_snmp.c:806
+#: plugins/check_smtp.c:296
+#, c-format
+msgid "Invalid SMTP response received from host: %s\n"
+msgstr "Réponse SMTP reçue de l'hôte invalide: %s\n"
+
+#: plugins/check_smtp.c:298
+#, c-format
+msgid "Invalid SMTP response received from host on port %d: %s\n"
+msgstr "Réponse SMTP reçue de l'hôte sur le port %d invalide: %s\n"
+
+#: plugins/check_smtp.c:321 plugins/check_snmp.c:865
 #, c-format
 msgid "Could Not Compile Regular Expression"
 msgstr "Impossible de compiler l'expression rationnelle"
 
-#: plugins/check_smtp.c:312
+#: plugins/check_smtp.c:330
 #, c-format
 msgid "SMTP %s - Invalid response '%s' to command '%s'\n"
 msgstr "SMTP %s - réponse invalide de '%s' à la commande '%s'\n"
 
-#: plugins/check_smtp.c:316 plugins/check_snmp.c:511
+#: plugins/check_smtp.c:334 plugins/check_snmp.c:540
 #, c-format
 msgid "Execute Error: %s\n"
 msgstr "Erreur d'exécution: %s\n"
 
-#: plugins/check_smtp.c:330
+#: plugins/check_smtp.c:348
 msgid "no authuser specified, "
 msgstr "Pas d'utilisateur pour l'authentification spécifié, "
 
-#: plugins/check_smtp.c:335
+#: plugins/check_smtp.c:353
 msgid "no authpass specified, "
 msgstr "pas de mot de passe spécifié, "
 
-#: plugins/check_smtp.c:342 plugins/check_smtp.c:363 plugins/check_smtp.c:383
-#: plugins/check_smtp.c:688
+#: plugins/check_smtp.c:360 plugins/check_smtp.c:381 plugins/check_smtp.c:401
+#: plugins/check_smtp.c:714
 #, c-format
 msgid "sent %s\n"
 msgstr "envoyé %s\n"
 
-#: plugins/check_smtp.c:345
+#: plugins/check_smtp.c:363
 msgid "recv() failed after AUTH LOGIN, "
 msgstr "recv() à échoué après AUTH LOGIN, "
 
-#: plugins/check_smtp.c:350 plugins/check_smtp.c:371 plugins/check_smtp.c:391
-#: plugins/check_smtp.c:699
+#: plugins/check_smtp.c:368 plugins/check_smtp.c:389 plugins/check_smtp.c:409
+#: plugins/check_smtp.c:725
 #, c-format
 msgid "received %s\n"
 msgstr "reçu %s\n"
 
-#: plugins/check_smtp.c:354
+#: plugins/check_smtp.c:372
 msgid "invalid response received after AUTH LOGIN, "
 msgstr "Réponse invalide reçue après AUTH LOGIN, "
 
-#: plugins/check_smtp.c:367
+#: plugins/check_smtp.c:385
 msgid "recv() failed after sending authuser, "
 msgstr "La commande recv() a échoué après authuser, "
 
-#: plugins/check_smtp.c:375
+#: plugins/check_smtp.c:393
 msgid "invalid response received after authuser, "
 msgstr "Réponse invalide reçue après authuser, "
 
-#: plugins/check_smtp.c:387
+#: plugins/check_smtp.c:405
 msgid "recv() failed after sending authpass, "
 msgstr "la commande recv() à échoué après authpass, "
 
-#: plugins/check_smtp.c:395
+#: plugins/check_smtp.c:413
 msgid "invalid response received after authpass, "
 msgstr "Réponse invalide reçue après authpass, "
 
-#: plugins/check_smtp.c:402
+#: plugins/check_smtp.c:420
 msgid "only authtype LOGIN is supported, "
 msgstr "seul la méthode d'authentification LOGIN est supportée, "
 
-#: plugins/check_smtp.c:426
+#: plugins/check_smtp.c:444
 #, c-format
 msgid "SMTP %s - %s%.3f sec. response time%s%s|%s\n"
 msgstr "SMTP %s - %s%.3f sec. de temps de réponse%s%s|%s\n"
 
-#: plugins/check_smtp.c:536 plugins/check_smtp.c:548
+#: plugins/check_smtp.c:556 plugins/check_smtp.c:568
 #, c-format
 msgid "Could not realloc() units [%d]\n"
 msgstr "Impossible de réallouer des unités [%d]\n"
 
-#: plugins/check_smtp.c:556
+#: plugins/check_smtp.c:576
 #, fuzzy
 msgid "Critical time must be a positive"
 msgstr "Le seuil critique doit être un entier positif"
 
-#: plugins/check_smtp.c:564
+#: plugins/check_smtp.c:584
 #, fuzzy
 msgid "Warning time must be a positive"
 msgstr "Le seuil d'avertissement doit être un entier positif"
 
-#: plugins/check_smtp.c:611
+#: plugins/check_smtp.c:627
 msgid "SSL support not available - install OpenSSL and recompile"
 msgstr "SSL n'est pas disponible - installer OpenSSL et recompilez"
 
-#: plugins/check_smtp.c:679 plugins/check_smtp.c:684
+#: plugins/check_smtp.c:705 plugins/check_smtp.c:710
 #, c-format
 msgid "Connection closed by server before sending QUIT command\n"
 msgstr ""
 
-#: plugins/check_smtp.c:694
+#: plugins/check_smtp.c:720
 #, c-format
 msgid "recv() failed after QUIT."
 msgstr "recv() à échoué après QUIT."
 
-#: plugins/check_smtp.c:696
+#: plugins/check_smtp.c:722
 #, c-format
 msgid "Connection reset by peer."
 msgstr ""
 
-#: plugins/check_smtp.c:784
+#: plugins/check_smtp.c:812
 msgid "This plugin will attempt to open an SMTP connection with the host."
 msgstr "Ce plugin va essayer d'ouvrir un connexion SMTP avec l'hôte."
 
-#: plugins/check_smtp.c:798
+#: plugins/check_smtp.c:826
 #, c-format
 msgid "    String to expect in first line of server response (default: '%s')\n"
 msgstr ""
 "   Texte attendu dans la première ligne de réponse du serveur (défaut: "
 "'%s')\n"
 
-#: plugins/check_smtp.c:800
+#: plugins/check_smtp.c:828
 msgid "SMTP command (may be used repeatedly)"
 msgstr "Commande SMTP (peut être utilisé plusieurs fois)"
 
-#: plugins/check_smtp.c:802
+#: plugins/check_smtp.c:830
 msgid "Expected response to command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:804
+#: plugins/check_smtp.c:832
 msgid "FROM-address to include in MAIL command, required by Exchange 2000"
 msgstr ""
 
-#: plugins/check_smtp.c:806
+#: plugins/check_smtp.c:834
 msgid "FQDN used for HELO"
 msgstr ""
 
-#: plugins/check_smtp.c:809 plugins/check_tcp.c:665
+#: plugins/check_smtp.c:836
+msgid "Use PROXY protocol prefix for the connection."
+msgstr ""
+
+#: plugins/check_smtp.c:839 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."
 msgstr "Nombre de jours minimum pour que le certificat soit valide."
 
-#: plugins/check_smtp.c:811
+#: plugins/check_smtp.c:841
 msgid "Use STARTTLS for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:815
+#: plugins/check_smtp.c:845
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"
 msgstr ""
 
-#: plugins/check_smtp.c:817
+#: plugins/check_smtp.c:847
 msgid "SMTP AUTH username"
 msgstr ""
 
-#: plugins/check_smtp.c:819
+#: plugins/check_smtp.c:849
 msgid "SMTP AUTH password"
 msgstr ""
 
-#: plugins/check_smtp.c:821
+#: plugins/check_smtp.c:851
+msgid "Send LHLO instead of HELO/EHLO"
+msgstr ""
+
+#: plugins/check_smtp.c:853
 msgid "Ignore failure when sending QUIT command to server"
 msgstr ""
 
-#: plugins/check_smtp.c:831
+#: plugins/check_smtp.c:863
 msgid "STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful"
 msgstr ""
 
-#: plugins/check_smtp.c:832
+#: plugins/check_smtp.c:864
 msgid "connects, but incorrect response messages from the host result in"
 msgstr ""
 
-#: plugins/check_smtp.c:833
+#: plugins/check_smtp.c:865
 msgid "STATE_WARNING return values."
 msgstr ""
 
-#: plugins/check_snmp.c:169 plugins/check_snmp.c:582
+#: plugins/check_snmp.c:177 plugins/check_snmp.c:626
 msgid "Cannot malloc"
 msgstr ""
 
-#: plugins/check_snmp.c:356
+#: plugins/check_snmp.c:368
 #, c-format
 msgid "External command error: %s\n"
 msgstr "Erreur d'exécution de commande externe: %s\n"
 
-#: plugins/check_snmp.c:361
+#: plugins/check_snmp.c:373
 #, c-format
 msgid "External command error with no output (return code: %d)\n"
 msgstr ""
 
-#: plugins/check_snmp.c:464
+#: plugins/check_snmp.c:486 plugins/check_snmp.c:488 plugins/check_snmp.c:490
+#: plugins/check_snmp.c:492
 #, fuzzy, c-format
 msgid "No valid data returned (%s)\n"
 msgstr "Pas de données valides reçues"
 
-#: plugins/check_snmp.c:475
+#: plugins/check_snmp.c:504
 msgid "Time duration between plugin calls is invalid"
 msgstr ""
 
-#: plugins/check_snmp.c:588
+#: plugins/check_snmp.c:632
 msgid "Cannot asprintf()"
 msgstr ""
 
-#: plugins/check_snmp.c:594
+#: plugins/check_snmp.c:638
 #, fuzzy
 msgid "Cannot realloc()"
 msgstr "Impossible de réallouer des unités\n"
 
-#: plugins/check_snmp.c:610
+#: plugins/check_snmp.c:654
 msgid "No previous data to calculate rate - assume okay"
 msgstr ""
 
-#: plugins/check_snmp.c:751
+#: plugins/check_snmp.c:804
 msgid "Retries interval must be a positive integer"
 msgstr "L'intervalle pour les essais doit être un entier positif"
 
-#: plugins/check_snmp.c:831
+#: plugins/check_snmp.c:841
+#, fuzzy
+msgid "Exit status must be a positive integer"
+msgstr "Maxbytes doit être un entier positif"
+
+#: plugins/check_snmp.c:890
 #, c-format
 msgid "Could not reallocate labels[%d]"
 msgstr "Impossible de réallouer des labels[%d]"
 
-#: plugins/check_snmp.c:844
+#: plugins/check_snmp.c:903
 msgid "Could not reallocate labels\n"
 msgstr "Impossible de réallouer des labels\n"
 
-#: plugins/check_snmp.c:860
+#: plugins/check_snmp.c:919
 #, c-format
 msgid "Could not reallocate units [%d]\n"
 msgstr "Impossible de réallouer des unités [%d]\n"
 
-#: plugins/check_snmp.c:872
+#: plugins/check_snmp.c:931
 msgid "Could not realloc() units\n"
 msgstr "Impossible de réallouer des unités\n"
 
-#: plugins/check_snmp.c:889
+#: plugins/check_snmp.c:948
 #, fuzzy
 msgid "Rate multiplier must be a positive integer"
 msgstr "La taille du paquet doit être un entier positif"
 
-#: plugins/check_snmp.c:947
+#: plugins/check_snmp.c:1023
 msgid "No host specified\n"
 msgstr "Pas d'hôte spécifié\n"
 
-#: plugins/check_snmp.c:951
+#: plugins/check_snmp.c:1027
 msgid "No OIDs specified\n"
 msgstr "Pas de compteur spécifié\n"
 
-#: plugins/check_snmp.c:973
-msgid "Invalid seclevel"
-msgstr ""
-
-#: plugins/check_snmp.c:980 plugins/check_snmp.c:983 plugins/check_snmp.c:1001
+#: plugins/check_snmp.c:1050 plugins/check_snmp.c:1068
+#: plugins/check_snmp.c:1086
 #, c-format
 msgid "Required parameter: %s\n"
 msgstr ""
 
-#: plugins/check_snmp.c:1022
+#: plugins/check_snmp.c:1061
+msgid "Invalid seclevel"
+msgstr ""
+
+#: plugins/check_snmp.c:1107
 msgid "Invalid SNMP version"
 msgstr "Version de SNMP invalide"
 
-#: plugins/check_snmp.c:1039
+#: plugins/check_snmp.c:1124
 msgid "Unbalanced quotes\n"
 msgstr "Guillemets manquants\n"
 
-#: plugins/check_snmp.c:1088
+#: plugins/check_snmp.c:1182
+#, c-format
+msgid "multiplier set (%.1f), but input is not a number: %s"
+msgstr ""
+
+#: plugins/check_snmp.c:1211
 msgid "Check status of remote machines and obtain system information via SNMP"
 msgstr ""
 "Vérifie l'état des machines distantes et obtient l'information système via "
 "SNMP"
 
-#: plugins/check_snmp.c:1101
+#: plugins/check_snmp.c:1225
 msgid "Use SNMP GETNEXT instead of SNMP GET"
 msgstr "Utiliser SNMP GETNEXT au lieu de SNMP GET"
 
-#: plugins/check_snmp.c:1103
+#: plugins/check_snmp.c:1227
 msgid "SNMP protocol version"
 msgstr "Version du protocole SNMP"
 
-#: plugins/check_snmp.c:1105
+#: plugins/check_snmp.c:1229
+#, fuzzy
+msgid "SNMPv3 context"
+msgstr "Nom d'utilisateur SNMPv3"
+
+#: plugins/check_snmp.c:1231
 msgid "SNMPv3 securityLevel"
 msgstr "Niveau de sécurité SNMPv3 (securityLevel)"
 
-#: plugins/check_snmp.c:1107
+#: plugins/check_snmp.c:1233
 msgid "SNMPv3 auth proto"
 msgstr "Protocole d'authentification SNMPv3"
 
-#: plugins/check_snmp.c:1109
+#: plugins/check_snmp.c:1235
 msgid "SNMPv3 priv proto (default DES)"
 msgstr ""
 
-#: plugins/check_snmp.c:1113
+#: plugins/check_snmp.c:1239
 msgid "Optional community string for SNMP communication"
 msgstr "Communauté optionnelle pour la communication SNMP"
 
-#: plugins/check_snmp.c:1114
+#: plugins/check_snmp.c:1240
 msgid "default is"
 msgstr "défaut:"
 
-#: plugins/check_snmp.c:1116
+#: plugins/check_snmp.c:1242
 msgid "SNMPv3 username"
 msgstr "Nom d'utilisateur SNMPv3"
 
-#: plugins/check_snmp.c:1118
+#: plugins/check_snmp.c:1244
 msgid "SNMPv3 authentication password"
 msgstr "Mot de passe d'authentification SNMPv3"
 
-#: plugins/check_snmp.c:1120
+#: plugins/check_snmp.c:1246
 msgid "SNMPv3 privacy password"
 msgstr "Mot de passe de confidentialité SNMPv3"
 
-#: plugins/check_snmp.c:1124
+#: plugins/check_snmp.c:1250
 msgid "Object identifier(s) or SNMP variables whose value you wish to query"
 msgstr ""
 
-#: plugins/check_snmp.c:1126
+#: plugins/check_snmp.c:1252
 msgid ""
 "List of MIBS to be loaded (default = none if using numeric OIDs or 'ALL'"
 msgstr ""
 
-#: plugins/check_snmp.c:1127
+#: plugins/check_snmp.c:1253
 msgid "for symbolic OIDs.)"
 msgstr ""
 
-#: plugins/check_snmp.c:1129
+#: plugins/check_snmp.c:1255
 msgid "Delimiter to use when parsing returned data. Default is"
 msgstr ""
 
-#: plugins/check_snmp.c:1130
+#: plugins/check_snmp.c:1256
 msgid "Any data on the right hand side of the delimiter is considered"
 msgstr ""
 
-#: plugins/check_snmp.c:1131
+#: plugins/check_snmp.c:1257
 msgid "to be the data that should be used in the evaluation."
 msgstr ""
 
-#: plugins/check_snmp.c:1135
+#: plugins/check_snmp.c:1259
+msgid "If the check returns a 0 length string or NULL value"
+msgstr ""
+
+#: plugins/check_snmp.c:1260
+msgid "This option allows you to choose what status you want it to exit"
+msgstr ""
+
+#: plugins/check_snmp.c:1261
+msgid "Excluding this option renders the default exit of 3(STATE_UNKNOWN)"
+msgstr ""
+
+#: plugins/check_snmp.c:1262
+msgid "0 = OK"
+msgstr ""
+
+#: plugins/check_snmp.c:1263
+#, fuzzy
+msgid "1 = WARNING"
+msgstr "AVERTISSEMENT"
+
+#: plugins/check_snmp.c:1264
+#, fuzzy
+msgid "2 = CRITICAL"
+msgstr "CRITIQUE"
+
+#: plugins/check_snmp.c:1265
+#, fuzzy
+msgid "3 = UNKNOWN"
+msgstr "INCONNU"
+
+#: plugins/check_snmp.c:1269
 msgid "Warning threshold range(s)"
 msgstr "Valeurs pour le seuil d'avertissement"
 
-#: plugins/check_snmp.c:1137
+#: plugins/check_snmp.c:1271
 msgid "Critical threshold range(s)"
 msgstr "Valeurs pour le seuil critique"
 
-#: plugins/check_snmp.c:1139
+#: plugins/check_snmp.c:1273
 msgid "Enable rate calculation. See 'Rate Calculation' below"
 msgstr ""
 
-#: plugins/check_snmp.c:1141
+#: plugins/check_snmp.c:1275
 msgid ""
 "Converts rate per second. For example, set to 60 to convert to per minute"
 msgstr ""
 
-#: plugins/check_snmp.c:1143
+#: plugins/check_snmp.c:1277
 msgid "Add/subtract the specified OFFSET to numeric sensor data"
 msgstr ""
 
-#: plugins/check_snmp.c:1147
+#: plugins/check_snmp.c:1281
 msgid "Return OK state (for that OID) if STRING is an exact match"
 msgstr ""
 
-#: plugins/check_snmp.c:1149
+#: plugins/check_snmp.c:1283
 msgid ""
 "Return OK state (for that OID) if extended regular expression REGEX matches"
 msgstr ""
 
-#: plugins/check_snmp.c:1151
+#: plugins/check_snmp.c:1285
 msgid ""
 "Return OK state (for that OID) if case-insensitive extended REGEX matches"
 msgstr ""
 
-#: plugins/check_snmp.c:1153
+#: plugins/check_snmp.c:1287
 msgid "Invert search result (CRITICAL if found)"
 msgstr ""
 
-#: plugins/check_snmp.c:1157
+#: plugins/check_snmp.c:1291
 msgid "Prefix label for output from plugin"
 msgstr ""
 
-#: plugins/check_snmp.c:1159
+#: plugins/check_snmp.c:1293
 msgid "Units label(s) for output data (e.g., 'sec.')."
 msgstr ""
 
-#: plugins/check_snmp.c:1161
+#: plugins/check_snmp.c:1295
 msgid "Separates output on multiple OID requests"
 msgstr ""
 
-#: plugins/check_snmp.c:1165
-msgid "Number of retries to be used in the requests"
+#: plugins/check_snmp.c:1297
+msgid "Multiplies current value, 0 < n < 1 works as divider, defaults to 1"
+msgstr ""
+
+#: plugins/check_snmp.c:1299
+msgid "C-style format string for float values (see option -M)"
+msgstr ""
+
+#: plugins/check_snmp.c:1302
+msgid ""
+"NOTE the final timeout value is calculated using this formula: "
+"timeout_interval * retries + 5"
+msgstr ""
+
+#: plugins/check_snmp.c:1304
+#, fuzzy
+msgid "Number of retries to be used in the requests, default: "
 msgstr "Le nombre d'essai pour les requêtes"
 
-#: plugins/check_snmp.c:1168
+#: plugins/check_snmp.c:1307
 msgid "Label performance data with OIDs instead of --label's"
 msgstr ""
 
-#: plugins/check_snmp.c:1173
+#: plugins/check_snmp.c:1312
 msgid ""
 "This plugin uses the 'snmpget' command included with the NET-SNMP package."
 msgstr ""
 
-#: plugins/check_snmp.c:1174
+#: plugins/check_snmp.c:1313
 msgid ""
 "if you don't have the package installed, you will need to download it from"
 msgstr ""
 "Si vous n'avez pas le programme installé, vous devrez le télécharger depuis"
 
-#: plugins/check_snmp.c:1175
+#: plugins/check_snmp.c:1314
 msgid "http://net-snmp.sourceforge.net before you can use this plugin."
 msgstr "http://net-snmp.sourceforge.net avant de pouvoir utiliser ce plugin."
 
-#: plugins/check_snmp.c:1179
+#: plugins/check_snmp.c:1318
 #, fuzzy
 msgid ""
 "- Multiple OIDs (and labels) may be indicated by a comma or space-delimited  "
 msgstr ""
 "- Des OIDs multiples peuvent être séparées par des virgules ou des espaces"
 
-#: plugins/check_snmp.c:1180
+#: plugins/check_snmp.c:1319
 #, fuzzy
 msgid "list (lists with internal spaces must be quoted)."
 msgstr "(Les liste avec espaces doivent être entre guillemets). Max:"
 
-#: plugins/check_snmp.c:1184
+#: plugins/check_snmp.c:1323
 msgid ""
 "- When checking multiple OIDs, separate ranges by commas like '-w "
 "1:10,1:,:20'"
 msgstr ""
 
-#: plugins/check_snmp.c:1185
+#: plugins/check_snmp.c:1324
 msgid "- Note that only one string and one regex may be checked at present"
 msgstr ""
 
-#: plugins/check_snmp.c:1186
+#: plugins/check_snmp.c:1325
 msgid ""
 "- All evaluation methods other than PR, STR, and SUBSTR expect that the value"
 msgstr ""
 
-#: plugins/check_snmp.c:1187
+#: plugins/check_snmp.c:1326
 msgid "returned from the SNMP query is an unsigned integer."
 msgstr ""
 
-#: plugins/check_snmp.c:1190
+#: plugins/check_snmp.c:1329
 msgid "Rate Calculation:"
 msgstr ""
 
-#: plugins/check_snmp.c:1191
+#: plugins/check_snmp.c:1330
 msgid "In many places, SNMP returns counters that are only meaningful when"
 msgstr ""
 
-#: plugins/check_snmp.c:1192
+#: plugins/check_snmp.c:1331
 msgid "calculating the counter difference since the last check. check_snmp"
 msgstr ""
 
-#: plugins/check_snmp.c:1193
+#: plugins/check_snmp.c:1332
 msgid "saves the last state information in a file so that the rate per second"
 msgstr ""
 
-#: plugins/check_snmp.c:1194
+#: plugins/check_snmp.c:1333
 msgid "can be calculated. Use the --rate option to save state information."
 msgstr ""
 
-#: plugins/check_snmp.c:1195
+#: plugins/check_snmp.c:1334
 msgid ""
 "On the first run, there will be no prior state - this will return with OK."
 msgstr ""
 
-#: plugins/check_snmp.c:1196
+#: plugins/check_snmp.c:1335
 msgid "The state is uniquely determined by the arguments to the plugin, so"
 msgstr ""
 
-#: plugins/check_snmp.c:1197
+#: plugins/check_snmp.c:1336
 msgid "changing the arguments will create a new state file."
 msgstr ""
 
-#: plugins/check_ssh.c:165
+#: plugins/check_ssh.c:170
 msgid "Port number must be a positive integer"
 msgstr "Le numéro du port doit être un nombre entier positif"
 
-#: plugins/check_ssh.c:232
+#: plugins/check_ssh.c:237
 #, c-format
 msgid "Server answer: %s"
 msgstr "Réponse du serveur: %s"
 
-#: plugins/check_ssh.c:251
-#, c-format
-msgid "SSH WARNING - %s (protocol %s) version mismatch, expected '%s'\n"
+#: plugins/check_ssh.c:256
+#, fuzzy, c-format
+msgid "SSH CRITICAL - %s (protocol %s) version mismatch, expected '%s'\n"
 msgstr ""
 "SSH AVERTISSEMENT - %s (protocole %s) différence de version, attendu'%s'\n"
 
-#: plugins/check_ssh.c:260
+#: plugins/check_ssh.c:264
+#, fuzzy, c-format
+msgid ""
+"SSH CRITICAL - %s (protocol %s) protocol version mismatch, expected '%s'\n"
+msgstr ""
+"SSH AVERTISSEMENT - %s (protocole %s) différence de version, attendu'%s'\n"
+
+#: plugins/check_ssh.c:273
 #, fuzzy, c-format
 msgid "SSH OK - %s (protocol %s) | %s\n"
 msgstr "SSH OK - %s (protocole %s)\n"
 
-#: plugins/check_ssh.c:281
+#: plugins/check_ssh.c:294
 msgid "Try to connect to an SSH server at specified server and port"
 msgstr "Essaye de se connecter à un serveur SSH précisé à un port précis"
 
-#: plugins/check_ssh.c:297
+#: plugins/check_ssh.c:310
+#, fuzzy
 msgid ""
-"Warn if string doesn't match expected server version (ex: OpenSSH_3.9p1)"
+"Alert if string doesn't match expected server version (ex: OpenSSH_3.9p1)"
 msgstr ""
 "AVERTISSEMENT si la chaîne ne correspond pas à la version précisée (ex: "
 "OpenSSH_3.9p1)"
 
-#: plugins/check_swap.c:169
+#: plugins/check_ssh.c:313
+#, fuzzy
+msgid "Alert if protocol doesn't match expected protocol version (ex: 2.0)"
+msgstr ""
+"AVERTISSEMENT si la chaîne ne correspond pas à la version précisée (ex: "
+"OpenSSH_3.9p1)"
+
+#: plugins/check_swap.c:187
 #, c-format
 msgid "Command: %s\n"
 msgstr "Commande: %s\n"
 
-#: plugins/check_swap.c:171
+#: plugins/check_swap.c:189
 #, c-format
 msgid "Format: %s\n"
 msgstr "Format: %s\n"
 
-#: plugins/check_swap.c:207
+#: plugins/check_swap.c:225
 #, c-format
 msgid "total=%.0f, used=%.0f, free=%.0f\n"
 msgstr "total=%.0f, utilisé=%.0f, libre=%.0ff\n"
 
-#: plugins/check_swap.c:221
+#: plugins/check_swap.c:239
 #, c-format
 msgid "total=%.0f, free=%.0f\n"
 msgstr "total=%.0f, libre=%.0f\n"
 
-#: plugins/check_swap.c:253
+#: plugins/check_swap.c:271
 msgid "Error getting swap devices\n"
 msgstr ""
 
-#: plugins/check_swap.c:256
+#: plugins/check_swap.c:274
 msgid "SWAP OK: No swap devices defined\n"
 msgstr "SWAP OK: Pas de périphériques swap définis\n"
 
-#: plugins/check_swap.c:277 plugins/check_swap.c:319
+#: plugins/check_swap.c:295 plugins/check_swap.c:337
 msgid "swapctl failed: "
 msgstr "swapctl à échoué:"
 
-#: plugins/check_swap.c:278 plugins/check_swap.c:320
+#: plugins/check_swap.c:296 plugins/check_swap.c:338
 msgid "Error in swapctl call\n"
 msgstr ""
 
-#: plugins/check_swap.c:357
-#, c-format
-msgid "SWAP %s - %d%% free (%d MB out of %d MB) %s|"
+#: plugins/check_swap.c:376
+#, fuzzy, c-format
+msgid "SWAP %s - %d%% free (%dMB out of %dMB) %s|"
 msgstr "SWAP %s - %d%% libre (%d MB sur un total de %d MB) %s|"
 
-#: plugins/check_swap.c:435
-msgid "Warning threshold must be integer or percentage!"
+#: plugins/check_swap.c:472
+#, fuzzy
+msgid "Warning threshold percentage must be <= 100!"
+msgstr "Le seuil d'avertissement doit être un entier positif"
+
+#: plugins/check_swap.c:482
+#, fuzzy
+msgid "Warning threshold be positive integer or percentage!"
 msgstr "Le seuil d'avertissement doit être un entier ou un pourcentage!"
 
-#: plugins/check_swap.c:453
-msgid "Critical threshold must be integer or percentage!"
+#: plugins/check_swap.c:502
+#, fuzzy
+msgid "Critical threshold percentage must be <= 100!"
+msgstr "le seuil critique doit être un entier positif"
+
+#: plugins/check_swap.c:512
+#, fuzzy
+msgid "Critical threshold be positive integer or percentage!"
 msgstr "Le seuil critique doit être un entier ou un pourcentage!"
 
-#: plugins/check_swap.c:507
-msgid "Warning percentage should be more than critical percentage"
+#: plugins/check_swap.c:521
+#, fuzzy
+msgid ""
+"no-swap result must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) "
+"or integer (0-3)."
+msgstr ""
+"Le résultat de temps dépassé doit être un nom d'état valide (OK, WARNING, "
+"CRITICAL, UNKNOWN) ou un nombre entier (0-3)."
+
+#: plugins/check_swap.c:558
+#, fuzzy
+msgid "Warning should be more than critical"
 msgstr ""
 "Le pourcentage d'avertissement doit être plus important que le pourcentage "
 "critique"
 
-#: plugins/check_swap.c:511
-msgid "Warning free space should be more than critical free space"
-msgstr ""
-"Le seuil d'avertissement pour la place libre doit être plus grand que le "
-"seuil critique"
-
-#: plugins/check_swap.c:525
+#: plugins/check_swap.c:572
 msgid "Check swap space on local machine."
 msgstr "Vérifie l'espace swap sur la machine locale."
 
-#: plugins/check_swap.c:535
+#: plugins/check_swap.c:582
 msgid ""
 "Exit with WARNING status if less than INTEGER bytes of swap space are free"
 msgstr ""
 "Sortir avec un résultat AVERTISSEMENT si moins de X octets de mémoire "
 "virtuelle sont libres"
 
-#: plugins/check_swap.c:537
+#: plugins/check_swap.c:584
 msgid "Exit with WARNING status if less than PERCENT of swap space is free"
 msgstr ""
 "Sortir avec un résultat AVERTISSEMENT si moins de X pour cent de mémoire "
 "virtuelle est libre"
 
-#: plugins/check_swap.c:539
+#: plugins/check_swap.c:586
 msgid ""
 "Exit with CRITICAL status if less than INTEGER bytes of swap space are free"
 msgstr ""
 "Sortir avec un résultat CRITIQUE si moins de X octets de mémoire virtuelle "
 "sont libres"
 
-#: plugins/check_swap.c:541
+#: plugins/check_swap.c:588
 msgid "Exit with CRITICAL status if less than PERCENT of swap space is free"
 msgstr ""
 "Sortir avec un résultat CRITIQUE si moins de X pour cent de mémoire "
 "virtuelle est libre"
 
-#: plugins/check_swap.c:543
+#: plugins/check_swap.c:590
 msgid "Conduct comparisons for all swap partitions, one by one"
 msgstr "Vérifier chacune des partitions de mémoire virtuelle séparément"
 
-#: plugins/check_swap.c:548
+#: plugins/check_swap.c:592
+msgid ""
+"Resulting state when there is no swap regardless of thresholds. Default:"
+msgstr ""
+
+#: plugins/check_swap.c:597
+#, fuzzy
+msgid ""
+"Both INTEGER and PERCENT thresholds can be specified, they are all checked."
+msgstr "Les seuils d'alerte et critiques peuvent être spécifiés avec -w et -c."
+
+#: plugins/check_swap.c:598
 msgid "On AIX, if -a is specified, uses lsps -a, otherwise uses lsps -s."
 msgstr ""
 "Sur AIX, si -a est spécifié, le plugin utilise lsps -a, sinon il utilise "
 "lsps -s."
 
-#: plugins/check_tcp.c:206
+#: plugins/check_tcp.c:210
 msgid "CRITICAL - Generic check_tcp called with unknown service\n"
 msgstr ""
 "CRITIQUE -check_tcp version générique utilisé avec un service inconnu\n"
 
-#: plugins/check_tcp.c:230
+#: plugins/check_tcp.c:234
 msgid "With UDP checks, a send/expect string must be specified."
 msgstr ""
 "Avec la surveillance UDP, une chaîne d'envoi et un chaîne de réponse doit "
 "être spécifiée."
 
-#: plugins/check_tcp.c:431
+#: plugins/check_tcp.c:445
 msgid "No arguments found"
 msgstr "Pas de paramètres"
 
-#: plugins/check_tcp.c:534
+#: plugins/check_tcp.c:548
 msgid "Maxbytes must be a positive integer"
 msgstr "Maxbytes doit être un entier positif"
 
-#: plugins/check_tcp.c:552
+#: plugins/check_tcp.c:566
 msgid "Refuse must be one of ok, warn, crit"
 msgstr "Refuse doit être parmis ok, warn, crit"
 
-#: plugins/check_tcp.c:562
+#: plugins/check_tcp.c:576
 msgid "Mismatch must be one of ok, warn, crit"
 msgstr "Mismatch doit être parmis ok, warn, crit"
 
-#: plugins/check_tcp.c:568
+#: plugins/check_tcp.c:582
 msgid "Delay must be a positive integer"
 msgstr "Delay doit être un entier positif"
 
-#: plugins/check_tcp.c:613
+#: plugins/check_tcp.c:637
 msgid "You must provide a server address"
 msgstr "Vous devez fournir une adresse serveur"
 
-#: plugins/check_tcp.c:615
+#: plugins/check_tcp.c:639
 msgid "Invalid hostname, address or socket"
 msgstr "Adresse/Nom/Socket invalide"
 
-#: plugins/check_tcp.c:629
+#: plugins/check_tcp.c:653
 #, c-format
 msgid ""
 "This plugin tests %s connections with the specified host (or unix socket).\n"
@@ -5084,69 +5472,75 @@ msgstr ""
 "Ce plugin teste %s connections avec l'hôte spécifié (ou socket unix).\n"
 "\n"
 
-#: plugins/check_tcp.c:642
+#: plugins/check_tcp.c:666
+#, fuzzy
 msgid ""
-"Can use \\n, \\r, \\t or \\ in send or quit string. Must come before send or "
-"quit option"
+"Can use \\n, \\r, \\t or \\\\ in send or quit string. Must come before send "
+"or quit option"
 msgstr ""
 "Permet d'utiliser \\n, \\r, \\t ou \\ dans la chaîne de caractères send ou "
 "quit. Doit être placé avant ces dernières."
 
-#: plugins/check_tcp.c:643
+#: plugins/check_tcp.c:667
 msgid "Default: nothing added to send, \\r\\n added to end of quit"
 msgstr ""
 "Par défaut: Rien n'est ajouté à send, \\r\\n est ajouté à la fin de quit"
 
-#: plugins/check_tcp.c:645
+#: plugins/check_tcp.c:669
 msgid "String to send to the server"
 msgstr "Chaîne de caractères à envoyer au serveur"
 
-#: plugins/check_tcp.c:647
+#: plugins/check_tcp.c:671
 msgid "String to expect in server response"
 msgstr "Chaîne de caractères à attendre en réponse"
 
-#: plugins/check_tcp.c:647
+#: plugins/check_tcp.c:671
 msgid "(may be repeated)"
 msgstr "(peut être utilisé plusieurs fois)"
 
-#: plugins/check_tcp.c:649
+#: plugins/check_tcp.c:673
 msgid "All expect strings need to occur in server response. Default is any"
 msgstr ""
 "Toutes les chaînes attendus (expect) doivent être repérés dans la réponse. "
 "Par défaut, n'importe laquelle suffit."
 
-#: plugins/check_tcp.c:651
+#: plugins/check_tcp.c:675
 msgid "String to send server to initiate a clean close of the connection"
 msgstr "Chaîne de caractères à envoyer pour fermer gracieusement la connection"
 
-#: plugins/check_tcp.c:653
+#: plugins/check_tcp.c:677
 msgid "Accept TCP refusals with states ok, warn, crit (default: crit)"
 msgstr ""
 
-#: plugins/check_tcp.c:655
+#: plugins/check_tcp.c:679
 msgid ""
 "Accept expected string mismatches with states ok, warn, crit (default: warn)"
 msgstr ""
 
-#: plugins/check_tcp.c:657
+#: plugins/check_tcp.c:681
 msgid "Hide output from TCP socket"
 msgstr "Cacher la réponse provenant du socket TCP"
 
-#: plugins/check_tcp.c:659
+#: plugins/check_tcp.c:683
 msgid "Close connection once more than this number of bytes are received"
 msgstr ""
 
-#: plugins/check_tcp.c:661
+#: plugins/check_tcp.c:685
 msgid "Seconds to wait between sending string and polling for response"
 msgstr ""
 
-#: plugins/check_tcp.c:666
+#: plugins/check_tcp.c:690
 msgid "1st is #days for warning, 2nd is critical (if not specified - 0)."
 msgstr ""
 
-#: plugins/check_tcp.c:668
+#: plugins/check_tcp.c:692
 msgid "Use SSL for the connection."
 msgstr ""
+
+#: plugins/check_tcp.c:694
+#, fuzzy
+msgid "SSL server_name"
+msgstr "Nom d'utilisateur SNMPv3"
 
 #: plugins/check_time.c:102
 #, c-format
@@ -5263,221 +5657,260 @@ msgstr ", Inconnu"
 msgid "UPS does not support any available options\n"
 msgstr "L'UPS ne supporte aucune des options disponibles\n"
 
-#: plugins/check_ups.c:348 plugins/check_ups.c:411
+#: plugins/check_ups.c:348 plugins/check_ups.c:414
 msgid "Invalid response received from host"
 msgstr "Réponse invalide reçue de l'hôte"
 
-#: plugins/check_ups.c:420
+#: plugins/check_ups.c:406
+msgid "UPS name to long for buffer"
+msgstr ""
+
+#: plugins/check_ups.c:423
 #, c-format
 msgid "CRITICAL - no such UPS '%s' on that host\n"
 msgstr "CRITIQUE - pas d'UPS '%s' sur cet hôte\n"
 
-#: plugins/check_ups.c:430
+#: plugins/check_ups.c:433
 msgid "CRITICAL - UPS data is stale"
 msgstr "CRITIQUE - les données de l'ups ne sont plus valables"
 
-#: plugins/check_ups.c:435
+#: plugins/check_ups.c:438
 #, c-format
 msgid "Unknown error: %s\n"
 msgstr "Erreur inconnue: %s\n"
 
-#: plugins/check_ups.c:442
+#: plugins/check_ups.c:445
 msgid "Error: unable to parse variable"
 msgstr "Erreur: impossible de lire la variable"
 
-#: plugins/check_ups.c:549
+#: plugins/check_ups.c:552
 msgid "Unrecognized UPS variable"
 msgstr "Variable d'UPS non reconnue"
 
-#: plugins/check_ups.c:587
+#: plugins/check_ups.c:590
 msgid "Error : no UPS indicated"
 msgstr "Erreur: pas d'UPS indiqué"
 
-#: plugins/check_ups.c:607
+#: plugins/check_ups.c:610
 msgid ""
 "This plugin tests the UPS service on the specified host. Network UPS Tools"
 msgstr "Ce plugin teste le service UPS sur l'hôte spécifié. Network UPS Tools"
 
-#: plugins/check_ups.c:608
+#: plugins/check_ups.c:611
 msgid "from www.networkupstools.org must be running for this plugin to work."
 msgstr ""
 "de www.networkupstools.org doit s'exécuter sur l'hôte pour que ce plugin "
 "fonctionne."
 
-#: plugins/check_ups.c:620
+#: plugins/check_ups.c:623
 msgid "Name of UPS"
 msgstr ""
 
-#: plugins/check_ups.c:622
+#: plugins/check_ups.c:625
 msgid "Output of temperatures in Celsius"
 msgstr "Affichage des températures en Celsius"
 
-#: plugins/check_ups.c:624
+#: plugins/check_ups.c:627
 msgid "Valid values for STRING are"
 msgstr "Les variables valides pour STRING sont"
 
-#: plugins/check_ups.c:635
+#: plugins/check_ups.c:638
 msgid ""
 "This plugin attempts to determine the status of a UPS (Uninterruptible Power"
 msgstr ""
 
-#: plugins/check_ups.c:636
+#: plugins/check_ups.c:639
 msgid ""
 "Supply) on a local or remote host. If the UPS is online or calibrating, the"
 msgstr ""
 
-#: plugins/check_ups.c:637
+#: plugins/check_ups.c:640
 msgid ""
 "plugin will return an OK state. If the battery is on it will return a WARNING"
 msgstr ""
 
-#: plugins/check_ups.c:638
+#: plugins/check_ups.c:641
 msgid ""
 "state. If the UPS is off or has a low battery the plugin will return a "
 "CRITICAL"
 msgstr ""
 
-#: plugins/check_ups.c:643
+#: plugins/check_ups.c:646
 msgid ""
 "You may also specify a variable to check (such as temperature, utility "
 "voltage,"
 msgstr ""
 
-#: plugins/check_ups.c:644
+#: plugins/check_ups.c:647
 msgid ""
 "battery load, etc.) as well as warning and critical thresholds for the value"
 msgstr ""
 
-#: plugins/check_ups.c:645
+#: plugins/check_ups.c:648
 msgid ""
 "of that variable.  If the remote host has multiple UPS that are being "
 "monitored"
 msgstr ""
 
-#: plugins/check_ups.c:646
+#: plugins/check_ups.c:649
 msgid "you will have to use the --ups option to specify which UPS to check."
 msgstr ""
 
-#: plugins/check_ups.c:648
+#: plugins/check_ups.c:651
 msgid ""
 "This plugin requires that the UPSD daemon distributed with Russell Kroll's"
 msgstr ""
 
-#: plugins/check_ups.c:649
+#: plugins/check_ups.c:652
 msgid ""
 "Network UPS Tools be installed on the remote host. If you do not have the"
 msgstr ""
 
-#: plugins/check_ups.c:650
+#: plugins/check_ups.c:653
 msgid "package installed on your system, you can download it from"
 msgstr ""
 
-#: plugins/check_ups.c:651
+#: plugins/check_ups.c:654
 msgid "http://www.networkupstools.org"
 msgstr ""
 
-#: plugins/check_users.c:110
+#: plugins/check_users.c:91
+#, fuzzy, c-format
+msgid "Could not enumerate RD sessions: %d\n"
+msgstr "Impossible d'utiliser le protocole version %d\n"
+
+#: plugins/check_users.c:146
 #, c-format
 msgid "# users=%d"
 msgstr "# utilisateurs=%d"
 
-#: plugins/check_users.c:133
+#: plugins/check_users.c:164
 msgid "Unable to read output"
 msgstr "Impossible de lire les données en entrée"
 
-#: plugins/check_users.c:140
+#: plugins/check_users.c:166
 #, c-format
 msgid "USERS %s - %d users currently logged in |%s\n"
 msgstr "UTILISATEURS %s - %d utilisateurs actuellement connectés sur |%s\n"
 
-#: plugins/check_users.c:219
+#: plugins/check_users.c:241
 msgid "This plugin checks the number of users currently logged in on the local"
 msgstr ""
 "Ce plugin vérifie le nombre d'utilisateurs actuellement connecté sur le "
 "système local"
 
-#: plugins/check_users.c:220
+#: plugins/check_users.c:242
 msgid ""
 "system and generates an error if the number exceeds the thresholds specified."
 msgstr "et génère une erreur si le nombre excède le seuil spécifié."
 
-#: plugins/check_users.c:230
+#: plugins/check_users.c:252
 msgid "Set WARNING status if more than INTEGER users are logged in"
 msgstr ""
 "Sortir avec un résultat AVERTISSEMENT si plus de INTEGER utilisateurs sont "
 "connectés"
 
-#: plugins/check_users.c:232
+#: plugins/check_users.c:254
 msgid "Set CRITICAL status if more than INTEGER users are logged in"
 msgstr ""
 "Sortir avec un résultat CRITIQUE si plus de INTEGER utilisateurs sont "
 "connectés"
 
-#: plugins/check_ide_smart.c:256
+#: plugins/check_ide_smart.c:218
+msgid ""
+"DEPRECATION WARNING: the -q switch (quiet output) is no longer \"quiet\"."
+msgstr ""
+
+#: plugins/check_ide_smart.c:219
+msgid "Nagios-compatible output is now always returned."
+msgstr ""
+
+#: plugins/check_ide_smart.c:224
+msgid "SMART commands are broken and have been disabled (See Notes in --help)."
+msgstr ""
+
+#: plugins/check_ide_smart.c:228
+msgid ""
+"DEPRECATION WARNING: the -n switch (Nagios-compatible output) is now the"
+msgstr ""
+
+#: plugins/check_ide_smart.c:229
+#, fuzzy
+msgid "default and will be removed from future releases."
+msgstr ""
+"Note: nslookup est obsolète et pourra être retiré dans les prochaines "
+"versions."
+
+#: plugins/check_ide_smart.c:257
 #, c-format
 msgid "CRITICAL - Couldn't open device %s: %s\n"
 msgstr "Critique - Impossible d'ouvrir le périphérique %s: %s\n"
 
-#: plugins/check_ide_smart.c:261
+#: plugins/check_ide_smart.c:262
 #, c-format
 msgid "CRITICAL - SMART_CMD_ENABLE\n"
 msgstr "CRITIQUE - SMART_CMD_ENABLE\n"
 
-#: plugins/check_ide_smart.c:323 plugins/check_ide_smart.c:350
+#: plugins/check_ide_smart.c:303 plugins/check_ide_smart.c:330
 #, c-format
 msgid "CRITICAL - SMART_READ_VALUES: %s\n"
 msgstr "CRITIQUE - SMART_READ_VALUES: %s\n"
 
-#: plugins/check_ide_smart.c:421
+#: plugins/check_ide_smart.c:376
 #, c-format
 msgid "CRITICAL - %d Harddrive PreFailure%cDetected! %d/%d tests failed.\n"
 msgstr ""
 "CRITIQUE - %d État de pré-panne %c Détecté! %d/%d les tests on échoués.\n"
 
-#: plugins/check_ide_smart.c:429
+#: plugins/check_ide_smart.c:384
 #, c-format
 msgid "WARNING - %d Harddrive Advisor%s Detected. %d/%d tests failed.\n"
 msgstr ""
 "AVERTISSEMENT -  %d État de pré-panne %s Détecté! %d/%d les tests on "
 "échoués.\n"
 
-#: plugins/check_ide_smart.c:437
+#: plugins/check_ide_smart.c:392
 #, c-format
 msgid "OK - Operational (%d/%d tests passed)\n"
 msgstr "OK - En fonctionnement (%d/%d les tests on été réussi)\n"
 
-#: plugins/check_ide_smart.c:441
+#: plugins/check_ide_smart.c:396
 #, c-format
 msgid "ERROR - Status '%d' unknown. %d/%d tests passed\n"
 msgstr "ERREUR - État '%d' inconnu. %d/%d les tests on réussi\n"
 
-#: plugins/check_ide_smart.c:474
+#: plugins/check_ide_smart.c:429
 #, c-format
 msgid "OffLineStatus=%d {%s}, AutoOffLine=%s, OffLineTimeout=%d minutes\n"
 msgstr ""
 "Etat Hors Ligne=%d {%s}, Hors Ligne Auto=%s, Temps avant arrêt=%d minutes\n"
 
-#: plugins/check_ide_smart.c:480
+#: plugins/check_ide_smart.c:435
 #, c-format
 msgid "OffLineCapability=%d {%s %s %s}\n"
 msgstr "Capacité Hors Ligne=%d {%s %s %s}\n"
 
-#: plugins/check_ide_smart.c:486
+#: plugins/check_ide_smart.c:441
 #, c-format
 msgid "SmartRevision=%d, CheckSum=%d, SmartCapability=%d {%s %s}\n"
 msgstr "Révision Smart=%d, Somme de contrôle=%d, Capacité Smart=%d {%s %s}\n"
 
-#: plugins/check_ide_smart.c:508 plugins/check_ide_smart.c:532
+#: plugins/check_ide_smart.c:463 plugins/check_ide_smart.c:492
 #, c-format
 msgid "CRITICAL - %s: %s\n"
 msgstr "CRITIQUE - %s: %s\n"
 
-#: plugins/check_ide_smart.c:553 plugins/check_ide_smart.c:580
+#: plugins/check_ide_smart.c:467 plugins/check_ide_smart.c:496
+#, fuzzy, c-format
+msgid "OK - Command sent (%s)\n"
+msgstr "Commande: %s\n"
+
+#: plugins/check_ide_smart.c:517 plugins/check_ide_smart.c:544
 #, c-format
 msgid "CRITICAL - SMART_READ_THRESHOLDS: %s\n"
 msgstr "CRITIQUE - SMART_READ_THRESHOLDS: %s\n"
 
-#: plugins/check_ide_smart.c:599
+#: plugins/check_ide_smart.c:563
 #, c-format
 msgid ""
 "This plugin checks a local hard drive with the (Linux specific) SMART "
@@ -5486,41 +5919,50 @@ msgstr ""
 "Ce plugin vérifie un disque dur local à l'aide de l'interface SMART (pour "
 "Linux) [http://smartlinux.sourceforge.net/smart/index.php]."
 
-#: plugins/check_ide_smart.c:609
+#: plugins/check_ide_smart.c:573
 msgid "Select device DEVICE"
 msgstr ""
 
-#: plugins/check_ide_smart.c:610
+#: plugins/check_ide_smart.c:574
 msgid ""
-"Note: if the device is selected with this option, _no_ other options are "
-"accepted"
+"Note: if the device is specified without this option, any further option will"
 msgstr ""
 
-#: plugins/check_ide_smart.c:612
-msgid "Perform immediately offline tests"
+#: plugins/check_ide_smart.c:575
+msgid "be ignored."
 msgstr ""
 
-#: plugins/check_ide_smart.c:614
-msgid "Returns the number of failed tests"
+#: plugins/check_ide_smart.c:581
+msgid ""
+"The SMART command modes (-i/--immediate, -0/--auto-off and -1/--auto-on) were"
 msgstr ""
 
-#: plugins/check_ide_smart.c:616
-msgid "Turn on automatic offline tests"
+#: plugins/check_ide_smart.c:582
+msgid ""
+"broken in an underhand manner and have been disabled. You can use smartctl"
 msgstr ""
 
-#: plugins/check_ide_smart.c:618
-msgid "Turn off automatic offline tests"
+#: plugins/check_ide_smart.c:583
+msgid "instead:"
 msgstr ""
 
-#: plugins/check_ide_smart.c:620
-msgid "Output suitable for the monitoring system"
+#: plugins/check_ide_smart.c:584
+msgid "-0/--auto-off:  use \"smartctl --offlineauto=off\""
 msgstr ""
 
-#: plugins/negate.c:99
+#: plugins/check_ide_smart.c:585
+msgid "-1/--auto-on:   use \"smartctl --offlineauto=on\""
+msgstr ""
+
+#: plugins/check_ide_smart.c:586
+msgid "-i/--immediate: use \"smartctl --test=offline\""
+msgstr ""
+
+#: plugins/negate.c:96
 msgid "No data returned from command\n"
 msgstr "Pas de données reçues de la commande\n"
 
-#: plugins/negate.c:170
+#: plugins/negate.c:166
 msgid ""
 "Timeout result must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) "
 "or integer (0-3)."
@@ -5528,7 +5970,7 @@ msgstr ""
 "Le résultat de temps dépassé doit être un nom d'état valide (OK, WARNING, "
 "CRITICAL, UNKNOWN) ou un nombre entier (0-3)."
 
-#: plugins/negate.c:174
+#: plugins/negate.c:170
 msgid ""
 "Ok must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer "
 "(0-3)."
@@ -5536,7 +5978,7 @@ msgstr ""
 "Ok doit être un nom d'état valide (OK, WARNING, CRITICAL, UNKNOWN) ou un "
 "nombre entier (0-3)."
 
-#: plugins/negate.c:180
+#: plugins/negate.c:176
 msgid ""
 "Warning must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or "
 "integer (0-3)."
@@ -5544,7 +5986,7 @@ msgstr ""
 "Warning doit être un nom d'état valide (OK, WARNING, CRITICAL, UNKNOWN) ou "
 "un nombre entier (0-3)."
 
-#: plugins/negate.c:185
+#: plugins/negate.c:181
 msgid ""
 "Critical must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or "
 "integer (0-3)."
@@ -5552,7 +5994,7 @@ msgstr ""
 "Critical doit être un nom d'état valide (OK, WARNING, CRITICAL, UNKNOWN) ou "
 "un nombre entier (0-3)."
 
-#: plugins/negate.c:190
+#: plugins/negate.c:186
 msgid ""
 "Unknown must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or "
 "integer (0-3)."
@@ -5560,33 +6002,33 @@ msgstr ""
 "Unknown doit être un nom d'état valide (OK, WARNING, CRITICAL, UNKNOWN) ou "
 "un nombre entier (0-3)."
 
-#: plugins/negate.c:217
+#: plugins/negate.c:213
 msgid "Require path to command"
 msgstr "Chemin vers la commande requis"
 
-#: plugins/negate.c:246
+#: plugins/negate.c:224
 msgid ""
 "Negates the status of a plugin (returns OK for CRITICAL and vice-versa)."
 msgstr ""
 "Inverse le statut d'un plugin (retourne OK pour CRITIQUE et vice-versa)."
 
-#: plugins/negate.c:247
+#: plugins/negate.c:225
 msgid "Additional switches can be used to control which state becomes what."
 msgstr ""
 "Des options additionnelles peuvent être utilisées pour contrôler quel état "
 "devient quoi."
 
-#: plugins/negate.c:256
+#: plugins/negate.c:234
 msgid "Keep timeout longer than the plugin timeout to retain CRITICAL status."
 msgstr ""
 "Utilisez un délai de réponse plus long que celui du plugin afin de conserver "
 "les résultats CRITIQUE"
 
-#: plugins/negate.c:258
+#: plugins/negate.c:236
 msgid "Custom result on Negate timeouts; see below for STATUS definition\n"
 msgstr ""
 
-#: plugins/negate.c:264
+#: plugins/negate.c:242
 #, c-format
 msgid ""
 "    STATUS can be 'OK', 'WARNING', 'CRITICAL' or 'UNKNOWN' without single\n"
@@ -5594,63 +6036,63 @@ msgstr ""
 "    STATUS peut être 'OK', 'WARNING', 'CRITICAL' ou 'UNKNOWN' sans les "
 "simple\n"
 
-#: plugins/negate.c:265
+#: plugins/negate.c:243
 #, c-format
 msgid ""
 "    quotes. Numeric values are accepted. If nothing is specified, permutes\n"
 msgstr "    quotes. Les valeurs numériques sont acceptées. Si rien n'est\n"
 
-#: plugins/negate.c:266
+#: plugins/negate.c:244
 #, c-format
 msgid "    OK and CRITICAL.\n"
 msgstr "    spécifié, inverse OK et CRITIQUE.\n"
 
-#: plugins/negate.c:268
+#: plugins/negate.c:246
 #, c-format
 msgid ""
 "    Substitute output text as well. Will only substitute text in CAPITALS\n"
 msgstr ""
 
-#: plugins/negate.c:273
+#: plugins/negate.c:251
 msgid "Run check_ping and invert result. Must use full path to plugin"
 msgstr ""
 "Execute check_ping et inverse le résultat. Le chemin complet du plug-in doit "
 "être spécifié"
 
-#: plugins/negate.c:275
+#: plugins/negate.c:253
 msgid "This will return OK instead of WARNING and UNKNOWN instead of CRITICAL"
 msgstr ""
 "Ceci retournera OK au lieu de AVERTISSEMENT et INCONNU au lieu de CRITIQUE"
 
-#: plugins/negate.c:278
+#: plugins/negate.c:256
 msgid ""
 "This plugin is a wrapper to take the output of another plugin and invert it."
 msgstr ""
 "Ce plugin est un adaptateur qui prends l'état d'un autre plug-in et "
 "l'inverse."
 
-#: plugins/negate.c:279
+#: plugins/negate.c:257
 msgid "The full path of the plugin must be provided."
 msgstr "Le chemin complet du plugin doit être spécifié."
 
-#: plugins/negate.c:280
+#: plugins/negate.c:258
 msgid "If the wrapped plugin returns OK, the wrapper will return CRITICAL."
 msgstr "Si le plugin executé retourne OK, l'adaptateur retournera CRITIQUE."
 
-#: plugins/negate.c:281
+#: plugins/negate.c:259
 msgid "If the wrapped plugin returns CRITICAL, the wrapper will return OK."
 msgstr "Si le plugin executé retourne CRITIQUE, l'adaptateur retournera OK."
 
-#: plugins/negate.c:282
+#: plugins/negate.c:260
 msgid "Otherwise, the output state of the wrapped plugin is unchanged."
 msgstr "Autrement, l'état du plugin executé reste inchangé."
 
-#: plugins/negate.c:284
+#: plugins/negate.c:262
 msgid ""
 "Using timeout-result, it is possible to override the timeout behaviour or a"
 msgstr ""
 
-#: plugins/negate.c:285
+#: plugins/negate.c:263
 msgid "plugin by setting the negate timeout a bit lower."
 msgstr ""
 
@@ -5664,59 +6106,55 @@ msgstr "%s - Le socket n'a pas répondu dans les %d secondes\n"
 msgid "%s - Abnormal timeout after %d seconds\n"
 msgstr "%s - Dépassement anormal du temps de réponse après %d secondes\n"
 
-#: plugins/netutils.c:79 plugins/netutils.c:281
+#: plugins/netutils.c:79 plugins/netutils.c:292
 msgid "Send failed"
 msgstr "L'envoi à échoué"
 
-#: plugins/netutils.c:96 plugins/netutils.c:296
+#: plugins/netutils.c:96 plugins/netutils.c:307
 msgid "No data was received from host!"
 msgstr "Pas de données reçues de l'hôte!"
 
-#: plugins/netutils.c:204 plugins/netutils.c:240
+#: plugins/netutils.c:209 plugins/netutils.c:245
 msgid "Socket creation failed"
 msgstr "La création du socket à échoué "
 
-#: plugins/netutils.c:233
+#: plugins/netutils.c:238
 msgid "Supplied path too long unix domain socket"
 msgstr "Le chemin fourni est trop long pour un socket unix"
 
-#: plugins/netutils.c:305
+#: plugins/netutils.c:316
 msgid "Receive failed"
 msgstr "La réception à échoué"
 
-#: plugins/netutils.c:331 plugins-root/check_dhcp.c:1342
+#: plugins/netutils.c:342 plugins-root/check_dhcp.c:1310
 #, c-format
 msgid "Invalid hostname/address - %s"
 msgstr "Adresse/Nom invalide - %s"
 
-#: plugins/popen.c:142
+#: plugins/popen.c:133
 msgid "Could not malloc argv array in popen()"
 msgstr "Impossible de réallouer un tableau pour les paramètres dans popen()"
 
-#: plugins/popen.c:152
+#: plugins/popen.c:143
 msgid "CRITICAL - You need more args!!!"
 msgstr "CRITIQUE - Vous devez spécifier plus d'arguments!!!"
 
-#: plugins/popen.c:209
+#: plugins/popen.c:201
 msgid "Cannot catch SIGCHLD"
 msgstr "impossible d'obtenir le signal SIGCHLD"
 
-#: plugins/popen.c:304
+#: plugins/popen.c:287
 #, c-format
 msgid "CRITICAL - Plugin timed out after %d seconds\n"
 msgstr "CRITIQUE - Le plugin n'as pas répondu dans les %d secondes\n"
 
-#: plugins/popen.c:307
+#: plugins/popen.c:290
 msgid "CRITICAL - popen timeout received, but no child process"
 msgstr ""
 "CRITIQUE - le temps d'attente à été dépassé dans la fonction popen, mais il "
 "n'y a pas de processus fils"
 
-#: plugins/popen.c:323
-msgid "sysconf error for _SC_OPEN_MAX"
-msgstr ""
-
-#: plugins/urlize.c:130
+#: plugins/urlize.c:129
 #, c-format
 msgid ""
 "%s UNKNOWN - No data received from host\n"
@@ -5725,7 +6163,7 @@ msgstr ""
 "%s INCONNU - Pas de données reçues de l'hôte\n"
 "Commande: %s</A>\n"
 
-#: plugins/urlize.c:169
+#: plugins/urlize.c:168
 #, fuzzy
 msgid ""
 "This plugin wraps the text output of another command (plugin) in HTML <A>"
@@ -5733,66 +6171,65 @@ msgstr ""
 "Ce plugin est un adaptateur qui prends l'état d'un autre plug-in et "
 "l'inverse."
 
-#: plugins/urlize.c:170
+#: plugins/urlize.c:169
 msgid ""
 "tags, thus displaying the child plugin's output as a clickable link in "
 "compatible"
 msgstr ""
 
-#: plugins/urlize.c:171
+#: plugins/urlize.c:170
 msgid ""
 "monitoring status screen. This plugin returns the status of the invoked "
 "plugin."
 msgstr ""
 
-#: plugins/urlize.c:181
+#: plugins/urlize.c:180
 msgid ""
 "Pay close attention to quoting to ensure that the shell passes the expected"
 msgstr ""
 
-#: plugins/urlize.c:182
+#: plugins/urlize.c:181
 msgid "data to the plugin. For example, in:"
 msgstr ""
 
-#: plugins/urlize.c:183
+#: plugins/urlize.c:182
 msgid "urlize http://example.com/ check_http -H example.com -r 'two words'"
 msgstr ""
 
-#: plugins/urlize.c:184
+#: plugins/urlize.c:183
 msgid "the shell will remove the single quotes and urlize will see:"
 msgstr ""
 
-#: plugins/urlize.c:185
+#: plugins/urlize.c:184
 msgid "urlize http://example.com/ check_http -H example.com -r two words"
 msgstr ""
 
-#: plugins/urlize.c:186
+#: plugins/urlize.c:185
 msgid "You probably want:"
 msgstr ""
 
-#: plugins/urlize.c:187
+#: plugins/urlize.c:186
 msgid "urlize http://example.com/ \"check_http -H example.com -r 'two words'\""
 msgstr ""
 
-#: plugins/utils.c:174
-#, c-format
-msgid "%s - Plugin timed out after %d seconds\n"
-msgstr "%s - Le plugin n'as pas répondu dans les %d secondes\n"
-
-#: plugins/utils.c:469
+#: plugins/utils.c:479
 msgid "failed realloc in strpcpy\n"
 msgstr "La fonction realloc à échoué dans strpcpy\n"
 
-#: plugins/utils.c:511
+#: plugins/utils.c:521
 msgid "failed malloc in strscat\n"
 msgstr "La fonction malloc à échoué dans strscat\n"
 
-#: plugins/utils.c:531
+#: plugins/utils.c:541
 #, fuzzy
 msgid "failed malloc in xvasprintf\n"
 msgstr "La fonction malloc à échoué dans strscat\n"
 
-#: plugins/utils.h:137
+#: plugins/utils.c:819
+msgid "sysconf error for _SC_OPEN_MAX\n"
+msgstr ""
+
+#: plugins/utils.h:127
 #, c-format
 msgid ""
 "       %s (-h | --help) for detailed help\n"
@@ -5801,7 +6238,7 @@ msgstr ""
 "       %s (-h | --help) pour l'aide détaillée\n"
 "       %s (-V | --version) pour les informations relative à la version\n"
 
-#: plugins/utils.h:141
+#: plugins/utils.h:131
 msgid ""
 "\n"
 "Options:\n"
@@ -5817,7 +6254,7 @@ msgstr ""
 " -V, --version\n"
 "    Afficher les informations relative à la version\n"
 
-#: plugins/utils.h:148
+#: plugins/utils.h:138
 #, c-format
 msgid ""
 " -H, --hostname=ADDRESS\n"
@@ -5830,7 +6267,7 @@ msgstr ""
 " -%c, --port=INTEGER\n"
 "    Numéro de port (défaut: %s)\n"
 
-#: plugins/utils.h:154
+#: plugins/utils.h:144
 msgid ""
 " -4, --use-ipv4\n"
 "    Use IPv4 connection\n"
@@ -5842,18 +6279,18 @@ msgstr ""
 " -6, --use-ipv6\n"
 "    Utiliser une connection IPv6\n"
 
-#: plugins/utils.h:160
+#: plugins/utils.h:150
 #, fuzzy
 msgid ""
 " -v, --verbose\n"
 "    Show details for command-line debugging (output may be truncated by\n"
-"\t\tthe monitoring system)\n"
+"    the monitoring system)\n"
 msgstr ""
 " -v, --verbose\n"
 "    Affiche les informations de déboguage en ligne de commande (Nagios peut "
 "tronquer la sortie)\n"
 
-#: plugins/utils.h:165
+#: plugins/utils.h:155
 msgid ""
 " -w, --warning=DOUBLE\n"
 "    Response time to result in warning status (seconds)\n"
@@ -5865,7 +6302,7 @@ msgstr ""
 " -c, --critical=DOUBLE\n"
 "    Temps de réponse résultant en un état critique (secondes)\n"
 
-#: plugins/utils.h:171
+#: plugins/utils.h:161
 msgid ""
 " -w, --warning=RANGE\n"
 "    Warning range (format: start:end). Alert if outside this range\n"
@@ -5878,7 +6315,7 @@ msgstr ""
 " -c, --critical=RANGE\n"
 "    Seuil critique\n"
 
-#: plugins/utils.h:177
+#: plugins/utils.h:167
 #, c-format
 msgid ""
 " -t, --timeout=INTEGER\n"
@@ -5887,7 +6324,16 @@ msgstr ""
 " -t, --timeout=INTEGER\n"
 "    Délais de connection en secondes (défaut: %d)\n"
 
-#: plugins/utils.h:182
+#: plugins/utils.h:171
+#, fuzzy, c-format
+msgid ""
+" -t, --timeout=INTEGER\n"
+"    Seconds before plugin times out (default: %d)\n"
+msgstr ""
+" -t, --timeout=INTEGER\n"
+"    Délais de connection en secondes (défaut: %d)\n"
+
+#: plugins/utils.h:176
 #, fuzzy
 msgid ""
 " --extra-opts=[section][@file]\n"
@@ -5900,7 +6346,7 @@ msgstr ""
 "    https://www.monitoring-plugins.org/doc/extra-opts.html\n"
 "    pour les instructions et examples.\n"
 
-#: plugins/utils.h:190
+#: plugins/utils.h:185
 #, fuzzy
 msgid ""
 " See:\n"
@@ -5912,7 +6358,7 @@ msgstr ""
 "html#THRESHOLDFORMAT\n"
 " pour le format et examples des seuils (THRESHOLD).\n"
 
-#: plugins/utils.h:195
+#: plugins/utils.h:190
 #, fuzzy
 msgid ""
 "\n"
@@ -5922,14 +6368,13 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Envoyez un email à help@monitoring-plugins.org si vous avez des "
-"questions\n"
+"Envoyez un email à help@monitoring-plugins.org si vous avez des questions\n"
 "reliées à l'utilisation de ce logiciel. Pour envoyer des patches ou suggérer "
 "des\n"
 "améliorations, envoyez un email à devel@monitoring-plugins.org\n"
 "\n"
 
-#: plugins/utils.h:200
+#: plugins/utils.h:195
 #, fuzzy
 msgid ""
 "\n"
@@ -5943,25 +6388,25 @@ msgstr ""
 "des copies des plugins selon les termes de la GNU General Public License.\n"
 "Pour de plus ample informations, voir le fichier COPYING.\n"
 
-#: plugins-root/check_dhcp.c:320
+#: plugins-root/check_dhcp.c:317
 #, c-format
 msgid "Error: Could not get hardware address of interface '%s'\n"
 msgstr ""
 "Erreur: Impossible d'obtenir l'adresse matérielle pour l'interface '%s'\n"
 
-#: plugins-root/check_dhcp.c:342
+#: plugins-root/check_dhcp.c:340
 #, c-format
 msgid "Error: if_nametoindex error - %s.\n"
 msgstr "Erreur: if_nametoindex erreur - %s.\n"
 
-#: plugins-root/check_dhcp.c:347
+#: plugins-root/check_dhcp.c:345
 #, c-format
 msgid "Error: Couldn't get hardware address from %s. sysctl 1 error - %s.\n"
 msgstr ""
 "Erreur: Impossible d'obtenir l'adresse matérielle depuis %s. erreur sysctl 1 "
 "- %s.\n"
 
-#: plugins-root/check_dhcp.c:352
+#: plugins-root/check_dhcp.c:350
 #, c-format
 msgid ""
 "Error: Couldn't get hardware address from interface %s. malloc error - %s.\n"
@@ -5969,14 +6414,14 @@ msgstr ""
 "Erreur: Impossible d'obtenir l'adresse matérielle depuis l'interface %s\n"
 " erreur malloc - %s.\n"
 
-#: plugins-root/check_dhcp.c:357
+#: plugins-root/check_dhcp.c:355
 #, c-format
 msgid "Error: Couldn't get hardware address from %s. sysctl 2 error - %s.\n"
 msgstr ""
 "Erreur: Impossible d'obtenir l'adresse matérielle depuis %s erreur sysctl 2 "
 "- %s.\n"
 
-#: plugins-root/check_dhcp.c:388
+#: plugins-root/check_dhcp.c:386
 #, c-format
 msgid ""
 "Error: can't find unit number in interface_name (%s) - expecting TypeNumber "
@@ -5985,7 +6430,7 @@ msgstr ""
 "Erreur: impossible de trouver le numéro dans le nom de l'interface (%s).\n"
 "J'attendais le nom suivi du type ex lnc0.\n"
 
-#: plugins-root/check_dhcp.c:393 plugins-root/check_dhcp.c:405
+#: plugins-root/check_dhcp.c:391 plugins-root/check_dhcp.c:403
 #, c-format
 msgid ""
 "Error: can't read MAC address from DLPI streams interface for device %s unit "
@@ -5994,7 +6439,7 @@ msgstr ""
 "Erreur: impossible de lire l'adresse MAC depuis l'interface DLPI pour le \n"
 "périphérique %s numéro %d.\n"
 
-#: plugins-root/check_dhcp.c:411
+#: plugins-root/check_dhcp.c:409
 #, c-format
 msgid ""
 "Error: can't get MAC address for this architecture.  Use the --mac option.\n"
@@ -6002,47 +6447,47 @@ msgstr ""
 "Erreur: impossible d'obtenir l'adresse MAC sur cette architecture.  Utilisez "
 "l'option --mac.\n"
 
-#: plugins-root/check_dhcp.c:430
+#: plugins-root/check_dhcp.c:428
 #, c-format
 msgid "Error: Cannot determine IP address of interface %s\n"
 msgstr "Erreur: Impossible d'obtenir l'adresse IP de l'interface %s\n"
 
-#: plugins-root/check_dhcp.c:438
+#: plugins-root/check_dhcp.c:436
 #, c-format
 msgid "Error: Cannot get interface IP address on this platform.\n"
 msgstr "Erreur: Impossible d'obtenir l'adresse IP sur cette architecture.\n"
 
-#: plugins-root/check_dhcp.c:443
+#: plugins-root/check_dhcp.c:441
 #, c-format
 msgid "Pretending to be relay client %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:528
+#: plugins-root/check_dhcp.c:521
 #, c-format
 msgid "DHCPDISCOVER to %s port %d\n"
 msgstr "DHCPDISCOVER vers %s port %d\n"
 
-#: plugins-root/check_dhcp.c:580
+#: plugins-root/check_dhcp.c:573
 #, c-format
 msgid "Result=ERROR\n"
 msgstr "Résultat=ERREUR\n"
 
-#: plugins-root/check_dhcp.c:586
+#: plugins-root/check_dhcp.c:579
 #, c-format
 msgid "Result=OK\n"
 msgstr "Résultat=OK\n"
 
-#: plugins-root/check_dhcp.c:596
+#: plugins-root/check_dhcp.c:589
 #, c-format
 msgid "DHCPOFFER from IP address %s"
 msgstr "DHCPOFFER depuis l'adresse IP %s"
 
-#: plugins-root/check_dhcp.c:597
+#: plugins-root/check_dhcp.c:590
 #, c-format
 msgid " via %s\n"
 msgstr " depuis %s\n"
 
-#: plugins-root/check_dhcp.c:604
+#: plugins-root/check_dhcp.c:597
 #, c-format
 msgid ""
 "DHCPOFFER XID (%u) did not match DHCPDISCOVER XID (%u) - ignoring packet\n"
@@ -6050,67 +6495,67 @@ msgstr ""
 "DHCPOFFER XID (%u) ne correspond pas au DHCPDISCOVER XID (%u) - paquet "
 "ignoré\n"
 
-#: plugins-root/check_dhcp.c:626
+#: plugins-root/check_dhcp.c:619
 #, c-format
 msgid "DHCPOFFER hardware address did not match our own - ignoring packet\n"
 msgstr ""
 "l'adresse matérielle du DHCPOFFER ne correspond pas à la notre paquet "
 "ignoré\n"
 
-#: plugins-root/check_dhcp.c:644
+#: plugins-root/check_dhcp.c:637
 #, c-format
 msgid "Total responses seen on the wire: %d\n"
 msgstr "Nombre total de réponses vues: %d\n"
 
-#: plugins-root/check_dhcp.c:645
+#: plugins-root/check_dhcp.c:638
 #, c-format
 msgid "Valid responses for this machine: %d\n"
 msgstr "Nombre de réponse valides pour cette machine: %d\n"
 
-#: plugins-root/check_dhcp.c:660
+#: plugins-root/check_dhcp.c:653
 #, c-format
 msgid "send_dhcp_packet result: %d\n"
 msgstr "résultat de send_dchp_packet: %d\n"
 
-#: plugins-root/check_dhcp.c:693
+#: plugins-root/check_dhcp.c:686
 #, c-format
 msgid "No (more) data received (nfound: %d)\n"
 msgstr "Plus de données reçues (nfound: %d)\n"
 
-#: plugins-root/check_dhcp.c:712
+#: plugins-root/check_dhcp.c:699
 #, c-format
 msgid "recvfrom() failed, "
 msgstr "recvfrom() a échoué, "
 
-#: plugins-root/check_dhcp.c:719
+#: plugins-root/check_dhcp.c:706
 #, c-format
 msgid "receive_dhcp_packet() result: %d\n"
 msgstr "résultat de receive_dchp_packet(): %d\n"
 
-#: plugins-root/check_dhcp.c:720
+#: plugins-root/check_dhcp.c:707
 #, c-format
 msgid "receive_dhcp_packet() source: %s\n"
 msgstr "source de receive_dchp_packet(): %s\n"
 
-#: plugins-root/check_dhcp.c:750
+#: plugins-root/check_dhcp.c:737
 #, c-format
 msgid "Error: Could not create socket!\n"
 msgstr "Erreur: Impossible de créer un socket!\n"
 
-#: plugins-root/check_dhcp.c:760
+#: plugins-root/check_dhcp.c:747
 #, c-format
 msgid "Error: Could not set reuse address option on DHCP socket!\n"
 msgstr ""
 "Erreur: Impossible de configurer l'option de réutilisation de l'adresse sur\n"
 "le socket DHCP!\n"
 
-#: plugins-root/check_dhcp.c:766
+#: plugins-root/check_dhcp.c:753
 #, c-format
 msgid "Error: Could not set broadcast option on DHCP socket!\n"
 msgstr ""
 "Erreur: Impossible de configurer l'option broadcast sur le socket DHCP!\n"
 
-#: plugins-root/check_dhcp.c:775
+#: plugins-root/check_dhcp.c:762
 #, c-format
 msgid ""
 "Error: Could not bind socket to interface %s.  Check your privileges...\n"
@@ -6118,7 +6563,7 @@ msgstr ""
 "Erreur: Impossible de connecter le socket à l'interface %s.\n"
 "Vérifiez vos droits...\n"
 
-#: plugins-root/check_dhcp.c:786
+#: plugins-root/check_dhcp.c:773
 #, c-format
 msgid ""
 "Error: Could not bind to DHCP socket (port %d)!  Check your privileges...\n"
@@ -6126,256 +6571,289 @@ msgstr ""
 "Erreur: Impossible de se connecter au socket (port %d)!  Vérifiez vos "
 "droits..\n"
 
-#: plugins-root/check_dhcp.c:820
+#: plugins-root/check_dhcp.c:807
 #, c-format
 msgid "Requested server address: %s\n"
 msgstr "Adresse serveur demandée: %s\n"
 
-#: plugins-root/check_dhcp.c:882
+#: plugins-root/check_dhcp.c:869
 #, c-format
 msgid "Lease Time: Infinite\n"
 msgstr "Durée du Bail: Infini\n"
 
-#: plugins-root/check_dhcp.c:884
+#: plugins-root/check_dhcp.c:871
 #, c-format
 msgid "Lease Time: %lu seconds\n"
 msgstr "Durée du Bail: %lu secondes\n"
 
-#: plugins-root/check_dhcp.c:886
+#: plugins-root/check_dhcp.c:873
 #, c-format
 msgid "Renewal Time: Infinite\n"
 msgstr "Renouvellement du bail: Infini\n"
 
-#: plugins-root/check_dhcp.c:888
+#: plugins-root/check_dhcp.c:875
 #, c-format
 msgid "Renewal Time: %lu seconds\n"
 msgstr "Durée du renouvellement = %lu secondes\n"
 
-#: plugins-root/check_dhcp.c:890
+#: plugins-root/check_dhcp.c:877
 #, c-format
 msgid "Rebinding Time: Infinite\n"
 msgstr "Délai de nouvelle demande: Infini\n"
 
-#: plugins-root/check_dhcp.c:891
+#: plugins-root/check_dhcp.c:878
 #, c-format
 msgid "Rebinding Time: %lu seconds\n"
 msgstr "Délai de nouvelle demande: %lu secondes\n"
 
-#: plugins-root/check_dhcp.c:919
+#: plugins-root/check_dhcp.c:906
 #, c-format
 msgid "Added offer from server @ %s"
 msgstr "Rajouté offre du serveur @ %s"
 
-#: plugins-root/check_dhcp.c:920
+#: plugins-root/check_dhcp.c:907
 #, c-format
 msgid " of IP address %s\n"
 msgstr "de l'adresse IP %s\n"
 
-#: plugins-root/check_dhcp.c:987
+#: plugins-root/check_dhcp.c:974
 #, c-format
 msgid "DHCP Server Match: Offerer=%s"
 msgstr "Correspondance du serveur DHCP: Offrant=%s"
 
-#: plugins-root/check_dhcp.c:988
+#: plugins-root/check_dhcp.c:975
 #, c-format
 msgid " Requested=%s"
 msgstr " Demandé=%s"
 
-#: plugins-root/check_dhcp.c:990
+#: plugins-root/check_dhcp.c:977
 #, c-format
 msgid " (duplicate)"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:991
+#: plugins-root/check_dhcp.c:978
 #, c-format
 msgid "\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1039
+#: plugins-root/check_dhcp.c:1026
 #, c-format
 msgid "No DHCPOFFERs were received.\n"
 msgstr "Pas de DHCPOFFERs reçus.\n"
 
-#: plugins-root/check_dhcp.c:1043
+#: plugins-root/check_dhcp.c:1030
 #, c-format
 msgid "Received %d DHCPOFFER(s)"
 msgstr "Reçu %d DHCPOFFER(s)"
 
-#: plugins-root/check_dhcp.c:1046
+#: plugins-root/check_dhcp.c:1033
 #, c-format
 msgid ", %s%d of %d requested servers responded"
 msgstr ", %s%d de %d serveurs ont répondus"
 
-#: plugins-root/check_dhcp.c:1049
+#: plugins-root/check_dhcp.c:1036
 #, c-format
 msgid ", requested address (%s) was %soffered"
 msgstr ", l'adresse demandée (%s) %s été offerte"
 
-#: plugins-root/check_dhcp.c:1049
+#: plugins-root/check_dhcp.c:1036
 msgid "not "
 msgstr "n'as pas"
 
-#: plugins-root/check_dhcp.c:1051
+#: plugins-root/check_dhcp.c:1038
 #, c-format
 msgid ", max lease time = "
 msgstr ", bail maximum = "
 
-#: plugins-root/check_dhcp.c:1053
+#: plugins-root/check_dhcp.c:1040
 #, c-format
 msgid "Infinity"
 msgstr "Infini"
 
-#: plugins-root/check_dhcp.c:1234
+#: plugins-root/check_dhcp.c:1160
+msgid "Got unexpected non-option argument"
+msgstr ""
+
+#: plugins-root/check_dhcp.c:1202
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in check_ctrl: %s.\n"
 msgstr ""
 "Erreur: Impossible d'obtenir la MAC par l'API DLPI dans check_ctrl: %s.\n"
 
-#: plugins-root/check_dhcp.c:1246
+#: plugins-root/check_dhcp.c:1214
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in put_ctrl/putmsg(): %s.\n"
 msgstr ""
 "Erreur: Impossible d'obtenir la MAC par l'API DLPI dans put_ctrl/putmsg(): "
 "%s.\n"
 
-#: plugins-root/check_dhcp.c:1259
+#: plugins-root/check_dhcp.c:1227
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in put_both/putmsg().\n"
 msgstr ""
 "Erreur: Impossible d'obtenir la MAC par l'API DLPI dans put_both/putmsg().\n"
 
-#: plugins-root/check_dhcp.c:1271
+#: plugins-root/check_dhcp.c:1239
 #, c-format
 msgid ""
 "Error: DLPI stream API failed to get MAC in dl_attach_req/open(%s..): %s.\n"
 msgstr ""
-"Erreur: Impossible d'obtenir la MAC par l'API DLPI dans dl_attach_req/open"
-"(%s..): %s.\n"
+"Erreur: Impossible d'obtenir la MAC par l'API DLPI dans dl_attach_req/"
+"open(%s..): %s.\n"
 
-#: plugins-root/check_dhcp.c:1295
+#: plugins-root/check_dhcp.c:1263
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in dl_bind/check_ctrl(): %s.\n"
 msgstr ""
-"Erreur: Impossible d'obtenir la MAC par l'API DLPI dans dl_bind/check_ctrl"
-"(): %s.\n"
+"Erreur: Impossible d'obtenir la MAC par l'API DLPI dans dl_bind/"
+"check_ctrl(): %s.\n"
 
-#: plugins-root/check_dhcp.c:1374
+#: plugins-root/check_dhcp.c:1342
 #, c-format
 msgid "Hardware address: "
 msgstr "Adresse matérielle: "
 
-#: plugins-root/check_dhcp.c:1390
+#: plugins-root/check_dhcp.c:1358
 msgid "This plugin tests the availability of DHCP servers on a network."
 msgstr "Ce plugin teste la disponibilité de serveurs DHCP dans un réseau."
 
-#: plugins-root/check_dhcp.c:1402
+#: plugins-root/check_dhcp.c:1370
 msgid "IP address of DHCP server that we must hear from"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1404
+#: plugins-root/check_dhcp.c:1372
 msgid "IP address that should be offered by at least one DHCP server"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1406
+#: plugins-root/check_dhcp.c:1374
 msgid "Seconds to wait for DHCPOFFER before timeout occurs"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1408
+#: plugins-root/check_dhcp.c:1376
 msgid "Interface to to use for listening (i.e. eth0)"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1410
+#: plugins-root/check_dhcp.c:1378
 msgid "MAC address to use in the DHCP request"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1412
+#: plugins-root/check_dhcp.c:1380
 msgid "Unicast testing: mimic a DHCP relay, requires -s"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1295
+#: plugins-root/check_icmp.c:1567
 msgid "specify a target"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1297
+#: plugins-root/check_icmp.c:1569
+msgid "Use IPv4 (default) or IPv6 to communicate with the targets"
+msgstr ""
+
+#: plugins-root/check_icmp.c:1571
 msgid "warning threshold (currently "
 msgstr "Valeurs pour le seuil d'avertissement (actuellement "
 
-#: plugins-root/check_icmp.c:1300
+#: plugins-root/check_icmp.c:1574
 msgid "critical threshold (currently "
 msgstr "Valeurs pour le seuil critique (actuellement "
 
-#: plugins-root/check_icmp.c:1303
+#: plugins-root/check_icmp.c:1577
 msgid "specify a source IP address or device name"
 msgstr "spécifiez une adresse ou un nom d'hôte"
 
-#: plugins-root/check_icmp.c:1305
+#: plugins-root/check_icmp.c:1579
 msgid "number of packets to send (currently "
 msgstr "nombre de paquets à envoyer (actuellement "
 
-#: plugins-root/check_icmp.c:1308
+#: plugins-root/check_icmp.c:1582
 msgid "max packet interval (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1311
+#: plugins-root/check_icmp.c:1585
 msgid "max target interval (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1314
+#: plugins-root/check_icmp.c:1588
 msgid "number of alive hosts required for success"
 msgstr "nombre d'hôtes vivants requis pour réussite"
 
-#: plugins-root/check_icmp.c:1317
+#: plugins-root/check_icmp.c:1591
 msgid "TTL on outgoing packets (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1320
+#: plugins-root/check_icmp.c:1594
 msgid "timeout value (seconds, currently  "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1323
+#: plugins-root/check_icmp.c:1597
 msgid "Number of icmp data bytes to send"
 msgstr "Nombre de paquets ICMP à envoyer"
 
-#: plugins-root/check_icmp.c:1324
+#: plugins-root/check_icmp.c:1598
 msgid "Packet size will be data bytes + icmp header (currently"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1326
+#: plugins-root/check_icmp.c:1600
 msgid "verbose"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1330
+#: plugins-root/check_icmp.c:1604
 msgid "The -H switch is optional. Naming a host (or several) to check is not."
 msgstr ""
 
-#: plugins-root/check_icmp.c:1332
+#: plugins-root/check_icmp.c:1606
 msgid ""
 "Threshold format for -w and -c is 200.25,60% for 200.25 msec RTA and 60%"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1333
+#: plugins-root/check_icmp.c:1607
 msgid "packet loss.  The default values should work well for most users."
 msgstr ""
 
-#: plugins-root/check_icmp.c:1334
+#: plugins-root/check_icmp.c:1608
 msgid ""
 "You can specify different RTA factors using the standardized abbreviations"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1335
+#: plugins-root/check_icmp.c:1609
 msgid ""
 "us (microseconds), ms (milliseconds, default) or just plain s for seconds."
 msgstr ""
 
-#: plugins-root/check_icmp.c:1341
+#: plugins-root/check_icmp.c:1615
 msgid "The -v switch can be specified several times for increased verbosity."
 msgstr ""
 
-#~ msgid "Critical threshold must be integer"
-#~ msgstr "le seuil critique doit être un entier positif"
+#~ msgid "Path or partition (may be repeated)"
+#~ msgstr "Répertoire ou partition (peut être utilisé plusieurs fois)"
 
-#~ msgid "Warning threshold must be integer"
-#~ msgstr "Le seuil d'avertissement doit être un entier positif"
+#~ msgid ""
+#~ "value match). If multiple addresses are returned at once, you have to "
+#~ "match"
+#~ msgstr ""
+#~ "valeur correspond). Si plusieurs adresses sont retournées en même temps,"
+
+#~ msgid ""
+#~ "the whole string of addresses separated with commas (sorted "
+#~ "alphabetically)."
+#~ msgstr ""
+#~ "vous devrez toutes les inscrire séparées pas des virgules (en ordre "
+#~ "alphabétique)"
+
+#~ msgid "No specific parameters. No warning or critical threshold"
+#~ msgstr "Pas d'argument spécifique. Pas de seuil d'avertissement ou critique"
+
+#~ msgid "Can't find local IP for NAS-IP-Address"
+#~ msgstr "Impossible de trouver une addresse IP locale pour le NAS-IP-Address"
+
+#~ msgid "Warning free space should be more than critical free space"
+#~ msgstr ""
+#~ "Le seuil d'avertissement pour la place libre doit être plus grand que le "
+#~ "seuil critique"
+
+#, c-format
+#~ msgid "%s - Plugin timed out after %d seconds\n"
+#~ msgstr "%s - Le plugin n'as pas répondu dans les %d secondes\n"
 
 #~ msgid "Critical Process Count must be an integer!"
 #~ msgstr "Critique Le total des processus doit être un nombre entier!"

--- a/po/fr.po
+++ b/po/fr.po
@@ -4848,7 +4848,7 @@ msgstr ""
 
 #: plugins/check_smtp.c:836
 msgid "Use PROXY protocol prefix for the connection."
-msgstr ""
+msgstr "Utiliser le préfixe du protocole PROXY pour la connexion."
 
 #: plugins/check_smtp.c:839 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."

--- a/po/monitoring-plugins.pot
+++ b/po/monitoring-plugins.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2014-01-19 16:30-0500\n"
+"POT-Creation-Date: 2023-06-12 16:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,783 +18,837 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: plugins/check_by_ssh.c:86 plugins/check_cluster.c:76 plugins/check_dig.c:88
-#: plugins/check_disk.c:194 plugins/check_dns.c:102 plugins/check_dummy.c:52
-#: plugins/check_fping.c:93 plugins/check_game.c:82 plugins/check_hpjd.c:103
-#: plugins/check_http.c:167 plugins/check_ldap.c:109 plugins/check_load.c:122
-#: plugins/check_mrtgtraf.c:83 plugins/check_mysql.c:122
-#: plugins/check_nagios.c:91 plugins/check_nt.c:127 plugins/check_ntp.c:770
-#: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:552
+#: plugins/check_by_ssh.c:88 plugins/check_cluster.c:76 plugins/check_dig.c:91
+#: plugins/check_disk.c:206 plugins/check_dns.c:106 plugins/check_dummy.c:52
+#: plugins/check_fping.c:95 plugins/check_game.c:82 plugins/check_hpjd.c:105
+#: plugins/check_http.c:174 plugins/check_ldap.c:118 plugins/check_load.c:128
+#: plugins/check_mrtgtraf.c:83 plugins/check_mysql.c:124
+#: plugins/check_nagios.c:91 plugins/check_nt.c:127 plugins/check_ntp.c:780
+#: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:557
 #: plugins/check_nwstat.c:173 plugins/check_overcr.c:102
-#: plugins/check_pgsql.c:172 plugins/check_ping.c:95 plugins/check_procs.c:172
-#: plugins/check_radius.c:160 plugins/check_real.c:80 plugins/check_smtp.c:144
-#: plugins/check_snmp.c:240 plugins/check_ssh.c:73 plugins/check_swap.c:110
-#: plugins/check_tcp.c:218 plugins/check_time.c:78 plugins/check_ups.c:122
-#: plugins/check_users.c:77 plugins/negate.c:214 plugins-root/check_dhcp.c:270
+#: plugins/check_pgsql.c:174 plugins/check_ping.c:97 plugins/check_procs.c:176
+#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:145
+#: plugins/check_snmp.c:248 plugins/check_ssh.c:74 plugins/check_swap.c:115
+#: plugins/check_tcp.c:222 plugins/check_time.c:78 plugins/check_ups.c:122
+#: plugins/check_users.c:84 plugins/negate.c:210 plugins-root/check_dhcp.c:270
 msgid "Could not parse arguments"
 msgstr ""
 
-#: plugins/check_by_ssh.c:90 plugins/check_dig.c:82 plugins/check_dns.c:95
-#: plugins/check_nagios.c:95 plugins/check_pgsql.c:178 plugins/check_ping.c:99
-#: plugins/check_procs.c:188 plugins/check_snmp.c:336 plugins/negate.c:79
+#: plugins/check_by_ssh.c:92 plugins/check_dig.c:85 plugins/check_dns.c:99
+#: plugins/check_nagios.c:95 plugins/check_pgsql.c:180 plugins/check_ping.c:101
+#: plugins/check_procs.c:192 plugins/check_snmp.c:348 plugins/negate.c:78
 msgid "Cannot catch SIGALRM"
 msgstr ""
 
-#: plugins/check_by_ssh.c:110
+#: plugins/check_by_ssh.c:107
+#, c-format
+msgid "SSH connection failed: %s\n"
+msgstr ""
+
+#: plugins/check_by_ssh.c:126
 #, c-format
 msgid "Remote command execution failed: %s\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:122
+#: plugins/check_by_ssh.c:141
 #, c-format
 msgid "%s - check_by_ssh: Remote command '%s' returned status %d\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:134
+#: plugins/check_by_ssh.c:153
 #, c-format
 msgid "SSH WARNING: could not open %s\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:143
+#: plugins/check_by_ssh.c:162
 #, c-format
 msgid "%s: Error parsing output\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:220 plugins/check_disk.c:476
-#: plugins/check_http.c:278 plugins/check_ldap.c:293 plugins/check_pgsql.c:311
-#: plugins/check_procs.c:437 plugins/check_radius.c:308
-#: plugins/check_real.c:356 plugins/check_smtp.c:581 plugins/check_snmp.c:736
-#: plugins/check_ssh.c:138 plugins/check_tcp.c:505 plugins/check_time.c:302
-#: plugins/check_ups.c:556 plugins/negate.c:164
+#: plugins/check_by_ssh.c:242 plugins/check_disk.c:568 plugins/check_http.c:292
+#: plugins/check_ldap.c:334 plugins/check_pgsql.c:314 plugins/check_procs.c:461
+#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:601
+#: plugins/check_snmp.c:789 plugins/check_ssh.c:140 plugins/check_tcp.c:519
+#: plugins/check_time.c:302 plugins/check_ups.c:559 plugins/negate.c:160
 msgid "Timeout interval must be a positive integer"
 msgstr ""
 
-#: plugins/check_by_ssh.c:230 plugins/check_pgsql.c:341
-#: plugins/check_radius.c:272 plugins/check_real.c:327
-#: plugins/check_smtp.c:506 plugins/check_tcp.c:511 plugins/check_time.c:296
-#: plugins/check_ups.c:518
+#: plugins/check_by_ssh.c:254 plugins/check_pgsql.c:344
+#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:526
+#: plugins/check_tcp.c:525 plugins/check_time.c:296 plugins/check_ups.c:521
 msgid "Port must be a positive integer"
 msgstr ""
 
-#: plugins/check_by_ssh.c:291
+#: plugins/check_by_ssh.c:315
 msgid "skip-stdout argument must be an integer"
 msgstr ""
 
-#: plugins/check_by_ssh.c:299
+#: plugins/check_by_ssh.c:323
 msgid "skip-stderr argument must be an integer"
 msgstr ""
 
-#: plugins/check_by_ssh.c:322
+#: plugins/check_by_ssh.c:349
 #, c-format
 msgid "%s: You must provide a host name\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:340
+#: plugins/check_by_ssh.c:366
 msgid "No remotecmd"
 msgstr ""
 
-#: plugins/check_by_ssh.c:354
+#: plugins/check_by_ssh.c:380
 #, c-format
 msgid "%s: Argument limit of %d exceeded\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:357
+#: plugins/check_by_ssh.c:383
 msgid "Can not (re)allocate 'commargv' buffer\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:371
+#: plugins/check_by_ssh.c:397
 #, c-format
 msgid ""
 "%s: In passive mode, you must provide a service name for each command.\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:374
+#: plugins/check_by_ssh.c:400
 #, c-format
 msgid ""
 "%s: In passive mode, you must provide the host short name from the "
 "monitoring configs.\n"
 msgstr ""
 
-#: plugins/check_by_ssh.c:388
+#: plugins/check_by_ssh.c:414
 #, c-format
 msgid "This plugin uses SSH to execute commands on a remote host"
 msgstr ""
 
-#: plugins/check_by_ssh.c:403
+#: plugins/check_by_ssh.c:429
 msgid "tell ssh to use Protocol 1 [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:405
+#: plugins/check_by_ssh.c:431
 msgid "tell ssh to use Protocol 2 [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:407
+#: plugins/check_by_ssh.c:433
 msgid "Ignore all or (if specified) first n lines on STDOUT [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:409
+#: plugins/check_by_ssh.c:435
 msgid "Ignore all or (if specified) first n lines on STDERR [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:411
+#: plugins/check_by_ssh.c:437
+msgid "Exit with an warning, if there is an output on STDERR"
+msgstr ""
+
+#: plugins/check_by_ssh.c:439
 msgid ""
 "tells ssh to fork rather than create a tty [optional]. This will always "
 "return OK if ssh is executed"
 msgstr ""
 
-#: plugins/check_by_ssh.c:413
+#: plugins/check_by_ssh.c:441
 msgid "command to execute on the remote machine"
 msgstr ""
 
-#: plugins/check_by_ssh.c:415
+#: plugins/check_by_ssh.c:443
 msgid "SSH user name on remote host [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:417
+#: plugins/check_by_ssh.c:445
 msgid "identity of an authorized key [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:419
+#: plugins/check_by_ssh.c:447
 msgid "external command file for monitoring [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:421
+#: plugins/check_by_ssh.c:449
 msgid "list of monitoring service names, separated by ':' [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:423
+#: plugins/check_by_ssh.c:451
 msgid "short name of host in the monitoring configuration [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:425
+#: plugins/check_by_ssh.c:453
 msgid "Call ssh with '-o OPTION' (may be used multiple times) [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:427
+#: plugins/check_by_ssh.c:455
 msgid "Tell ssh to use this configfile [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:429
+#: plugins/check_by_ssh.c:457
 msgid "Tell ssh to suppress warning and diagnostic messages [optional]"
 msgstr ""
 
-#: plugins/check_by_ssh.c:434
+#: plugins/check_by_ssh.c:461
+msgid "Make connection problems return UNKNOWN instead of CRITICAL"
+msgstr ""
+
+#: plugins/check_by_ssh.c:464
 msgid "The most common mode of use is to refer to a local identity file with"
 msgstr ""
 
-#: plugins/check_by_ssh.c:435
+#: plugins/check_by_ssh.c:465
 msgid "the '-i' option. In this mode, the identity pair should have a null"
 msgstr ""
 
-#: plugins/check_by_ssh.c:436
+#: plugins/check_by_ssh.c:466
 msgid "passphrase and the public key should be listed in the authorized_keys"
 msgstr ""
 
-#: plugins/check_by_ssh.c:437
+#: plugins/check_by_ssh.c:467
 msgid "file of the remote host. Usually the key will be restricted to running"
 msgstr ""
 
-#: plugins/check_by_ssh.c:438
+#: plugins/check_by_ssh.c:468
 msgid "only one command on the remote server. If the remote SSH server tracks"
 msgstr ""
 
-#: plugins/check_by_ssh.c:439
+#: plugins/check_by_ssh.c:469
 msgid "invocation arguments, the one remote program may be an agent that can"
 msgstr ""
 
-#: plugins/check_by_ssh.c:440
+#: plugins/check_by_ssh.c:470
 msgid "execute additional commands as proxy"
 msgstr ""
 
-#: plugins/check_by_ssh.c:442
+#: plugins/check_by_ssh.c:472
 msgid "To use passive mode, provide multiple '-C' options, and provide"
 msgstr ""
 
-#: plugins/check_by_ssh.c:443
+#: plugins/check_by_ssh.c:473
 msgid ""
 "all of -O, -s, and -n options (servicelist order must match '-C'options)"
 msgstr ""
 
-#: plugins/check_by_ssh.c:445 plugins/check_cluster.c:261
-#: plugins/check_dig.c:355 plugins/check_disk.c:924 plugins/check_http.c:1560
-#: plugins/check_nagios.c:312 plugins/check_ntp.c:869
-#: plugins/check_ntp_peer.c:705 plugins/check_ntp_time.c:633
-#: plugins/check_procs.c:763 plugins/negate.c:271 plugins/urlize.c:180
+#: plugins/check_by_ssh.c:475 plugins/check_cluster.c:271
+#: plugins/check_dig.c:364 plugins/check_disk.c:1000 plugins/check_http.c:1845
+#: plugins/check_nagios.c:312 plugins/check_ntp.c:879
+#: plugins/check_ntp_peer.c:733 plugins/check_ntp_time.c:642
+#: plugins/check_procs.c:806 plugins/negate.c:249 plugins/urlize.c:179
 msgid "Examples:"
 msgstr ""
 
-#: plugins/check_by_ssh.c:460 plugins/check_cluster.c:274
-#: plugins/check_dig.c:367 plugins/check_disk.c:941 plugins/check_dns.c:486
-#: plugins/check_dummy.c:122 plugins/check_fping.c:505
-#: plugins/check_game.c:331 plugins/check_hpjd.c:414 plugins/check_http.c:1590
-#: plugins/check_ldap.c:451 plugins/check_load.c:334 plugins/check_mrtg.c:382
-#: plugins/check_mysql.c:569 plugins/check_nagios.c:323 plugins/check_nt.c:774
-#: plugins/check_ntp.c:888 plugins/check_ntp_peer.c:725
-#: plugins/check_ntp_time.c:642 plugins/check_nwstat.c:1685
-#: plugins/check_overcr.c:467 plugins/check_pgsql.c:578
-#: plugins/check_ping.c:603 plugins/check_procs.c:781
-#: plugins/check_radius.c:385 plugins/check_real.c:451
-#: plugins/check_smtp.c:843 plugins/check_snmp.c:1207 plugins/check_ssh.c:309
-#: plugins/check_swap.c:558 plugins/check_tcp.c:684 plugins/check_time.c:371
-#: plugins/check_ups.c:660 plugins/check_users.c:240
-#: plugins/check_ide_smart.c:640 plugins/negate.c:295 plugins/urlize.c:197
-#: plugins-root/check_dhcp.c:1422 plugins-root/check_icmp.c:1354
+#: plugins/check_by_ssh.c:490 plugins/check_cluster.c:284
+#: plugins/check_dig.c:376 plugins/check_disk.c:1017 plugins/check_dns.c:617
+#: plugins/check_dummy.c:122 plugins/check_fping.c:524 plugins/check_game.c:331
+#: plugins/check_hpjd.c:439 plugins/check_http.c:1883 plugins/check_ldap.c:511
+#: plugins/check_load.c:372 plugins/check_mrtg.c:382 plugins/check_mysql.c:587
+#: plugins/check_nagios.c:323 plugins/check_nt.c:797 plugins/check_ntp.c:898
+#: plugins/check_ntp_peer.c:753 plugins/check_ntp_time.c:651
+#: plugins/check_nwstat.c:1685 plugins/check_overcr.c:467
+#: plugins/check_pgsql.c:551 plugins/check_ping.c:617 plugins/check_procs.c:829
+#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:875
+#: plugins/check_snmp.c:1346 plugins/check_ssh.c:325 plugins/check_swap.c:607
+#: plugins/check_tcp.c:710 plugins/check_time.c:371 plugins/check_ups.c:663
+#: plugins/check_users.c:262 plugins/check_ide_smart.c:606 plugins/negate.c:273
+#: plugins/urlize.c:196 plugins-root/check_dhcp.c:1390
+#: plugins-root/check_icmp.c:1628
 msgid "Usage:"
 msgstr ""
 
-#: plugins/check_cluster.c:230
+#: plugins/check_cluster.c:240
 #, c-format
 msgid "Host/Service Cluster Plugin for Monitoring"
 msgstr ""
 
-#: plugins/check_cluster.c:236 plugins/check_nt.c:676
+#: plugins/check_cluster.c:246 plugins/check_nt.c:697
 msgid "Options:"
 msgstr ""
 
-#: plugins/check_cluster.c:239
+#: plugins/check_cluster.c:249
 msgid "Check service cluster status"
 msgstr ""
 
-#: plugins/check_cluster.c:241
+#: plugins/check_cluster.c:251
 msgid "Check host cluster status"
 msgstr ""
 
-#: plugins/check_cluster.c:243
+#: plugins/check_cluster.c:253
 msgid "Optional prepended text output (i.e. \"Host cluster\")"
 msgstr ""
 
-#: plugins/check_cluster.c:245 plugins/check_cluster.c:248
+#: plugins/check_cluster.c:255 plugins/check_cluster.c:258
 msgid "Specifies the range of hosts or services in cluster that must be in a"
 msgstr ""
 
-#: plugins/check_cluster.c:246
+#: plugins/check_cluster.c:256
 msgid "non-OK state in order to return a WARNING status level"
 msgstr ""
 
-#: plugins/check_cluster.c:249
+#: plugins/check_cluster.c:259
 msgid "non-OK state in order to return a CRITICAL status level"
 msgstr ""
 
-#: plugins/check_cluster.c:251
+#: plugins/check_cluster.c:261
 msgid "The status codes of the hosts or services in the cluster, separated by"
 msgstr ""
 
-#: plugins/check_cluster.c:252
+#: plugins/check_cluster.c:262
 msgid "commas"
 msgstr ""
 
-#: plugins/check_cluster.c:257 plugins/check_game.c:318
-#: plugins/check_http.c:1542 plugins/check_ldap.c:438 plugins/check_mrtg.c:363
-#: plugins/check_mrtgtraf.c:361 plugins/check_mysql.c:558
-#: plugins/check_nt.c:758 plugins/check_ntp.c:865 plugins/check_ntp_peer.c:696
-#: plugins/check_ntp_time.c:626 plugins/check_nwstat.c:1670
-#: plugins/check_overcr.c:456 plugins/check_snmp.c:1178
-#: plugins/check_swap.c:547 plugins/check_ups.c:642 plugins/negate.c:277
-#: plugins-root/check_icmp.c:1329
+#: plugins/check_cluster.c:267 plugins/check_game.c:318
+#: plugins/check_http.c:1827 plugins/check_ldap.c:497 plugins/check_mrtg.c:363
+#: plugins/check_mrtgtraf.c:361 plugins/check_mysql.c:576
+#: plugins/check_nt.c:781 plugins/check_ntp.c:875 plugins/check_ntp_peer.c:724
+#: plugins/check_ntp_time.c:633 plugins/check_nwstat.c:1670
+#: plugins/check_overcr.c:456 plugins/check_snmp.c:1317
+#: plugins/check_swap.c:596 plugins/check_ups.c:645
+#: plugins/check_ide_smart.c:580 plugins/negate.c:255
+#: plugins-root/check_icmp.c:1603
 msgid "Notes:"
 msgstr ""
 
-#: plugins/check_cluster.c:263
+#: plugins/check_cluster.c:273
 msgid ""
 "Will alert critical if there are 3 or more service data points in a non-OK"
 msgstr ""
 
-#: plugins/check_cluster.c:264 plugins/check_ups.c:639
+#: plugins/check_cluster.c:274 plugins/check_ups.c:642
 msgid "state."
 msgstr ""
 
-#: plugins/check_dig.c:100 plugins/check_dig.c:102
+#: plugins/check_dig.c:106 plugins/check_dig.c:108
 #, c-format
 msgid "Looking for: '%s'\n"
 msgstr ""
 
-#: plugins/check_dig.c:109
+#: plugins/check_dig.c:115
 msgid "dig returned an error status"
 msgstr ""
 
-#: plugins/check_dig.c:134
+#: plugins/check_dig.c:140
 msgid "Server not found in ANSWER SECTION"
 msgstr ""
 
-#: plugins/check_dig.c:144
+#: plugins/check_dig.c:150
 msgid "No ANSWER SECTION found"
 msgstr ""
 
-#: plugins/check_dig.c:171
+#: plugins/check_dig.c:177
 msgid "Probably a non-existent host/domain"
 msgstr ""
 
-#: plugins/check_dig.c:233
+#: plugins/check_dig.c:239
 #, c-format
 msgid "Port must be a positive integer - %s"
 msgstr ""
 
-#: plugins/check_dig.c:244
+#: plugins/check_dig.c:250
 #, c-format
 msgid "Warning interval must be a positive integer - %s"
 msgstr ""
 
-#: plugins/check_dig.c:252
+#: plugins/check_dig.c:258
 #, c-format
 msgid "Critical interval must be a positive integer - %s"
 msgstr ""
 
-#: plugins/check_dig.c:260
+#: plugins/check_dig.c:266
 #, c-format
 msgid "Timeout interval must be a positive integer - %s"
 msgstr ""
 
-#: plugins/check_dig.c:325
+#: plugins/check_dig.c:334
 #, c-format
-msgid "This plugin test the DNS service on the specified host using dig"
+msgid "This plugin tests the DNS service on the specified host using dig"
 msgstr ""
 
-#: plugins/check_dig.c:338
+#: plugins/check_dig.c:347
 msgid "Force dig to only use IPv4 query transport"
 msgstr ""
 
-#: plugins/check_dig.c:340
+#: plugins/check_dig.c:349
 msgid "Force dig to only use IPv6 query transport"
 msgstr ""
 
-#: plugins/check_dig.c:342
+#: plugins/check_dig.c:351
 msgid "Machine name to lookup"
 msgstr ""
 
-#: plugins/check_dig.c:344
+#: plugins/check_dig.c:353
 msgid "Record type to lookup (default: A)"
 msgstr ""
 
-#: plugins/check_dig.c:346
+#: plugins/check_dig.c:355
 msgid ""
 "An address expected to be in the answer section. If not set, uses whatever"
 msgstr ""
 
-#: plugins/check_dig.c:347
+#: plugins/check_dig.c:356
 msgid "was in -l"
 msgstr ""
 
-#: plugins/check_dig.c:349
+#: plugins/check_dig.c:358
 msgid "Pass STRING as argument(s) to dig"
 msgstr ""
 
-#: plugins/check_disk.c:216
+#: plugins/check_disk.c:241
 #, c-format
 msgid "DISK %s: %s not found\n"
 msgstr ""
 
-#: plugins/check_disk.c:216 plugins/check_disk.c:956 plugins/check_dns.c:241
-#: plugins/check_dummy.c:74 plugins/check_mysql.c:299
+#: plugins/check_disk.c:241 plugins/check_disk.c:1035 plugins/check_dns.c:295
+#: plugins/check_dummy.c:74 plugins/check_mysql.c:313
 #: plugins/check_nagios.c:104 plugins/check_nagios.c:168
-#: plugins/check_nagios.c:172 plugins/check_pgsql.c:601
-#: plugins/check_pgsql.c:618 plugins/check_pgsql.c:627
-#: plugins/check_pgsql.c:642 plugins/check_procs.c:351
+#: plugins/check_nagios.c:172 plugins/check_pgsql.c:575
+#: plugins/check_pgsql.c:592 plugins/check_pgsql.c:601
+#: plugins/check_pgsql.c:616 plugins/check_procs.c:374
 #, c-format
 msgid "CRITICAL"
 msgstr ""
 
-#: plugins/check_disk.c:550
+#: plugins/check_disk.c:645
 #, c-format
 msgid "unit type %s not known\n"
 msgstr ""
 
-#: plugins/check_disk.c:553
+#: plugins/check_disk.c:648
 #, c-format
 msgid "failed allocating storage for '%s'\n"
 msgstr ""
 
-#: plugins/check_disk.c:577 plugins/check_disk.c:618 plugins/check_disk.c:626
-#: plugins/check_disk.c:633 plugins/check_disk.c:637 plugins/check_disk.c:677
-#: plugins/check_disk.c:683 plugins/check_disk.c:702 plugins/check_dummy.c:77
-#: plugins/check_dummy.c:80 plugins/check_pgsql.c:643
-#: plugins/check_procs.c:506
+#: plugins/check_disk.c:676 plugins/check_disk.c:724 plugins/check_disk.c:732
+#: plugins/check_disk.c:740 plugins/check_disk.c:744 plugins/check_disk.c:789
+#: plugins/check_disk.c:795 plugins/check_disk.c:818 plugins/check_dummy.c:77
+#: plugins/check_dummy.c:80 plugins/check_pgsql.c:617 plugins/check_procs.c:547
 #, c-format
 msgid "UNKNOWN"
 msgstr ""
 
-#: plugins/check_disk.c:577
+#: plugins/check_disk.c:676
 msgid "Must set a threshold value before using -p\n"
 msgstr ""
 
-#: plugins/check_disk.c:618
+#: plugins/check_disk.c:724
 msgid "Must set -E before selecting paths\n"
 msgstr ""
 
-#: plugins/check_disk.c:626
+#: plugins/check_disk.c:732
 msgid "Must set group value before selecting paths\n"
 msgstr ""
 
-#: plugins/check_disk.c:633
+#: plugins/check_disk.c:740
 msgid ""
 "Paths need to be selected before using -i/-I. Use -A to select all paths "
 "explicitly"
 msgstr ""
 
-#: plugins/check_disk.c:637 plugins/check_disk.c:683 plugins/check_procs.c:506
+#: plugins/check_disk.c:744 plugins/check_disk.c:795 plugins/check_procs.c:547
 msgid "Could not compile regular expression"
 msgstr ""
 
-#: plugins/check_disk.c:677
+#: plugins/check_disk.c:789
 msgid "Must set a threshold value before using -r/-R\n"
 msgstr ""
 
-#: plugins/check_disk.c:703
+#: plugins/check_disk.c:819
 msgid "Regular expression did not match any path or disk"
 msgstr ""
 
-#: plugins/check_disk.c:749
+#: plugins/check_disk.c:865
 msgid "Unknown argument"
 msgstr ""
 
-#: plugins/check_disk.c:783
+#: plugins/check_disk.c:899
 #, c-format
 msgid " for %s\n"
 msgstr ""
 
-#: plugins/check_disk.c:857
+#: plugins/check_disk.c:928
 msgid ""
 "This plugin checks the amount of used disk space on a mounted file system"
 msgstr ""
 
-#: plugins/check_disk.c:858
+#: plugins/check_disk.c:929
 msgid ""
 "and generates an alert if free space is less than one of the threshold values"
 msgstr ""
 
-#: plugins/check_disk.c:868
+#: plugins/check_disk.c:939
 msgid "Exit with WARNING status if less than INTEGER units of disk are free"
 msgstr ""
 
-#: plugins/check_disk.c:870
+#: plugins/check_disk.c:941
 msgid "Exit with WARNING status if less than PERCENT of disk space is free"
 msgstr ""
 
-#: plugins/check_disk.c:872
+#: plugins/check_disk.c:943
 msgid "Exit with CRITICAL status if less than INTEGER units of disk are free"
 msgstr ""
 
-#: plugins/check_disk.c:874
+#: plugins/check_disk.c:945
 msgid "Exit with CRITICAL status if less than PERCENT of disk space is free"
 msgstr ""
 
-#: plugins/check_disk.c:876
+#: plugins/check_disk.c:947
 msgid "Exit with WARNING status if less than PERCENT of inode space is free"
 msgstr ""
 
-#: plugins/check_disk.c:878
+#: plugins/check_disk.c:949
 msgid "Exit with CRITICAL status if less than PERCENT of inode space is free"
 msgstr ""
 
-#: plugins/check_disk.c:880
-msgid "Path or partition (may be repeated)"
+#: plugins/check_disk.c:951
+msgid ""
+"Mount point or block device as emitted by the mount(8) command (may be "
+"repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:882
+#: plugins/check_disk.c:953
 msgid "Ignore device (only works if -p unspecified)"
 msgstr ""
 
-#: plugins/check_disk.c:884
+#: plugins/check_disk.c:955
 msgid "Clear thresholds"
 msgstr ""
 
-#: plugins/check_disk.c:886
+#: plugins/check_disk.c:957
 msgid "For paths or partitions specified with -p, only check for exact paths"
 msgstr ""
 
-#: plugins/check_disk.c:888
+#: plugins/check_disk.c:959
 msgid "Display only devices/mountpoints with errors"
 msgstr ""
 
-#: plugins/check_disk.c:890
+#: plugins/check_disk.c:961
 msgid "Don't account root-reserved blocks into freespace in perfdata"
 msgstr ""
 
-#: plugins/check_disk.c:892
+#: plugins/check_disk.c:963
+msgid "Display inode usage in perfdata"
+msgstr ""
+
+#: plugins/check_disk.c:965
 msgid ""
 "Group paths. Thresholds apply to (free-)space of all partitions together"
 msgstr ""
 
-#: plugins/check_disk.c:894
+#: plugins/check_disk.c:967
 msgid "Same as '--units kB'"
 msgstr ""
 
-#: plugins/check_disk.c:896
+#: plugins/check_disk.c:969
 msgid "Only check local filesystems"
 msgstr ""
 
-#: plugins/check_disk.c:898
+#: plugins/check_disk.c:971
 msgid ""
 "Only check local filesystems against thresholds. Yet call stat on remote "
 "filesystems"
 msgstr ""
 
-#: plugins/check_disk.c:899
+#: plugins/check_disk.c:972
 msgid "to test if they are accessible (e.g. to detect Stale NFS Handles)"
 msgstr ""
 
-#: plugins/check_disk.c:901
-msgid "Display the mountpoint instead of the partition"
+#: plugins/check_disk.c:974
+msgid "Display the (block) device instead of the mount point"
 msgstr ""
 
-#: plugins/check_disk.c:903
+#: plugins/check_disk.c:976
 msgid "Same as '--units MB'"
 msgstr ""
 
-#: plugins/check_disk.c:905
+#: plugins/check_disk.c:978
 msgid "Explicitly select all paths. This is equivalent to -R '.*'"
 msgstr ""
 
-#: plugins/check_disk.c:907
+#: plugins/check_disk.c:980
 msgid ""
 "Case insensitive regular expression for path/partition (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:909
+#: plugins/check_disk.c:982
 msgid "Regular expression for path or partition (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:911
+#: plugins/check_disk.c:984
 msgid ""
 "Regular expression to ignore selected path/partition (case insensitive) (may "
 "be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:913
+#: plugins/check_disk.c:986
 msgid ""
 "Regular expression to ignore selected path or partition (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:916
+#: plugins/check_disk.c:988
+msgid ""
+"Return OK if no filesystem matches, filesystem does not exist or is "
+"inaccessible."
+msgstr ""
+
+#: plugins/check_disk.c:989
+msgid "(Provide this option before -p / -r / --ereg-path if used)"
+msgstr ""
+
+#: plugins/check_disk.c:992
 msgid "Choose bytes, kB, MB, GB, TB (default: MB)"
 msgstr ""
 
-#: plugins/check_disk.c:919
+#: plugins/check_disk.c:995
 msgid "Ignore all filesystems of indicated type (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:921
+#: plugins/check_disk.c:997
 msgid "Check only filesystems of indicated type (may be repeated)"
 msgstr ""
 
-#: plugins/check_disk.c:926
+#: plugins/check_disk.c:1002
 msgid "Checks /tmp and /var at 10% and 5%, and / at 100MB and 50MB"
 msgstr ""
 
-#: plugins/check_disk.c:928
+#: plugins/check_disk.c:1004
 msgid ""
 "Checks all filesystems not matching -r at 100M and 50M. The fs matching the -"
 "r regex"
 msgstr ""
 
-#: plugins/check_disk.c:929
+#: plugins/check_disk.c:1005
 msgid ""
 "are grouped which means the freespace thresholds are applied to all disks "
 "together"
 msgstr ""
 
-#: plugins/check_disk.c:931
+#: plugins/check_disk.c:1007
 msgid ""
 "Checks /foo for 1000M/500M and /bar for 5/3%. All remaining volumes use "
 "100M/50M"
 msgstr ""
 
-#: plugins/check_disk.c:957
+#: plugins/check_disk.c:1036
 #, c-format
 msgid "%s %s: %s\n"
 msgstr ""
 
-#: plugins/check_disk.c:957
+#: plugins/check_disk.c:1036
 msgid "is not accessible"
 msgstr ""
 
-#: plugins/check_dns.c:116
+#: plugins/check_dns.c:120
 msgid "nslookup returned an error status"
 msgstr ""
 
-#: plugins/check_dns.c:134
+#: plugins/check_dns.c:138
 msgid "Warning plugin error"
 msgstr ""
 
-#: plugins/check_dns.c:154
+#: plugins/check_dns.c:156
+#, c-format
+msgid "DNS CRITICAL - '%s' returned empty server string\n"
+msgstr ""
+
+#: plugins/check_dns.c:161
+#, c-format
+msgid "DNS CRITICAL - No response from DNS %s\n"
+msgstr ""
+
+#: plugins/check_dns.c:180
 #, c-format
 msgid "DNS CRITICAL - '%s' returned empty host name string\n"
 msgstr ""
 
-#: plugins/check_dns.c:160
+#: plugins/check_dns.c:186
 msgid "Non-authoritative answer:"
 msgstr ""
 
-#: plugins/check_dns.c:201
+#: plugins/check_dns.c:215
+#, c-format
+msgid "Domain '%s' was not found by the server\n"
+msgstr ""
+
+#: plugins/check_dns.c:234
 #, c-format
 msgid "DNS CRITICAL - '%s' msg parsing exited with no address\n"
 msgstr ""
 
-#: plugins/check_dns.c:216
+#: plugins/check_dns.c:265
 #, c-format
 msgid "expected '%s' but got '%s'"
 msgstr ""
 
-#: plugins/check_dns.c:223
+#: plugins/check_dns.c:272
+#, c-format
+msgid "Domain '%s' was found by the server: '%s'\n"
+msgstr ""
+
+#: plugins/check_dns.c:282
 #, c-format
 msgid "server %s is not authoritative for %s"
 msgstr ""
 
-#: plugins/check_dns.c:237 plugins/check_dummy.c:68 plugins/check_nagios.c:182
-#: plugins/check_pgsql.c:638 plugins/check_procs.c:344
+#: plugins/check_dns.c:291 plugins/check_dummy.c:68 plugins/check_nagios.c:182
+#: plugins/check_pgsql.c:612 plugins/check_procs.c:367
 #, c-format
 msgid "OK"
 msgstr ""
 
-#: plugins/check_dns.c:239 plugins/check_dummy.c:71 plugins/check_mysql.c:296
-#: plugins/check_nagios.c:182 plugins/check_pgsql.c:607
-#: plugins/check_pgsql.c:612 plugins/check_pgsql.c:640
-#: plugins/check_procs.c:346
+#: plugins/check_dns.c:293 plugins/check_dummy.c:71 plugins/check_mysql.c:310
+#: plugins/check_nagios.c:182 plugins/check_pgsql.c:581
+#: plugins/check_pgsql.c:586 plugins/check_pgsql.c:614
+#: plugins/check_procs.c:369
 #, c-format
 msgid "WARNING"
 msgstr ""
 
-#: plugins/check_dns.c:243
+#: plugins/check_dns.c:297
 #, c-format
 msgid "%.3f second response time"
 msgid_plural "%.3f seconds response time"
 msgstr[0] ""
 msgstr[1] ""
 
-#: plugins/check_dns.c:244
+#: plugins/check_dns.c:298
 #, c-format
 msgid ". %s returns %s"
 msgstr ""
 
-#: plugins/check_dns.c:248
+#: plugins/check_dns.c:318
 #, c-format
 msgid "DNS WARNING - %s\n"
 msgstr ""
 
-#: plugins/check_dns.c:249 plugins/check_dns.c:252 plugins/check_dns.c:255
+#: plugins/check_dns.c:319 plugins/check_dns.c:322 plugins/check_dns.c:325
 msgid " Probably a non-existent host/domain"
 msgstr ""
 
-#: plugins/check_dns.c:251
+#: plugins/check_dns.c:321
 #, c-format
 msgid "DNS CRITICAL - %s\n"
 msgstr ""
 
-#: plugins/check_dns.c:254
+#: plugins/check_dns.c:324
 #, c-format
 msgid "DNS UNKNOWN - %s\n"
 msgstr ""
 
-#: plugins/check_dns.c:267
+#: plugins/check_dns.c:368
 msgid "Note: nslookup is deprecated and may be removed from future releases."
 msgstr ""
 
-#: plugins/check_dns.c:268
+#: plugins/check_dns.c:369
 msgid "Consider using the `dig' or `host' programs instead.  Run nslookup with"
 msgstr ""
 
-#: plugins/check_dns.c:269
+#: plugins/check_dns.c:370
 msgid "the `-sil[ent]' option to prevent this message from appearing."
 msgstr ""
 
-#: plugins/check_dns.c:274
+#: plugins/check_dns.c:375 plugins/check_dns.c:377
 #, c-format
 msgid "No response from DNS %s\n"
 msgstr ""
 
-#: plugins/check_dns.c:278
+#: plugins/check_dns.c:381
 #, c-format
 msgid "DNS %s has no records\n"
 msgstr ""
 
-#: plugins/check_dns.c:286
+#: plugins/check_dns.c:389
 #, c-format
 msgid "Connection to DNS %s was refused\n"
 msgstr ""
 
-#: plugins/check_dns.c:290
+#: plugins/check_dns.c:393
 #, c-format
 msgid "Query was refused by DNS server at %s\n"
 msgstr ""
 
-#: plugins/check_dns.c:294
+#: plugins/check_dns.c:397
 #, c-format
 msgid "No information returned by DNS server at %s\n"
 msgstr ""
 
-#: plugins/check_dns.c:300
-#, c-format
-msgid "Domain %s was not found by the server\n"
-msgstr ""
-
-#: plugins/check_dns.c:304
+#: plugins/check_dns.c:401
 msgid "Network is unreachable\n"
 msgstr ""
 
-#: plugins/check_dns.c:308
+#: plugins/check_dns.c:405
 #, c-format
 msgid "DNS failure for %s\n"
 msgstr ""
 
-#: plugins/check_dns.c:372 plugins/check_dns.c:380 plugins/check_dns.c:387
-#: plugins/check_dns.c:392 plugins/check_dns.c:414 plugins/check_dns.c:422
+#: plugins/check_dns.c:471 plugins/check_dns.c:479 plugins/check_dns.c:486
+#: plugins/check_dns.c:491 plugins/check_dns.c:533 plugins/check_dns.c:541
 #: plugins/check_game.c:211 plugins/check_game.c:219
 msgid "Input buffer overflow\n"
 msgstr ""
 
-#: plugins/check_dns.c:450
+#: plugins/check_dns.c:576
 msgid ""
 "This plugin uses the nslookup program to obtain the IP address for the given "
 "host/domain query."
 msgstr ""
 
-#: plugins/check_dns.c:451
+#: plugins/check_dns.c:577
 msgid "An optional DNS server to use may be specified."
 msgstr ""
 
-#: plugins/check_dns.c:452
+#: plugins/check_dns.c:578
 msgid ""
 "If no DNS server is specified, the default server(s) specified in /etc/"
 "resolv.conf will be used."
 msgstr ""
 
-#: plugins/check_dns.c:462
+#: plugins/check_dns.c:588
 msgid "The name or address you want to query"
 msgstr ""
 
-#: plugins/check_dns.c:464
+#: plugins/check_dns.c:590
 msgid "Optional DNS server you want to use for the lookup"
 msgstr ""
 
-#: plugins/check_dns.c:466
+#: plugins/check_dns.c:592
 msgid ""
-"Optional IP-ADDRESS you expect the DNS server to return. HOST must end with"
+"Optional IP-ADDRESS/CIDR you expect the DNS server to return. HOST must end"
 msgstr ""
 
-#: plugins/check_dns.c:467
+#: plugins/check_dns.c:593
 msgid ""
-"a dot (.). This option can be repeated multiple times (Returns OK if any"
+"with a dot (.). This option can be repeated multiple times (Returns OK if any"
 msgstr ""
 
-#: plugins/check_dns.c:468
-msgid ""
-"value match). If multiple addresses are returned at once, you have to match"
+#: plugins/check_dns.c:594
+msgid "value matches)."
 msgstr ""
 
-#: plugins/check_dns.c:469
+#: plugins/check_dns.c:596
 msgid ""
-"the whole string of addresses separated with commas (sorted alphabetically)."
+"Expect the DNS server to return NXDOMAIN (i.e. the domain was not found)"
 msgstr ""
 
-#: plugins/check_dns.c:471
+#: plugins/check_dns.c:597
+msgid "Cannot be used together with -a"
+msgstr ""
+
+#: plugins/check_dns.c:599
 msgid "Optionally expect the DNS server to be authoritative for the lookup"
 msgstr ""
 
-#: plugins/check_dns.c:473
+#: plugins/check_dns.c:601
 msgid "Return warning if elapsed time exceeds value. Default off"
 msgstr ""
 
-#: plugins/check_dns.c:475
+#: plugins/check_dns.c:603
 msgid "Return critical if elapsed time exceeds value. Default off"
+msgstr ""
+
+#: plugins/check_dns.c:605
+msgid ""
+"Return critical if the list of expected addresses does not match all "
+"addresses"
+msgstr ""
+
+#: plugins/check_dns.c:606
+msgid "returned. Default off"
 msgstr ""
 
 #: plugins/check_dummy.c:62
@@ -815,173 +869,182 @@ msgstr ""
 msgid "of the <state> argument with optional text"
 msgstr ""
 
-#: plugins/check_fping.c:125 plugins/check_hpjd.c:128 plugins/check_ping.c:438
-#: plugins/check_swap.c:175 plugins/check_users.c:94 plugins/urlize.c:110
+#: plugins/check_fping.c:127 plugins/check_hpjd.c:134 plugins/check_ping.c:444
+#: plugins/check_swap.c:193 plugins/check_users.c:130 plugins/urlize.c:109
 #, c-format
 msgid "Could not open pipe: %s\n"
 msgstr ""
 
-#: plugins/check_fping.c:131 plugins/check_hpjd.c:134 plugins/check_load.c:153
-#: plugins/check_swap.c:181 plugins/check_users.c:100 plugins/urlize.c:116
+#: plugins/check_fping.c:133 plugins/check_hpjd.c:140 plugins/check_load.c:159
+#: plugins/check_swap.c:199 plugins/check_users.c:136 plugins/urlize.c:115
 #, c-format
 msgid "Could not open stderr for %s\n"
 msgstr ""
 
-#: plugins/check_fping.c:157
+#: plugins/check_fping.c:161
 msgid "FPING UNKNOWN - IP address not found\n"
 msgstr ""
 
-#: plugins/check_fping.c:160
+#: plugins/check_fping.c:164
 msgid "FPING UNKNOWN - invalid commandline argument\n"
 msgstr ""
 
-#: plugins/check_fping.c:163
+#: plugins/check_fping.c:167
 msgid "FPING UNKNOWN - failed system call\n"
 msgstr ""
 
-#: plugins/check_fping.c:187
+#: plugins/check_fping.c:194
+#, c-format
+msgid "FPING %s - %s (rta=%f ms)|%s\n"
+msgstr ""
+
+#: plugins/check_fping.c:202
 #, c-format
 msgid "FPING UNKNOWN - %s not found\n"
 msgstr ""
 
-#: plugins/check_fping.c:191
+#: plugins/check_fping.c:206
 #, c-format
 msgid "FPING CRITICAL - %s is unreachable\n"
 msgstr ""
 
-#: plugins/check_fping.c:196
+#: plugins/check_fping.c:211
 #, c-format
 msgid "FPING UNKNOWN - %s parameter error\n"
 msgstr ""
 
-#: plugins/check_fping.c:200 plugins/check_fping.c:240
+#: plugins/check_fping.c:215 plugins/check_fping.c:255
 #, c-format
 msgid "FPING CRITICAL - %s is down\n"
 msgstr ""
 
-#: plugins/check_fping.c:227
+#: plugins/check_fping.c:242
 #, c-format
 msgid "FPING %s - %s (loss=%.0f%%, rta=%f ms)|%s %s\n"
 msgstr ""
 
-#: plugins/check_fping.c:253
+#: plugins/check_fping.c:268
 #, c-format
 msgid "FPING %s - %s (loss=%.0f%% )|%s\n"
 msgstr ""
 
-#: plugins/check_fping.c:326 plugins/check_fping.c:332
-#: plugins/check_hpjd.c:338 plugins/check_hpjd.c:361 plugins/check_mysql.c:371
-#: plugins/check_mysql.c:455 plugins/check_ntp.c:709
-#: plugins/check_ntp_peer.c:497 plugins/check_ntp_time.c:496
-#: plugins/check_pgsql.c:335 plugins/check_ping.c:295 plugins/check_ping.c:418
-#: plugins/check_radius.c:264 plugins/check_real.c:314
-#: plugins/check_real.c:376 plugins/check_smtp.c:499 plugins/check_smtp.c:641
-#: plugins/check_ssh.c:157 plugins/check_time.c:240 plugins/check_time.c:315
-#: plugins/check_ups.c:504 plugins/check_ups.c:573
+#: plugins/check_fping.c:345 plugins/check_fping.c:351 plugins/check_hpjd.c:345
+#: plugins/check_hpjd.c:376 plugins/check_mysql.c:389 plugins/check_mysql.c:476
+#: plugins/check_ntp.c:719 plugins/check_ntp_peer.c:497
+#: plugins/check_ntp_time.c:498 plugins/check_pgsql.c:338
+#: plugins/check_ping.c:301 plugins/check_ping.c:424 plugins/check_radius.c:279
+#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:519
+#: plugins/check_smtp.c:667 plugins/check_ssh.c:162 plugins/check_time.c:240
+#: plugins/check_time.c:315 plugins/check_ups.c:507 plugins/check_ups.c:576
 msgid "Invalid hostname/address"
 msgstr ""
 
-#: plugins/check_fping.c:345 plugins/check_ldap.c:353 plugins/check_ping.c:246
+#: plugins/check_fping.c:364 plugins/check_ldap.c:400 plugins/check_ping.c:252
+#: plugins-root/check_icmp.c:474
 msgid "IPv6 support not available\n"
 msgstr ""
 
-#: plugins/check_fping.c:378
+#: plugins/check_fping.c:397
 msgid "Packet size must be a positive integer"
 msgstr ""
 
-#: plugins/check_fping.c:384
+#: plugins/check_fping.c:403
 msgid "Packet count must be a positive integer"
 msgstr ""
 
-#: plugins/check_fping.c:390
+#: plugins/check_fping.c:409
 msgid "Target timeout must be a positive integer"
 msgstr ""
 
-#: plugins/check_fping.c:396
+#: plugins/check_fping.c:415
 msgid "Interval must be a positive integer"
 msgstr ""
 
-#: plugins/check_fping.c:402 plugins/check_ntp.c:733
-#: plugins/check_ntp_peer.c:524 plugins/check_ntp_time.c:523
-#: plugins/check_radius.c:314 plugins/check_time.c:319
+#: plugins/check_fping.c:421 plugins/check_ntp.c:743
+#: plugins/check_ntp_peer.c:524 plugins/check_ntp_time.c:528
+#: plugins/check_radius.c:329 plugins/check_time.c:319
 msgid "Hostname was not supplied"
 msgstr ""
 
-#: plugins/check_fping.c:422
+#: plugins/check_fping.c:441
 #, c-format
 msgid "%s: Only one threshold may be packet loss (%s)\n"
 msgstr ""
 
-#: plugins/check_fping.c:426
+#: plugins/check_fping.c:445
 #, c-format
 msgid "%s: Only one threshold must be packet loss (%s)\n"
 msgstr ""
 
-#: plugins/check_fping.c:458
+#: plugins/check_fping.c:475
 msgid ""
 "This plugin will use the fping command to ping the specified host for a fast "
 "check"
 msgstr ""
 
-#: plugins/check_fping.c:460
+#: plugins/check_fping.c:477
 msgid "Note that it is necessary to set the suid flag on fping."
 msgstr ""
 
-#: plugins/check_fping.c:472
+#: plugins/check_fping.c:489
 msgid ""
 "name or IP Address of host to ping (IP Address bypasses name lookup, "
 "reducing system load)"
 msgstr ""
 
-#: plugins/check_fping.c:474 plugins/check_ping.c:575
+#: plugins/check_fping.c:491 plugins/check_ping.c:589
 msgid "warning threshold pair"
 msgstr ""
 
-#: plugins/check_fping.c:476 plugins/check_ping.c:577
+#: plugins/check_fping.c:493 plugins/check_ping.c:591
 msgid "critical threshold pair"
 msgstr ""
 
-#: plugins/check_fping.c:478
+#: plugins/check_fping.c:495
+msgid "Return OK after first successful reply"
+msgstr ""
+
+#: plugins/check_fping.c:497
 msgid "size of ICMP packet"
 msgstr ""
 
-#: plugins/check_fping.c:480
+#: plugins/check_fping.c:499
 msgid "number of ICMP packets to send"
 msgstr ""
 
-#: plugins/check_fping.c:482
+#: plugins/check_fping.c:501
 msgid "Target timeout (ms)"
 msgstr ""
 
-#: plugins/check_fping.c:484
+#: plugins/check_fping.c:503
 msgid "Interval (ms) between sending packets"
 msgstr ""
 
-#: plugins/check_fping.c:486
+#: plugins/check_fping.c:505
 msgid "name or IP Address of sourceip"
 msgstr ""
 
-#: plugins/check_fping.c:488
+#: plugins/check_fping.c:507
 msgid "source interface name"
 msgstr ""
 
-#: plugins/check_fping.c:491
+#: plugins/check_fping.c:510
 #, c-format
 msgid ""
 "THRESHOLD is <rta>,<pl>%% where <rta> is the round trip average travel time "
 "(ms)"
 msgstr ""
 
-#: plugins/check_fping.c:492
+#: plugins/check_fping.c:511
 msgid ""
 "which triggers a WARNING or CRITICAL state, and <pl> is the percentage of"
 msgstr ""
 
-#: plugins/check_fping.c:493
+#: plugins/check_fping.c:512
 msgid "packet loss to trigger an alarm state."
 msgstr ""
 
-#: plugins/check_fping.c:496
+#: plugins/check_fping.c:515
 msgid "IPv4 is used by default. Specify -6 to use IPv6."
 msgstr ""
 
@@ -1038,781 +1101,902 @@ msgid ""
 msgstr ""
 
 #: plugins/check_game.c:321
-msgid ""
-"http://www.activesw.com/people/steve/qstat.html before you can use this "
-"plugin."
+msgid "https://github.com/multiplay/qstat before you can use this plugin."
 msgstr ""
 
-#: plugins/check_hpjd.c:239
+#: plugins/check_hpjd.c:245
 msgid "Paper Jam"
 msgstr ""
 
-#: plugins/check_hpjd.c:243
+#: plugins/check_hpjd.c:250
 msgid "Out of Paper"
 msgstr ""
 
-#: plugins/check_hpjd.c:248
+#: plugins/check_hpjd.c:255
 msgid "Printer Offline"
 msgstr ""
 
-#: plugins/check_hpjd.c:253
+#: plugins/check_hpjd.c:260
 msgid "Peripheral Error"
 msgstr ""
 
-#: plugins/check_hpjd.c:257
+#: plugins/check_hpjd.c:264
 msgid "Intervention Required"
 msgstr ""
 
-#: plugins/check_hpjd.c:261
+#: plugins/check_hpjd.c:268
 msgid "Toner Low"
 msgstr ""
 
-#: plugins/check_hpjd.c:265
+#: plugins/check_hpjd.c:272
 msgid "Insufficient Memory"
 msgstr ""
 
-#: plugins/check_hpjd.c:269
+#: plugins/check_hpjd.c:276
 msgid "A Door is Open"
 msgstr ""
 
-#: plugins/check_hpjd.c:273
+#: plugins/check_hpjd.c:280
 msgid "Output Tray is Full"
 msgstr ""
 
-#: plugins/check_hpjd.c:277
+#: plugins/check_hpjd.c:284
 msgid "Data too Slow for Engine"
 msgstr ""
 
-#: plugins/check_hpjd.c:281
+#: plugins/check_hpjd.c:288
 msgid "Unknown Paper Error"
 msgstr ""
 
-#: plugins/check_hpjd.c:286
+#: plugins/check_hpjd.c:293
 #, c-format
 msgid "Printer ok - (%s)\n"
 msgstr ""
 
-#: plugins/check_hpjd.c:391
+#: plugins/check_hpjd.c:353
+msgid "Port must be a positive short integer"
+msgstr ""
+
+#: plugins/check_hpjd.c:410
 msgid "This plugin tests the STATUS of an HP printer with a JetDirect card."
 msgstr ""
 
-#: plugins/check_hpjd.c:392
+#: plugins/check_hpjd.c:411
 msgid "Net-snmp must be installed on the computer running the plugin."
 msgstr ""
 
-#: plugins/check_hpjd.c:402
+#: plugins/check_hpjd.c:421
 msgid "The SNMP community name "
 msgstr ""
 
-#: plugins/check_hpjd.c:403
+#: plugins/check_hpjd.c:422 plugins/check_hpjd.c:426
 #, c-format
 msgid "(default=%s)"
 msgstr ""
 
-#: plugins/check_http.c:189
+#: plugins/check_hpjd.c:425
+msgid "Specify the port to check "
+msgstr ""
+
+#: plugins/check_hpjd.c:429
+msgid "Disable paper check "
+msgstr ""
+
+#: plugins/check_http.c:196
 msgid "file does not exist or is not readable"
 msgstr ""
 
-#: plugins/check_http.c:310 plugins/check_http.c:315 plugins/check_http.c:321
-#: plugins/check_smtp.c:600 plugins/check_tcp.c:576 plugins/check_tcp.c:580
-#: plugins/check_tcp.c:586
+#: plugins/check_http.c:324 plugins/check_http.c:329 plugins/check_http.c:335
+#: plugins/check_smtp.c:615 plugins/check_tcp.c:590 plugins/check_tcp.c:595
+#: plugins/check_tcp.c:601
 msgid "Invalid certificate expiration period"
 msgstr ""
 
-#: plugins/check_http.c:348
+#: plugins/check_http.c:378
 msgid ""
-"Invalid option - Valid values for SSL Version are 1 (TLSv1), 2 (SSLv2) or 3 "
-"(SSLv3)"
+"Invalid option - Valid SSL/TLS versions: 2, 3, 1, 1.1, 1.2 (with optional "
+"'+' suffix)"
 msgstr ""
 
-#: plugins/check_http.c:354 plugins/check_tcp.c:599
+#: plugins/check_http.c:384 plugins/check_tcp.c:614 plugins/check_tcp.c:623
 msgid "Invalid option - SSL is not available"
 msgstr ""
 
-#: plugins/check_http.c:375
+#: plugins/check_http.c:392
+msgid "Invalid max_redirs count"
+msgstr ""
+
+#: plugins/check_http.c:412
 msgid "Invalid onredirect option"
 msgstr ""
 
-#: plugins/check_http.c:377
+#: plugins/check_http.c:414
 #, c-format
 msgid "option f:%d \n"
 msgstr ""
 
-#: plugins/check_http.c:398
+#: plugins/check_http.c:449
 msgid "Invalid port number"
 msgstr ""
 
-#: plugins/check_http.c:450
+#: plugins/check_http.c:507
 #, c-format
 msgid "Could Not Compile Regular Expression: %s"
 msgstr ""
 
-#: plugins/check_http.c:464 plugins/check_ntp.c:722
-#: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:512
-#: plugins/check_smtp.c:621 plugins/check_ssh.c:149 plugins/check_tcp.c:477
+#: plugins/check_http.c:521 plugins/check_ntp.c:732
+#: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:517
+#: plugins/check_smtp.c:647 plugins/check_ssh.c:151 plugins/check_tcp.c:491
 msgid "IPv6 support not available"
 msgstr ""
 
-#: plugins/check_http.c:529 plugins/check_ping.c:422
+#: plugins/check_http.c:589 plugins/check_ping.c:428
 msgid "You must specify a server address or host name"
 msgstr ""
 
-#: plugins/check_http.c:543
+#: plugins/check_http.c:606
 msgid ""
 "If you use a client certificate you must also specify a private key file"
 msgstr ""
 
-#: plugins/check_http.c:667 plugins/check_http.c:835
+#: plugins/check_http.c:733 plugins/check_http.c:901
 msgid "HTTP UNKNOWN - Memory allocation error\n"
 msgstr ""
 
-#: plugins/check_http.c:739
+#: plugins/check_http.c:805
 #, c-format
 msgid "%sServer date unknown, "
 msgstr ""
 
-#: plugins/check_http.c:742
+#: plugins/check_http.c:808
 #, c-format
 msgid "%sDocument modification date unknown, "
 msgstr ""
 
-#: plugins/check_http.c:749
+#: plugins/check_http.c:815
 #, c-format
 msgid "%sServer date \"%100s\" unparsable, "
 msgstr ""
 
-#: plugins/check_http.c:752
+#: plugins/check_http.c:818
 #, c-format
 msgid "%sDocument date \"%100s\" unparsable, "
 msgstr ""
 
-#: plugins/check_http.c:755
+#: plugins/check_http.c:821
 #, c-format
 msgid "%sDocument is %d seconds in the future, "
 msgstr ""
 
-#: plugins/check_http.c:760
+#: plugins/check_http.c:826
 #, c-format
 msgid "%sLast modified %.1f days ago, "
 msgstr ""
 
-#: plugins/check_http.c:763
+#: plugins/check_http.c:829
 #, c-format
 msgid "%sLast modified %d:%02d:%02d ago, "
 msgstr ""
 
-#: plugins/check_http.c:876
+#: plugins/check_http.c:943
 msgid "HTTP CRITICAL - Unable to open TCP socket\n"
 msgstr ""
 
-#: plugins/check_http.c:995
+#: plugins/check_http.c:1103
+msgid "HTTP UNKNOWN - Could not allocate memory for full_page\n"
+msgstr ""
+
+#: plugins/check_http.c:1120
 msgid "HTTP CRITICAL - Error on receive\n"
 msgstr ""
 
-#: plugins/check_http.c:1005
+#: plugins/check_http.c:1125
 msgid "HTTP CRITICAL - No data received from host\n"
 msgstr ""
 
-#: plugins/check_http.c:1056
+#: plugins/check_http.c:1176
 #, c-format
 msgid "Invalid HTTP response received from host: %s\n"
 msgstr ""
 
-#: plugins/check_http.c:1060
+#: plugins/check_http.c:1180
 #, c-format
 msgid "Invalid HTTP response received from host on port %d: %s\n"
 msgstr ""
 
-#: plugins/check_http.c:1069
+#: plugins/check_http.c:1183 plugins/check_http.c:1376
+#, c-format
+msgid ""
+"%s\n"
+"%s"
+msgstr ""
+
+#: plugins/check_http.c:1191
 #, c-format
 msgid "Status line output matched \"%s\" - "
 msgstr ""
 
-#: plugins/check_http.c:1080
+#: plugins/check_http.c:1202
 #, c-format
 msgid "HTTP CRITICAL: Invalid Status Line (%s)\n"
 msgstr ""
 
-#: plugins/check_http.c:1087
+#: plugins/check_http.c:1209
 #, c-format
 msgid "HTTP CRITICAL: Invalid Status (%s)\n"
 msgstr ""
 
-#: plugins/check_http.c:1091 plugins/check_http.c:1096
-#: plugins/check_http.c:1106 plugins/check_http.c:1110
+#: plugins/check_http.c:1213 plugins/check_http.c:1218
+#: plugins/check_http.c:1228 plugins/check_http.c:1232
 #, c-format
 msgid "%s - "
 msgstr ""
 
-#: plugins/check_http.c:1129
+#: plugins/check_http.c:1260
 #, c-format
 msgid "%sheader '%s' not found on '%s://%s:%d%s', "
 msgstr ""
 
-#: plugins/check_http.c:1141
+#: plugins/check_http.c:1303
 #, c-format
 msgid "%sstring '%s' not found on '%s://%s:%d%s', "
 msgstr ""
 
-#: plugins/check_http.c:1154
+#: plugins/check_http.c:1317
 #, c-format
 msgid "%spattern not found, "
 msgstr ""
 
-#: plugins/check_http.c:1156
+#: plugins/check_http.c:1319
 #, c-format
 msgid "%spattern found, "
 msgstr ""
 
-#: plugins/check_http.c:1162
+#: plugins/check_http.c:1325
 #, c-format
 msgid "%sExecute Error: %s, "
 msgstr ""
 
-#: plugins/check_http.c:1178
+#: plugins/check_http.c:1341
 #, c-format
 msgid "%spage size %d too large, "
 msgstr ""
 
-#: plugins/check_http.c:1181
+#: plugins/check_http.c:1344
 #, c-format
 msgid "%spage size %d too small, "
 msgstr ""
 
-#: plugins/check_http.c:1194
+#: plugins/check_http.c:1357
 #, c-format
 msgid "%s - %d bytes in %.3f second response time %s|%s %s %s %s %s %s %s"
 msgstr ""
 
-#: plugins/check_http.c:1206
+#: plugins/check_http.c:1369
 #, c-format
 msgid "%s - %d bytes in %.3f second response time %s|%s %s"
 msgstr ""
 
-#: plugins/check_http.c:1244
+#: plugins/check_http.c:1499
 msgid "HTTP UNKNOWN - Could not allocate addr\n"
 msgstr ""
 
-#: plugins/check_http.c:1248 plugins/check_http.c:1279
+#: plugins/check_http.c:1504 plugins/check_http.c:1535
 msgid "HTTP UNKNOWN - Could not allocate URL\n"
 msgstr ""
 
-#: plugins/check_http.c:1257
+#: plugins/check_http.c:1513
 #, c-format
 msgid "HTTP UNKNOWN - Could not find redirect location - %s%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1272
+#: plugins/check_http.c:1528
 #, c-format
 msgid "HTTP UNKNOWN - Empty redirect location%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1322
+#: plugins/check_http.c:1590
 #, c-format
 msgid "HTTP UNKNOWN - Could not parse redirect location - %s%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1332
+#: plugins/check_http.c:1600
 #, c-format
 msgid "HTTP WARNING - maximum redirection depth %d exceeded - %s://%s:%d%s%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1340
+#: plugins/check_http.c:1608
 #, c-format
-msgid "HTTP WARNING - redirection creates an infinite loop - %s://%s:%d%s%s\n"
+msgid "HTTP CRITICAL - redirection creates an infinite loop - %s://%s:%d%s%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1361
+#: plugins/check_http.c:1629
 #, c-format
 msgid "HTTP UNKNOWN - Redirection to port above %d - %s://%s:%d%s%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1366
+#: plugins/check_http.c:1637
 #, c-format
 msgid "Redirection to %s://%s:%d%s\n"
 msgstr ""
 
-#: plugins/check_http.c:1440
+#: plugins/check_http.c:1712
 msgid "This plugin tests the HTTP service on the specified host. It can test"
 msgstr ""
 
-#: plugins/check_http.c:1441
+#: plugins/check_http.c:1713
 msgid "normal (http) and secure (https) servers, follow redirects, search for"
 msgstr ""
 
-#: plugins/check_http.c:1442
+#: plugins/check_http.c:1714
 msgid "strings and regular expressions, check connection times, and report on"
 msgstr ""
 
-#: plugins/check_http.c:1443
+#: plugins/check_http.c:1715
 msgid "certificate expiration times."
 msgstr ""
 
-#: plugins/check_http.c:1449
+#: plugins/check_http.c:1722
+#, c-format
+msgid "In the first form, make an HTTP request."
+msgstr ""
+
+#: plugins/check_http.c:1723
+#, c-format
+msgid ""
+"In the second form, connect to the server and check the TLS certificate."
+msgstr ""
+
+#: plugins/check_http.c:1725
 #, c-format
 msgid "NOTE: One or both of -H and -I must be specified"
 msgstr ""
 
-#: plugins/check_http.c:1457
+#: plugins/check_http.c:1733
 msgid "Host name argument for servers using host headers (virtual host)"
 msgstr ""
 
-#: plugins/check_http.c:1458
+#: plugins/check_http.c:1734
 msgid "Append a port to include it in the header (eg: example.com:5000)"
 msgstr ""
 
-#: plugins/check_http.c:1460
+#: plugins/check_http.c:1736
 msgid ""
 "IP address or name (use numeric address if possible to bypass DNS lookup)."
 msgstr ""
 
-#: plugins/check_http.c:1462
+#: plugins/check_http.c:1738
 msgid "Port number (default: "
 msgstr ""
 
-#: plugins/check_http.c:1469
+#: plugins/check_http.c:1745
 msgid ""
 "Connect via SSL. Port defaults to 443. VERSION is optional, and prevents"
 msgstr ""
 
-#: plugins/check_http.c:1470
-msgid "auto-negotiation (1 = TLSv1, 2 = SSLv2, 3 = SSLv3)."
+#: plugins/check_http.c:1746
+msgid "auto-negotiation (2 = SSLv2, 3 = SSLv3, 1 = TLSv1, 1.1 = TLSv1.1,"
 msgstr ""
 
-#: plugins/check_http.c:1472
+#: plugins/check_http.c:1747
+msgid "1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."
+msgstr ""
+
+#: plugins/check_http.c:1749
 msgid "Enable SSL/TLS hostname extension support (SNI)"
 msgstr ""
 
-#: plugins/check_http.c:1474
+#: plugins/check_http.c:1751
 msgid ""
 "Minimum number of days a certificate has to be valid. Port defaults to 443"
 msgstr ""
 
-#: plugins/check_http.c:1475
-msgid "(when this option is used the URL is not checked.)"
+#: plugins/check_http.c:1752
+msgid ""
+"(when this option is used the URL is not checked by default. You can use"
 msgstr ""
 
-#: plugins/check_http.c:1477
+#: plugins/check_http.c:1753
+msgid " --continue-after-certificate to override this behavior)"
+msgstr ""
+
+#: plugins/check_http.c:1755
+msgid ""
+"Allows the HTTP check to continue after performing the certificate check."
+msgstr ""
+
+#: plugins/check_http.c:1756
+msgid "Does nothing unless -C is used."
+msgstr ""
+
+#: plugins/check_http.c:1758
 msgid "Name of file that contains the client certificate (PEM format)"
 msgstr ""
 
-#: plugins/check_http.c:1478
+#: plugins/check_http.c:1759
 msgid "to be used in establishing the SSL session"
 msgstr ""
 
-#: plugins/check_http.c:1480
+#: plugins/check_http.c:1761
 msgid "Name of file containing the private key (PEM format)"
 msgstr ""
 
-#: plugins/check_http.c:1481
+#: plugins/check_http.c:1762
 msgid "matching the client certificate"
 msgstr ""
 
-#: plugins/check_http.c:1485
+#: plugins/check_http.c:1766
 msgid "Comma-delimited list of strings, at least one of them is expected in"
 msgstr ""
 
-#: plugins/check_http.c:1486
+#: plugins/check_http.c:1767
 msgid "the first (status) line of the server response (default: "
 msgstr ""
 
-#: plugins/check_http.c:1488
+#: plugins/check_http.c:1769
 msgid ""
 "If specified skips all other status line logic (ex: 3xx, 4xx, 5xx processing)"
 msgstr ""
 
-#: plugins/check_http.c:1490
+#: plugins/check_http.c:1771
 msgid "String to expect in the response headers"
 msgstr ""
 
-#: plugins/check_http.c:1492
+#: plugins/check_http.c:1773
 msgid "String to expect in the content"
 msgstr ""
 
-#: plugins/check_http.c:1494
+#: plugins/check_http.c:1775
 msgid "URL to GET or POST (default: /)"
 msgstr ""
 
-#: plugins/check_http.c:1496
+#: plugins/check_http.c:1777
 msgid "URL encoded http POST data"
 msgstr ""
 
-#: plugins/check_http.c:1498
+#: plugins/check_http.c:1779
 msgid "Set HTTP method."
 msgstr ""
 
-#: plugins/check_http.c:1500
+#: plugins/check_http.c:1781
 msgid "Don't wait for document body: stop reading after headers."
 msgstr ""
 
-#: plugins/check_http.c:1501
+#: plugins/check_http.c:1782
 msgid "(Note that this still does an HTTP GET or POST, not a HEAD.)"
 msgstr ""
 
-#: plugins/check_http.c:1503
+#: plugins/check_http.c:1784
 msgid "Warn if document is more than SECONDS old. the number can also be of"
 msgstr ""
 
-#: plugins/check_http.c:1504
+#: plugins/check_http.c:1785
 msgid "the form \"10m\" for minutes, \"10h\" for hours, or \"10d\" for days."
 msgstr ""
 
-#: plugins/check_http.c:1506
+#: plugins/check_http.c:1787
 msgid "specify Content-Type header media type when POSTing\n"
 msgstr ""
 
-#: plugins/check_http.c:1509
+#: plugins/check_http.c:1790
 msgid "Allow regex to span newlines (must precede -r or -R)"
 msgstr ""
 
-#: plugins/check_http.c:1511
+#: plugins/check_http.c:1792
 msgid "Search page for regex STRING"
 msgstr ""
 
-#: plugins/check_http.c:1513
+#: plugins/check_http.c:1794
 msgid "Search page for case-insensitive regex STRING"
 msgstr ""
 
-#: plugins/check_http.c:1515
+#: plugins/check_http.c:1796
 msgid "Return CRITICAL if found, OK if not\n"
 msgstr ""
 
-#: plugins/check_http.c:1518
+#: plugins/check_http.c:1799
 msgid "Username:password on sites with basic authentication"
 msgstr ""
 
-#: plugins/check_http.c:1520
+#: plugins/check_http.c:1801
 msgid "Username:password on proxy-servers with basic authentication"
 msgstr ""
 
-#: plugins/check_http.c:1522
+#: plugins/check_http.c:1803
 msgid "String to be sent in http header as \"User Agent\""
 msgstr ""
 
-#: plugins/check_http.c:1524
+#: plugins/check_http.c:1805
 msgid ""
 "Any other tags to be sent in http header. Use multiple times for additional "
 "headers"
 msgstr ""
 
-#: plugins/check_http.c:1526
+#: plugins/check_http.c:1807
 msgid "Print additional performance data"
 msgstr ""
 
-#: plugins/check_http.c:1528
+#: plugins/check_http.c:1809
+msgid "Print body content below status line"
+msgstr ""
+
+#: plugins/check_http.c:1811
 msgid "Wrap output in HTML link (obsoleted by urlize)"
 msgstr ""
 
-#: plugins/check_http.c:1530
+#: plugins/check_http.c:1813
 msgid "How to handle redirected pages. sticky is like follow but stick to the"
 msgstr ""
 
-#: plugins/check_http.c:1531
+#: plugins/check_http.c:1814
 msgid "specified IP address. stickyport also ensures port stays the same."
 msgstr ""
 
-#: plugins/check_http.c:1533
+#: plugins/check_http.c:1816
+msgid "Maximal number of redirects (default: "
+msgstr ""
+
+#: plugins/check_http.c:1819
 msgid "Minimum page size required (bytes) : Maximum page size required (bytes)"
 msgstr ""
 
-#: plugins/check_http.c:1543
+#: plugins/check_http.c:1828
 msgid "This plugin will attempt to open an HTTP connection with the host."
 msgstr ""
 
-#: plugins/check_http.c:1544
+#: plugins/check_http.c:1829
 msgid ""
 "Successful connects return STATE_OK, refusals and timeouts return "
 "STATE_CRITICAL"
 msgstr ""
 
-#: plugins/check_http.c:1545
+#: plugins/check_http.c:1830
 msgid ""
 "other errors return STATE_UNKNOWN.  Successful connects, but incorrect "
 "response"
 msgstr ""
 
-#: plugins/check_http.c:1546
+#: plugins/check_http.c:1831
 msgid ""
 "messages from the host result in STATE_WARNING return values.  If you are"
 msgstr ""
 
-#: plugins/check_http.c:1547
+#: plugins/check_http.c:1832
 msgid ""
 "checking a virtual server that uses 'host headers' you must supply the FQDN"
 msgstr ""
 
-#: plugins/check_http.c:1548
+#: plugins/check_http.c:1833
 msgid "(fully qualified domain name) as the [host_name] argument."
 msgstr ""
 
-#: plugins/check_http.c:1552
+#: plugins/check_http.c:1837
 msgid "This plugin can also check whether an SSL enabled web server is able to"
 msgstr ""
 
-#: plugins/check_http.c:1553
+#: plugins/check_http.c:1838
 msgid "serve content (optionally within a specified time) or whether the X509 "
 msgstr ""
 
-#: plugins/check_http.c:1554
+#: plugins/check_http.c:1839
 msgid "certificate is still valid for the specified number of days."
 msgstr ""
 
-#: plugins/check_http.c:1556
+#: plugins/check_http.c:1841
 msgid "Please note that this plugin does not check if the presented server"
 msgstr ""
 
-#: plugins/check_http.c:1557
+#: plugins/check_http.c:1842
 msgid "certificate matches the hostname of the server, or if the certificate"
 msgstr ""
 
-#: plugins/check_http.c:1558
+#: plugins/check_http.c:1843
 msgid "has a valid chain of trust to one of the locally installed CAs."
 msgstr ""
 
-#: plugins/check_http.c:1562
+#: plugins/check_http.c:1847
 msgid ""
 "When the 'www.verisign.com' server returns its content within 5 seconds,"
 msgstr ""
 
-#: plugins/check_http.c:1563
+#: plugins/check_http.c:1848 plugins/check_http.c:1867
 msgid ""
 "a STATE_OK will be returned. When the server returns its content but exceeds"
 msgstr ""
 
-#: plugins/check_http.c:1564
+#: plugins/check_http.c:1849 plugins/check_http.c:1868
 msgid ""
 "the 5-second threshold, a STATE_WARNING will be returned. When an error "
 "occurs,"
 msgstr ""
 
-#: plugins/check_http.c:1565
+#: plugins/check_http.c:1850
 msgid "a STATE_CRITICAL will be returned."
 msgstr ""
 
-#: plugins/check_http.c:1568
+#: plugins/check_http.c:1853
 msgid ""
 "When the certificate of 'www.verisign.com' is valid for more than 14 days,"
 msgstr ""
 
-#: plugins/check_http.c:1569 plugins/check_http.c:1575
+#: plugins/check_http.c:1854 plugins/check_http.c:1860
 msgid ""
 "a STATE_OK is returned. When the certificate is still valid, but for less "
 "than"
 msgstr ""
 
-#: plugins/check_http.c:1570
+#: plugins/check_http.c:1855
 msgid ""
 "14 days, a STATE_WARNING is returned. A STATE_CRITICAL will be returned when"
 msgstr ""
 
-#: plugins/check_http.c:1571
+#: plugins/check_http.c:1856
 msgid "the certificate is expired."
 msgstr ""
 
-#: plugins/check_http.c:1574
+#: plugins/check_http.c:1859
 msgid ""
 "When the certificate of 'www.verisign.com' is valid for more than 30 days,"
 msgstr ""
 
-#: plugins/check_http.c:1576
+#: plugins/check_http.c:1861
 msgid "30 days, but more than 14 days, a STATE_WARNING is returned."
 msgstr ""
 
-#: plugins/check_http.c:1577
+#: plugins/check_http.c:1862
 msgid ""
 "A STATE_CRITICAL will be returned when certificate expires in less than 14 "
 "days"
 msgstr ""
 
-#: plugins/check_ldap.c:133
-#, c-format
-msgid "Could not connect to the server at port %i\n"
+#: plugins/check_http.c:1865
+msgid ""
+"check_http -I 192.168.100.35 -p 80 -u https://www.verisign.com/ -S -j "
+"CONNECT -H www.verisign.com "
+msgstr ""
+
+#: plugins/check_http.c:1866
+msgid ""
+"all these options are needed: -I <proxy> -p <proxy-port> -u <check-url> -"
+"S(sl) -j CONNECT -H <webserver>"
+msgstr ""
+
+#: plugins/check_http.c:1869
+msgid ""
+"a STATE_CRITICAL will be returned. By adding a colon to the method you can "
+"set the method used"
+msgstr ""
+
+#: plugins/check_http.c:1870
+msgid "inside the proxied connection: -j CONNECT:POST"
 msgstr ""
 
 #: plugins/check_ldap.c:142
 #, c-format
+msgid "Could not connect to the server at port %i\n"
+msgstr ""
+
+#: plugins/check_ldap.c:151
+#, c-format
 msgid "Could not set protocol version %d\n"
 msgstr ""
 
-#: plugins/check_ldap.c:157
+#: plugins/check_ldap.c:166
 #, c-format
 msgid "Could not init TLS at port %i!\n"
 msgstr ""
 
-#: plugins/check_ldap.c:161
+#: plugins/check_ldap.c:170
 #, c-format
 msgid "TLS not supported by the libraries!\n"
 msgstr ""
 
-#: plugins/check_ldap.c:181
+#: plugins/check_ldap.c:190
 #, c-format
 msgid "Could not init startTLS at port %i!\n"
 msgstr ""
 
-#: plugins/check_ldap.c:185
+#: plugins/check_ldap.c:194
 #, c-format
 msgid "startTLS not supported by the library, needs LDAPv3!\n"
 msgstr ""
 
-#: plugins/check_ldap.c:195
+#: plugins/check_ldap.c:204
 #, c-format
 msgid "Could not bind to the LDAP server\n"
 msgstr ""
 
-#: plugins/check_ldap.c:204
+#: plugins/check_ldap.c:213
 #, c-format
 msgid "Could not search/find objectclasses in %s\n"
 msgstr ""
 
-#: plugins/check_ldap.c:227
+#: plugins/check_ldap.c:252
+#, c-format
+msgid "LDAP %s - found %d entries in %.3f seconds|%s %s\n"
+msgstr ""
+
+#: plugins/check_ldap.c:265
 #, c-format
 msgid "LDAP %s - %.3f seconds response time|%s\n"
 msgstr ""
 
-#: plugins/check_ldap.c:339 plugins/check_ldap.c:347
+#: plugins/check_ldap.c:386 plugins/check_ldap.c:394
 #, c-format
 msgid "%s cannot be combined with %s"
 msgstr ""
 
-#: plugins/check_ldap.c:379
+#: plugins/check_ldap.c:426
 msgid "Please specify the host name\n"
 msgstr ""
 
-#: plugins/check_ldap.c:382
+#: plugins/check_ldap.c:429
 msgid "Please specify the LDAP base\n"
 msgstr ""
 
-#: plugins/check_ldap.c:411
+#: plugins/check_ldap.c:465
 msgid "ldap attribute to search (default: \"(objectclass=*)\""
 msgstr ""
 
-#: plugins/check_ldap.c:413
+#: plugins/check_ldap.c:467
 msgid "ldap base (eg. ou=my unit, o=my org, c=at"
 msgstr ""
 
-#: plugins/check_ldap.c:415
+#: plugins/check_ldap.c:469
 msgid "ldap bind DN (if required)"
 msgstr ""
 
-#: plugins/check_ldap.c:417
-msgid "ldap password (if required)"
+#: plugins/check_ldap.c:471
+msgid ""
+"ldap password (if required, or set the password through environment variable "
+"'LDAP_PASSWORD')"
 msgstr ""
 
-#: plugins/check_ldap.c:419
+#: plugins/check_ldap.c:473
 msgid "use starttls mechanism introduced in protocol version 3"
 msgstr ""
 
-#: plugins/check_ldap.c:421
+#: plugins/check_ldap.c:475
 msgid "use ldaps (ldap v2 ssl method). this also sets the default port to"
 msgstr ""
 
-#: plugins/check_ldap.c:425
+#: plugins/check_ldap.c:479
 msgid "use ldap protocol version 2"
 msgstr ""
 
-#: plugins/check_ldap.c:427
+#: plugins/check_ldap.c:481
 msgid "use ldap protocol version 3"
 msgstr ""
 
-#: plugins/check_ldap.c:428
+#: plugins/check_ldap.c:482
 msgid "default protocol version:"
 msgstr ""
 
-#: plugins/check_ldap.c:439
+#: plugins/check_ldap.c:488
+msgid "Number of found entries to result in warning status"
+msgstr ""
+
+#: plugins/check_ldap.c:490
+msgid "Number of found entries to result in critical status"
+msgstr ""
+
+#: plugins/check_ldap.c:498
 msgid "If this plugin is called via 'check_ldaps', method 'STARTTLS' will be"
 msgstr ""
 
-#: plugins/check_ldap.c:440
+#: plugins/check_ldap.c:499
 #, c-format
 msgid ""
 " implied (using default port %i) unless --port=636 is specified. In that "
 "case\n"
 msgstr ""
 
-#: plugins/check_ldap.c:441
+#: plugins/check_ldap.c:500
 msgid "'SSL on connect' will be used no matter how the plugin was called."
 msgstr ""
 
-#: plugins/check_ldap.c:442
+#: plugins/check_ldap.c:501
 msgid ""
 "This detection is deprecated, please use 'check_ldap' with the '--starttls' "
 "or '--ssl' flags"
 msgstr ""
 
-#: plugins/check_ldap.c:443
+#: plugins/check_ldap.c:502
 msgid "to define the behaviour explicitly instead."
 msgstr ""
 
-#: plugins/check_load.c:87
+#: plugins/check_ldap.c:503
+msgid "The parameters --warn-entries and --crit-entries are optional."
+msgstr ""
+
+#: plugins/check_load.c:93
 msgid "Warning threshold must be float or float triplet!\n"
 msgstr ""
 
-#: plugins/check_load.c:132 plugins/check_load.c:148
+#: plugins/check_load.c:138 plugins/check_load.c:154
 #, c-format
 msgid "Error opening %s\n"
 msgstr ""
 
-#: plugins/check_load.c:163
+#: plugins/check_load.c:169
 #, c-format
-msgid "could not parse load from uptime: %s\n"
+msgid "could not parse load from uptime %s: %d\n"
 msgstr ""
 
-#: plugins/check_load.c:169
+#: plugins/check_load.c:175
 #, c-format
 msgid "Error code %d returned in %s\n"
 msgstr ""
 
-#: plugins/check_load.c:184
+#: plugins/check_load.c:183
 #, c-format
 msgid "Error in getloadavg()\n"
 msgstr ""
 
-#: plugins/check_load.c:187 plugins/check_load.c:189
+#: plugins/check_load.c:186 plugins/check_load.c:188
 #, c-format
 msgid "Error processing %s\n"
 msgstr ""
 
-#: plugins/check_load.c:198
+#: plugins/check_load.c:197 plugins/check_load.c:212
 #, c-format
 msgid "load average: %.2f, %.2f, %.2f"
 msgstr ""
 
-#: plugins/check_load.c:291
+#: plugins/check_load.c:327
 #, c-format
 msgid "Critical threshold for %d-minute load average is not specified\n"
 msgstr ""
 
-#: plugins/check_load.c:293
+#: plugins/check_load.c:329
 #, c-format
 msgid "Warning threshold for %d-minute load average is not specified\n"
 msgstr ""
 
-#: plugins/check_load.c:295
+#: plugins/check_load.c:331
 #, c-format
 msgid ""
 "Parameter inconsistency: %d-minute \"warning load\" is greater than "
 "\"critical load\"\n"
 msgstr ""
 
-#: plugins/check_load.c:311
+#: plugins/check_load.c:346
 #, c-format
 msgid "This plugin tests the current system load average."
 msgstr ""
 
-#: plugins/check_load.c:321
+#: plugins/check_load.c:356
 msgid "Exit with WARNING status if load average exceeds WLOADn"
 msgstr ""
 
-#: plugins/check_load.c:323
+#: plugins/check_load.c:358
 msgid "Exit with CRITICAL status if load average exceed CLOADn"
 msgstr ""
 
-#: plugins/check_load.c:324
+#: plugins/check_load.c:359
 msgid "the load average format is the same used by \"uptime\" and \"w\""
 msgstr ""
 
-#: plugins/check_load.c:326
+#: plugins/check_load.c:361
 msgid "Divide the load averages by the number of CPUs (when possible)"
+msgstr ""
+
+#: plugins/check_load.c:363
+msgid "Number of processes to show when printing the top consuming processes."
+msgstr ""
+
+#: plugins/check_load.c:364
+msgid "NUMBER_OF_PROCS=0 disables this feature. Default value is 0"
+msgstr ""
+
+#: plugins/check_load.c:401
+#, c-format
+msgid "'%s' exited with non-zero status.\n"
+msgstr ""
+
+#: plugins/check_load.c:405
+#, c-format
+msgid "some error occurred getting procs list.\n"
 msgstr ""
 
 #: plugins/check_mrtg.c:75
@@ -1989,7 +2173,7 @@ msgstr ""
 
 #: plugins/check_mrtgtraf.c:194
 #, c-format
-msgid "%s. In = %0.1f %s, %s. Out = %0.1f %s|%s %s\n"
+msgid "%s. In = %0.1f %s/s, %s. Out = %0.1f %s/s|%s %s\n"
 msgstr ""
 
 #: plugins/check_mrtgtraf.c:207
@@ -2072,130 +2256,134 @@ msgstr ""
 msgid "Usage"
 msgstr ""
 
-#: plugins/check_mysql.c:171
+#: plugins/check_mysql.c:185
 #, c-format
 msgid "status store_result error: %s\n"
 msgstr ""
 
-#: plugins/check_mysql.c:202
+#: plugins/check_mysql.c:216
 #, c-format
 msgid "slave query error: %s\n"
 msgstr ""
 
-#: plugins/check_mysql.c:209
+#: plugins/check_mysql.c:223
 #, c-format
 msgid "slave store_result error: %s\n"
 msgstr ""
 
-#: plugins/check_mysql.c:215
+#: plugins/check_mysql.c:229
 msgid "No slaves defined"
 msgstr ""
 
-#: plugins/check_mysql.c:223
+#: plugins/check_mysql.c:237
 #, c-format
 msgid "slave fetch row error: %s\n"
 msgstr ""
 
-#: plugins/check_mysql.c:228
+#: plugins/check_mysql.c:242
 #, c-format
 msgid "Slave running: %s"
 msgstr ""
 
-#: plugins/check_mysql.c:505
+#: plugins/check_mysql.c:520
 msgid "This program tests connections to a MySQL server"
 msgstr ""
 
-#: plugins/check_mysql.c:516
+#: plugins/check_mysql.c:531
+msgid "Ignore authentication failure and check for mysql connectivity only"
+msgstr ""
+
+#: plugins/check_mysql.c:534
 msgid "Use the specified socket (has no effect if -H is used)"
 msgstr ""
 
-#: plugins/check_mysql.c:519
+#: plugins/check_mysql.c:537
 msgid "Check database with indicated name"
 msgstr ""
 
-#: plugins/check_mysql.c:521
+#: plugins/check_mysql.c:539
 msgid "Read from the specified client options file"
 msgstr ""
 
-#: plugins/check_mysql.c:523
+#: plugins/check_mysql.c:541
 msgid "Use a client options group"
 msgstr ""
 
-#: plugins/check_mysql.c:525
+#: plugins/check_mysql.c:543
 msgid "Connect using the indicated username"
 msgstr ""
 
-#: plugins/check_mysql.c:527
+#: plugins/check_mysql.c:545
 msgid "Use the indicated password to authenticate the connection"
 msgstr ""
 
-#: plugins/check_mysql.c:528
+#: plugins/check_mysql.c:546
 msgid "IMPORTANT: THIS FORM OF AUTHENTICATION IS NOT SECURE!!!"
 msgstr ""
 
-#: plugins/check_mysql.c:529
+#: plugins/check_mysql.c:547
 msgid "Your clear-text password could be visible as a process table entry"
 msgstr ""
 
-#: plugins/check_mysql.c:531
+#: plugins/check_mysql.c:549
 msgid "Check if the slave thread is running properly."
 msgstr ""
 
-#: plugins/check_mysql.c:533
+#: plugins/check_mysql.c:551
 msgid "Exit with WARNING status if slave server is more than INTEGER seconds"
 msgstr ""
 
-#: plugins/check_mysql.c:534 plugins/check_mysql.c:537
+#: plugins/check_mysql.c:552 plugins/check_mysql.c:555
 msgid "behind master"
 msgstr ""
 
-#: plugins/check_mysql.c:536
+#: plugins/check_mysql.c:554
 msgid "Exit with CRITICAL status if slave server is more then INTEGER seconds"
 msgstr ""
 
-#: plugins/check_mysql.c:539
-msgid "Use ssl encryptation"
+#: plugins/check_mysql.c:557
+msgid "Use ssl encryption"
 msgstr ""
 
-#: plugins/check_mysql.c:541
+#: plugins/check_mysql.c:559
 msgid "Path to CA signing the cert"
 msgstr ""
 
-#: plugins/check_mysql.c:543
+#: plugins/check_mysql.c:561
 msgid "Path to SSL certificate"
 msgstr ""
 
-#: plugins/check_mysql.c:545
+#: plugins/check_mysql.c:563
 msgid "Path to private SSL key"
 msgstr ""
 
-#: plugins/check_mysql.c:547
+#: plugins/check_mysql.c:565
 msgid "Path to CA directory"
 msgstr ""
 
-#: plugins/check_mysql.c:549
+#: plugins/check_mysql.c:567
 msgid "List of valid SSL ciphers"
 msgstr ""
 
-#: plugins/check_mysql.c:553
+#: plugins/check_mysql.c:571
 msgid ""
 "There are no required arguments. By default, the local database is checked"
 msgstr ""
 
-#: plugins/check_mysql.c:554
+#: plugins/check_mysql.c:572
 msgid ""
 "using the default unix socket. You can force TCP on localhost by using an"
 msgstr ""
 
-#: plugins/check_mysql.c:555
+#: plugins/check_mysql.c:573
 msgid "IP address or FQDN ('localhost' will use the socket as well)."
 msgstr ""
 
-#: plugins/check_mysql.c:559
+#: plugins/check_mysql.c:577
 msgid "You must specify -p with an empty string to force an empty password,"
 msgstr ""
 
-#: plugins/check_mysql.c:560
+#: plugins/check_mysql.c:578
 msgid "overriding any my.cnf settings."
 msgstr ""
 
@@ -2216,7 +2404,7 @@ msgstr ""
 msgid "Cannot parse Nagios log file for valid time"
 msgstr ""
 
-#: plugins/check_nagios.c:183 plugins/check_procs.c:356
+#: plugins/check_nagios.c:183 plugins/check_procs.c:379
 #, c-format
 msgid "%d process"
 msgid_plural "%d processes"
@@ -2286,7 +2474,7 @@ msgstr ""
 msgid "Wrong client version - running: %s, required: %s"
 msgstr ""
 
-#: plugins/check_nt.c:153 plugins/check_nt.c:218
+#: plugins/check_nt.c:153 plugins/check_nt.c:239
 msgid "missing -l parameters"
 msgstr ""
 
@@ -2312,493 +2500,519 @@ msgstr ""
 msgid "not enough values for -l parameters"
 msgstr ""
 
-#: plugins/check_nt.c:206
-#, c-format
-msgid "System Uptime - %u day(s) %u hour(s) %u minute(s)"
-msgstr ""
-
-#: plugins/check_nt.c:220
+#: plugins/check_nt.c:208 plugins/check_nt.c:241
 msgid "wrong -l argument"
 msgstr ""
 
-#: plugins/check_nt.c:236
+#: plugins/check_nt.c:225
+#, c-format
+msgid "System Uptime - %u day(s) %u hour(s) %u minute(s) |uptime=%lu"
+msgstr ""
+
+#: plugins/check_nt.c:257
 #, c-format
 msgid "%s:\\ - total: %.2f Gb - used: %.2f Gb (%.0f%%) - free %.2f Gb (%.0f%%)"
 msgstr ""
 
-#: plugins/check_nt.c:239
+#: plugins/check_nt.c:260
 #, c-format
 msgid "'%s:\\ Used Space'=%.2fGb;%.2f;%.2f;0.00;%.2f"
 msgstr ""
 
-#: plugins/check_nt.c:253
+#: plugins/check_nt.c:274
 msgid "Free disk space : Invalid drive"
 msgstr ""
 
-#: plugins/check_nt.c:263
+#: plugins/check_nt.c:284
 msgid "No service/process specified"
 msgstr ""
 
-#: plugins/check_nt.c:271 plugins/check_nt.c:284 plugins/check_nt.c:288
-#: plugins/check_nt.c:622
+#: plugins/check_nt.c:292 plugins/check_nt.c:305 plugins/check_nt.c:309
+#: plugins/check_nt.c:643
 msgid "could not fetch information from server\n"
 msgstr ""
 
-#: plugins/check_nt.c:296
+#: plugins/check_nt.c:317
 #, c-format
 msgid ""
-"Memory usage: total:%.2f Mb - used: %.2f Mb (%.0f%%) - free: %.2f Mb (%.0f%%)"
+"Memory usage: total:%.2f MB - used: %.2f MB (%.0f%%) - free: %.2f MB (%.0f%%)"
 msgstr ""
 
-#: plugins/check_nt.c:299
+#: plugins/check_nt.c:320
 #, c-format
-msgid "'Memory usage'=%.2fMb;%.2f;%.2f;0.00;%.2f"
+msgid "'Memory usage'=%.2fMB;%.2f;%.2f;0.00;%.2f"
 msgstr ""
 
-#: plugins/check_nt.c:335 plugins/check_nt.c:420 plugins/check_nt.c:450
+#: plugins/check_nt.c:356 plugins/check_nt.c:441 plugins/check_nt.c:471
 msgid "No counter specified"
 msgstr ""
 
-#: plugins/check_nt.c:367
+#: plugins/check_nt.c:388
 msgid "Minimum value contains non-numbers"
 msgstr ""
 
-#: plugins/check_nt.c:371
+#: plugins/check_nt.c:392
 msgid "Maximum value contains non-numbers"
 msgstr ""
 
-#: plugins/check_nt.c:378
+#: plugins/check_nt.c:399
 msgid "No unit counter specified"
 msgstr ""
 
-#: plugins/check_nt.c:465
+#: plugins/check_nt.c:486
 msgid "Please specify a variable to check"
 msgstr ""
 
-#: plugins/check_nt.c:549
+#: plugins/check_nt.c:570
 msgid "Server port must be an integer\n"
 msgstr ""
 
-#: plugins/check_nt.c:603
+#: plugins/check_nt.c:624
 msgid "You must provide a server address or host name"
 msgstr ""
 
-#: plugins/check_nt.c:609
+#: plugins/check_nt.c:630
 msgid "None"
 msgstr ""
 
-#: plugins/check_nt.c:666
+#: plugins/check_nt.c:687
 msgid "This plugin collects data from the NSClient service running on a"
 msgstr ""
 
-#: plugins/check_nt.c:667
+#: plugins/check_nt.c:688
 msgid "Windows NT/2000/XP/2003 server."
 msgstr ""
 
-#: plugins/check_nt.c:678
+#: plugins/check_nt.c:699
 msgid "Name of the host to check"
 msgstr ""
 
-#: plugins/check_nt.c:680
+#: plugins/check_nt.c:701
 msgid "Optional port number (default: "
 msgstr ""
 
-#: plugins/check_nt.c:683
+#: plugins/check_nt.c:704
 msgid "Password needed for the request"
 msgstr ""
 
-#: plugins/check_nt.c:685 plugins/check_nwstat.c:1661
+#: plugins/check_nt.c:706 plugins/check_nwstat.c:1661
 #: plugins/check_overcr.c:432
 msgid "Threshold which will result in a warning status"
 msgstr ""
 
-#: plugins/check_nt.c:687 plugins/check_nwstat.c:1663
+#: plugins/check_nt.c:708 plugins/check_nwstat.c:1663
 #: plugins/check_overcr.c:434
 msgid "Threshold which will result in a critical status"
 msgstr ""
 
-#: plugins/check_nt.c:689
+#: plugins/check_nt.c:710
 msgid "Seconds before connection attempt times out (default: "
 msgstr ""
 
-#: plugins/check_nt.c:691
+#: plugins/check_nt.c:712
 msgid "Parameters passed to specified check (see below)"
 msgstr ""
 
-#: plugins/check_nt.c:693
+#: plugins/check_nt.c:714
 msgid "Display options (currently only SHOWALL works)"
 msgstr ""
 
-#: plugins/check_nt.c:695
+#: plugins/check_nt.c:716
 msgid "Return UNKNOWN on timeouts"
 msgstr ""
 
-#: plugins/check_nt.c:698
+#: plugins/check_nt.c:719
 msgid "Print this help screen"
 msgstr ""
 
-#: plugins/check_nt.c:700
+#: plugins/check_nt.c:721
 msgid "Print version information"
 msgstr ""
 
-#: plugins/check_nt.c:702
+#: plugins/check_nt.c:723
 msgid "Variable to check"
 msgstr ""
 
-#: plugins/check_nt.c:703
+#: plugins/check_nt.c:724
 msgid "Valid variables are:"
 msgstr ""
 
-#: plugins/check_nt.c:705
+#: plugins/check_nt.c:726
 msgid "Get the NSClient version"
 msgstr ""
 
-#: plugins/check_nt.c:706
+#: plugins/check_nt.c:727
 msgid "If -l <version> is specified, will return warning if versions differ."
 msgstr ""
 
-#: plugins/check_nt.c:708
+#: plugins/check_nt.c:729
 msgid "Average CPU load on last x minutes."
 msgstr ""
 
-#: plugins/check_nt.c:709
+#: plugins/check_nt.c:730
 msgid "Request a -l parameter with the following syntax:"
 msgstr ""
 
-#: plugins/check_nt.c:710
+#: plugins/check_nt.c:731
 msgid "-l <minutes range>,<warning threshold>,<critical threshold>."
 msgstr ""
 
-#: plugins/check_nt.c:711
+#: plugins/check_nt.c:732
 msgid "<minute range> should be less than 24*60."
 msgstr ""
 
-#: plugins/check_nt.c:712
+#: plugins/check_nt.c:733
 msgid ""
 "Thresholds are percentage and up to 10 requests can be done in one shot."
 msgstr ""
 
-#: plugins/check_nt.c:715
+#: plugins/check_nt.c:736
 msgid "Get the uptime of the machine."
 msgstr ""
 
-#: plugins/check_nt.c:716
-msgid "No specific parameters. No warning or critical threshold"
-msgstr ""
-
-#: plugins/check_nt.c:718
-msgid "Size and percentage of disk use."
-msgstr ""
-
-#: plugins/check_nt.c:719
-msgid "Request a -l parameter containing the drive letter only."
-msgstr ""
-
-#: plugins/check_nt.c:720 plugins/check_nt.c:723
-msgid "Warning and critical thresholds can be specified with -w and -c."
-msgstr ""
-
-#: plugins/check_nt.c:722
-msgid "Memory use."
-msgstr ""
-
-#: plugins/check_nt.c:725
-msgid "Check the state of one or several services."
-msgstr ""
-
-#: plugins/check_nt.c:726 plugins/check_nt.c:735
-msgid "Request a -l parameters with the following syntax:"
-msgstr ""
-
-#: plugins/check_nt.c:727
-msgid "-l <service1>,<service2>,<service3>,..."
-msgstr ""
-
-#: plugins/check_nt.c:728
-msgid "You can specify -d SHOWALL in case you want to see working services"
-msgstr ""
-
-#: plugins/check_nt.c:729
-msgid "in the returned string."
-msgstr ""
-
-#: plugins/check_nt.c:731
-msgid "Check if one or several process are running."
-msgstr ""
-
-#: plugins/check_nt.c:732
-msgid "Same syntax as SERVICESTATE."
-msgstr ""
-
-#: plugins/check_nt.c:734
-msgid "Check any performance counter of Windows NT/2000."
-msgstr ""
-
-#: plugins/check_nt.c:736
-msgid "-l \"\\\\<performance object>\\\\counter\",\"<description>"
-msgstr ""
-
 #: plugins/check_nt.c:737
-msgid "The <description> parameter is optional and is given to a printf "
+msgid "-l <unit> "
 msgstr ""
 
 #: plugins/check_nt.c:738
-msgid "output command which requires a float parameter."
+msgid "<unit> = seconds, minutes, hours, or days. (default: minutes)"
 msgstr ""
 
 #: plugins/check_nt.c:739
+msgid "Thresholds will use the unit specified above."
+msgstr ""
+
+#: plugins/check_nt.c:741
+msgid "Size and percentage of disk use."
+msgstr ""
+
+#: plugins/check_nt.c:742
+msgid "Request a -l parameter containing the drive letter only."
+msgstr ""
+
+#: plugins/check_nt.c:743 plugins/check_nt.c:746
+msgid "Warning and critical thresholds can be specified with -w and -c."
+msgstr ""
+
+#: plugins/check_nt.c:745
+msgid "Memory use."
+msgstr ""
+
+#: plugins/check_nt.c:748
+msgid "Check the state of one or several services."
+msgstr ""
+
+#: plugins/check_nt.c:749 plugins/check_nt.c:758
+msgid "Request a -l parameters with the following syntax:"
+msgstr ""
+
+#: plugins/check_nt.c:750
+msgid "-l <service1>,<service2>,<service3>,..."
+msgstr ""
+
+#: plugins/check_nt.c:751
+msgid "You can specify -d SHOWALL in case you want to see working services"
+msgstr ""
+
+#: plugins/check_nt.c:752
+msgid "in the returned string."
+msgstr ""
+
+#: plugins/check_nt.c:754
+msgid "Check if one or several process are running."
+msgstr ""
+
+#: plugins/check_nt.c:755
+msgid "Same syntax as SERVICESTATE."
+msgstr ""
+
+#: plugins/check_nt.c:757
+msgid "Check any performance counter of Windows NT/2000."
+msgstr ""
+
+#: plugins/check_nt.c:759
+msgid "-l \"\\\\<performance object>\\\\counter\",\"<description>"
+msgstr ""
+
+#: plugins/check_nt.c:760
+msgid "The <description> parameter is optional and is given to a printf "
+msgstr ""
+
+#: plugins/check_nt.c:761
+msgid "output command which requires a float parameter."
+msgstr ""
+
+#: plugins/check_nt.c:762
 #, c-format
 msgid "If <description> does not include \"%%\", it is used as a label."
 msgstr ""
 
-#: plugins/check_nt.c:740 plugins/check_nt.c:755
+#: plugins/check_nt.c:763 plugins/check_nt.c:778
 msgid "Some examples:"
 msgstr ""
 
-#: plugins/check_nt.c:744
+#: plugins/check_nt.c:767
 msgid "Check any performance counter object of Windows NT/2000."
 msgstr ""
 
-#: plugins/check_nt.c:745
+#: plugins/check_nt.c:768
 msgid ""
 "Syntax: check_nt -H <hostname> -p <port> -v INSTANCES -l <counter object>"
 msgstr ""
 
-#: plugins/check_nt.c:746
+#: plugins/check_nt.c:769
 msgid "<counter object> is a Windows Perfmon Counter object (eg. Process),"
 msgstr ""
 
-#: plugins/check_nt.c:747
+#: plugins/check_nt.c:770
 msgid "if it is two words, it should be enclosed in quotes"
 msgstr ""
 
-#: plugins/check_nt.c:748
+#: plugins/check_nt.c:771
 msgid "The returned results will be a comma-separated list of instances on "
 msgstr ""
 
-#: plugins/check_nt.c:749
+#: plugins/check_nt.c:772
 msgid " the selected computer for that object."
 msgstr ""
 
-#: plugins/check_nt.c:750
+#: plugins/check_nt.c:773
 msgid ""
 "The purpose of this is to be run from command line to determine what "
 "instances"
 msgstr ""
 
-#: plugins/check_nt.c:751
+#: plugins/check_nt.c:774
 msgid ""
 " are available for monitoring without having to log onto the Windows server"
 msgstr ""
 
-#: plugins/check_nt.c:752
+#: plugins/check_nt.c:775
 msgid "  to run Perfmon directly."
 msgstr ""
 
-#: plugins/check_nt.c:753
+#: plugins/check_nt.c:776
 msgid ""
 "It can also be used in scripts that automatically create the monitoring "
 "service"
 msgstr ""
 
-#: plugins/check_nt.c:754
+#: plugins/check_nt.c:777
 msgid " configuration files."
 msgstr ""
 
-#: plugins/check_nt.c:756
+#: plugins/check_nt.c:779
 msgid "check_nt -H 192.168.1.1 -p 1248 -v INSTANCES -l Process"
 msgstr ""
 
-#: plugins/check_nt.c:759
+#: plugins/check_nt.c:782
 msgid ""
 "- The NSClient service should be running on the server to get any information"
 msgstr ""
 
-#: plugins/check_nt.c:761
+#: plugins/check_nt.c:784
 msgid "- Critical thresholds should be lower than warning thresholds"
 msgstr ""
 
-#: plugins/check_nt.c:762
+#: plugins/check_nt.c:785
 msgid "- Default port 1248 is sometimes in use by other services. The error"
 msgstr ""
 
-#: plugins/check_nt.c:763
+#: plugins/check_nt.c:786
 msgid ""
 "output when this happens contains \"Cannot map xxxxx to protocol number\"."
 msgstr ""
 
-#: plugins/check_nt.c:764
+#: plugins/check_nt.c:787
 msgid "One fix for this is to change the port to something else on check_nt "
 msgstr ""
 
-#: plugins/check_nt.c:765
+#: plugins/check_nt.c:788
 msgid "and on the client service it's connecting to."
 msgstr ""
 
-#: plugins/check_ntp.c:807 plugins/check_ntp_peer.c:612
-#: plugins/check_ntp_time.c:571
+#: plugins/check_ntp.c:629
+#, c-format
+msgid "jitter response too large (%lu bytes)\n"
+msgstr ""
+
+#: plugins/check_ntp.c:817 plugins/check_ntp_peer.c:619
+#: plugins/check_ntp_time.c:576
 msgid "NTP CRITICAL:"
 msgstr ""
 
-#: plugins/check_ntp.c:810 plugins/check_ntp_peer.c:615
-#: plugins/check_ntp_time.c:574
+#: plugins/check_ntp.c:820 plugins/check_ntp_peer.c:622
+#: plugins/check_ntp_time.c:579
 msgid "NTP WARNING:"
 msgstr ""
 
-#: plugins/check_ntp.c:813 plugins/check_ntp_peer.c:618
-#: plugins/check_ntp_time.c:577
+#: plugins/check_ntp.c:823 plugins/check_ntp_peer.c:625
+#: plugins/check_ntp_time.c:582
 msgid "NTP OK:"
 msgstr ""
 
-#: plugins/check_ntp.c:816 plugins/check_ntp_peer.c:621
-#: plugins/check_ntp_time.c:580
+#: plugins/check_ntp.c:826 plugins/check_ntp_peer.c:628
+#: plugins/check_ntp_time.c:585
 msgid "NTP UNKNOWN:"
 msgstr ""
 
-#: plugins/check_ntp.c:820 plugins/check_ntp_peer.c:630
-#: plugins/check_ntp_time.c:584
+#: plugins/check_ntp.c:830 plugins/check_ntp_peer.c:637
+#: plugins/check_ntp_time.c:589
 msgid "Offset unknown"
 msgstr ""
 
-#: plugins/check_ntp.c:823 plugins/check_ntp_peer.c:633
-#: plugins/check_ntp_time.c:587
+#: plugins/check_ntp.c:833 plugins/check_ntp_peer.c:640
+#: plugins/check_ntp_peer.c:642 plugins/check_ntp_peer.c:644
+#: plugins/check_ntp_time.c:592
 msgid "Offset"
 msgstr ""
 
-#: plugins/check_ntp.c:844 plugins/check_ntp_peer.c:662
+#: plugins/check_ntp.c:854 plugins/check_ntp_peer.c:690
 msgid "This plugin checks the selected ntp server"
 msgstr ""
 
-#: plugins/check_ntp.c:854 plugins/check_ntp_peer.c:674
-#: plugins/check_ntp_time.c:614
+#: plugins/check_ntp.c:864 plugins/check_ntp_peer.c:702
+#: plugins/check_ntp_time.c:619
 msgid "Offset to result in warning status (seconds)"
 msgstr ""
 
-#: plugins/check_ntp.c:856 plugins/check_ntp_peer.c:676
-#: plugins/check_ntp_time.c:616
+#: plugins/check_ntp.c:866 plugins/check_ntp_peer.c:704
+#: plugins/check_ntp_time.c:621
 msgid "Offset to result in critical status (seconds)"
 msgstr ""
 
-#: plugins/check_ntp.c:858 plugins/check_ntp_peer.c:682
+#: plugins/check_ntp.c:868 plugins/check_ntp_peer.c:710
 msgid "Warning threshold for jitter"
 msgstr ""
 
-#: plugins/check_ntp.c:860 plugins/check_ntp_peer.c:684
+#: plugins/check_ntp.c:870 plugins/check_ntp_peer.c:712
 msgid "Critical threshold for jitter"
 msgstr ""
 
-#: plugins/check_ntp.c:870
+#: plugins/check_ntp.c:880
 msgid "Normal offset check:"
 msgstr ""
 
-#: plugins/check_ntp.c:873 plugins/check_ntp_peer.c:709
+#: plugins/check_ntp.c:883 plugins/check_ntp_peer.c:737
 msgid ""
 "Check jitter too, avoiding critical notifications if jitter isn't available"
 msgstr ""
 
-#: plugins/check_ntp.c:874 plugins/check_ntp_peer.c:710
+#: plugins/check_ntp.c:884 plugins/check_ntp_peer.c:738
 msgid "(See Notes above for more details on thresholds formats):"
 msgstr ""
 
-#: plugins/check_ntp.c:879 plugins/check_ntp.c:886
+#: plugins/check_ntp.c:889 plugins/check_ntp.c:896
 msgid "WARNING: check_ntp is deprecated. Please use check_ntp_peer or"
 msgstr ""
 
-#: plugins/check_ntp.c:880 plugins/check_ntp.c:887
+#: plugins/check_ntp.c:890 plugins/check_ntp.c:897
 msgid "check_ntp_time instead."
 msgstr ""
 
-#: plugins/check_ntp_peer.c:625
+#: plugins/check_ntp_peer.c:632
 msgid "Server not synchronized"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:627
+#: plugins/check_ntp_peer.c:634
 msgid "Server has the LI_ALARM bit set"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:672
+#: plugins/check_ntp_peer.c:700
 msgid ""
 "Returns UNKNOWN instead of CRITICAL or WARNING if server isn't synchronized"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:678
+#: plugins/check_ntp_peer.c:706
 msgid "Warning threshold for stratum of server's synchronization peer"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:680
+#: plugins/check_ntp_peer.c:708
 msgid "Critical threshold for stratum of server's synchronization peer"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:686
+#: plugins/check_ntp_peer.c:714
 msgid "Warning threshold for number of usable time sources (\"truechimers\")"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:688
+#: plugins/check_ntp_peer.c:716
 msgid "Critical threshold for number of usable time sources (\"truechimers\")"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:693
+#: plugins/check_ntp_peer.c:721
 msgid "This plugin checks an NTP server independent of any commandline"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:694
+#: plugins/check_ntp_peer.c:722
 msgid "programs or external libraries."
 msgstr ""
 
-#: plugins/check_ntp_peer.c:697
+#: plugins/check_ntp_peer.c:725
 msgid "Use this plugin to check the health of an NTP server. It supports"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:698
+#: plugins/check_ntp_peer.c:726
 msgid "checking the offset with the sync peer, the jitter and stratum. This"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:699
+#: plugins/check_ntp_peer.c:727
 msgid "plugin will not check the clock offset between the local host and NTP"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:700
+#: plugins/check_ntp_peer.c:728
 msgid "server; please use check_ntp_time for that purpose."
 msgstr ""
 
-#: plugins/check_ntp_peer.c:706
+#: plugins/check_ntp_peer.c:734
 msgid "Simple NTP server check:"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:713
+#: plugins/check_ntp_peer.c:741
 msgid "Only check the number of usable time sources (\"truechimers\"):"
 msgstr ""
 
-#: plugins/check_ntp_peer.c:716
+#: plugins/check_ntp_peer.c:744
 msgid "Check only stratum:"
 msgstr ""
 
-#: plugins/check_ntp_time.c:602
+#: plugins/check_ntp_time.c:607
 msgid "This plugin checks the clock offset with the ntp server"
 msgstr ""
 
-#: plugins/check_ntp_time.c:612
+#: plugins/check_ntp_time.c:617
 msgid "Returns UNKNOWN instead of CRITICAL if offset cannot be found"
 msgstr ""
 
-#: plugins/check_ntp_time.c:621
-msgid "This plugin checks the clock offset between the local host and a"
-msgstr ""
-
-#: plugins/check_ntp_time.c:622
-msgid "remote NTP server. It is independent of any commandline programs or"
-msgstr ""
-
 #: plugins/check_ntp_time.c:623
-msgid "external libraries."
-msgstr ""
-
-#: plugins/check_ntp_time.c:627
-msgid "If you'd rather want to monitor an NTP server, please use"
+msgid "Expected offset of the ntp server relative to local server (seconds)"
 msgstr ""
 
 #: plugins/check_ntp_time.c:628
+msgid "This plugin checks the clock offset between the local host and a"
+msgstr ""
+
+#: plugins/check_ntp_time.c:629
+msgid "remote NTP server. It is independent of any commandline programs or"
+msgstr ""
+
+#: plugins/check_ntp_time.c:630
+msgid "external libraries."
+msgstr ""
+
+#: plugins/check_ntp_time.c:634
+msgid "If you'd rather want to monitor an NTP server, please use"
+msgstr ""
+
+#: plugins/check_ntp_time.c:635
 msgid "check_ntp_peer."
+msgstr ""
+
+#: plugins/check_ntp_time.c:636
+msgid "--time-offset is useful for compensating for servers with known"
+msgstr ""
+
+#: plugins/check_ntp_time.c:637
+msgid "and expected clock skew."
 msgstr ""
 
 #: plugins/check_nwstat.c:194
@@ -3367,593 +3581,628 @@ msgid ""
 "higher than the warning threshold value, EXCEPT with the uptime variable"
 msgstr ""
 
-#: plugins/check_pgsql.c:222
+#: plugins/check_pgsql.c:224
 #, c-format
 msgid "CRITICAL - no connection to '%s' (%s).\n"
 msgstr ""
 
-#: plugins/check_pgsql.c:250
+#: plugins/check_pgsql.c:252
 #, c-format
 msgid " %s - database %s (%f sec.)|%s\n"
 msgstr ""
 
-#: plugins/check_pgsql.c:317 plugins/check_time.c:277 plugins/check_time.c:289
-#: plugins/check_users.c:181
+#: plugins/check_pgsql.c:320 plugins/check_time.c:277 plugins/check_time.c:289
+#: plugins/check_users.c:228
 msgid "Critical threshold must be a positive integer"
 msgstr ""
 
-#: plugins/check_pgsql.c:323 plugins/check_time.c:258 plugins/check_time.c:282
-#: plugins/check_users.c:187 plugins/check_users.c:197
-#: plugins/check_users.c:203
+#: plugins/check_pgsql.c:326 plugins/check_time.c:258 plugins/check_time.c:282
+#: plugins/check_users.c:226
 msgid "Warning threshold must be a positive integer"
 msgstr ""
 
-#: plugins/check_pgsql.c:347
-msgid "Database name is not valid"
+#: plugins/check_pgsql.c:350
+msgid "Database name exceeds the maximum length"
 msgstr ""
 
-#: plugins/check_pgsql.c:353
+#: plugins/check_pgsql.c:356
 msgid "User name is not valid"
 msgstr ""
 
-#: plugins/check_pgsql.c:504
+#: plugins/check_pgsql.c:471
 #, c-format
 msgid "Test whether a PostgreSQL Database is accepting connections."
 msgstr ""
 
-#: plugins/check_pgsql.c:516
+#: plugins/check_pgsql.c:483
 msgid "Database to check "
 msgstr ""
 
-#: plugins/check_pgsql.c:517
+#: plugins/check_pgsql.c:484
 #, c-format
-msgid "(default: %s)"
+msgid "(default: %s)\n"
 msgstr ""
 
-#: plugins/check_pgsql.c:519
+#: plugins/check_pgsql.c:486
 msgid "Login name of user"
 msgstr ""
 
-#: plugins/check_pgsql.c:521
+#: plugins/check_pgsql.c:488
 msgid "Password (BIG SECURITY ISSUE)"
 msgstr ""
 
-#: plugins/check_pgsql.c:523
+#: plugins/check_pgsql.c:490
 msgid "Connection parameters (keyword = value), see below"
 msgstr ""
 
-#: plugins/check_pgsql.c:530
+#: plugins/check_pgsql.c:497
 msgid "SQL query to run. Only first column in first row will be read"
 msgstr ""
 
-#: plugins/check_pgsql.c:532
+#: plugins/check_pgsql.c:499
+msgid "A name for the query, this string is used instead of the query"
+msgstr ""
+
+#: plugins/check_pgsql.c:500
+msgid "in the long output of the plugin"
+msgstr ""
+
+#: plugins/check_pgsql.c:502
 msgid "SQL query value to result in warning status (double)"
 msgstr ""
 
-#: plugins/check_pgsql.c:534
+#: plugins/check_pgsql.c:504
 msgid "SQL query value to result in critical status (double)"
 msgstr ""
 
-#: plugins/check_pgsql.c:539
+#: plugins/check_pgsql.c:509
 msgid "All parameters are optional."
 msgstr ""
 
-#: plugins/check_pgsql.c:540
+#: plugins/check_pgsql.c:510
 msgid ""
 "This plugin tests a PostgreSQL DBMS to determine whether it is active and"
 msgstr ""
 
-#: plugins/check_pgsql.c:541
+#: plugins/check_pgsql.c:511
 msgid "accepting queries. In its current operation, it simply connects to the"
 msgstr ""
 
-#: plugins/check_pgsql.c:542
+#: plugins/check_pgsql.c:512
 msgid ""
 "specified database, and then disconnects. If no database is specified, it"
 msgstr ""
 
-#: plugins/check_pgsql.c:543
+#: plugins/check_pgsql.c:513
 msgid ""
 "connects to the template1 database, which is present in every functioning"
 msgstr ""
 
-#: plugins/check_pgsql.c:544
+#: plugins/check_pgsql.c:514
 msgid "PostgreSQL DBMS."
 msgstr ""
 
-#: plugins/check_pgsql.c:546
+#: plugins/check_pgsql.c:516
 msgid "If a query is specified using the -q option, it will be executed after"
 msgstr ""
 
-#: plugins/check_pgsql.c:547
+#: plugins/check_pgsql.c:517
 msgid "connecting to the server. The result from the query has to be numeric."
 msgstr ""
 
-#: plugins/check_pgsql.c:548
+#: plugins/check_pgsql.c:518
 msgid ""
 "Multiple SQL commands, separated by semicolon, are allowed but the result "
 msgstr ""
 
-#: plugins/check_pgsql.c:549
+#: plugins/check_pgsql.c:519
 msgid "of the last command is taken into account only. The value of the first"
 msgstr ""
 
-#: plugins/check_pgsql.c:550
-msgid "column in the first row is used as the check result."
+#: plugins/check_pgsql.c:520
+msgid ""
+"column in the first row is used as the check result. If a second column is"
 msgstr ""
 
-#: plugins/check_pgsql.c:552
+#: plugins/check_pgsql.c:521
+msgid "present in the result set, this is added to the plugin output with a"
+msgstr ""
+
+#: plugins/check_pgsql.c:522
+msgid ""
+"prefix of \"Extra Info:\". This information can be displayed in the system"
+msgstr ""
+
+#: plugins/check_pgsql.c:523
+msgid "executing the plugin."
+msgstr ""
+
+#: plugins/check_pgsql.c:525
 msgid ""
 "See the chapter \"Monitoring Database Activity\" of the PostgreSQL manual"
 msgstr ""
 
-#: plugins/check_pgsql.c:553
+#: plugins/check_pgsql.c:526
 msgid ""
 "for details about how to access internal statistics of the database server."
 msgstr ""
 
-#: plugins/check_pgsql.c:555
+#: plugins/check_pgsql.c:528
 msgid ""
 "For a list of available connection parameters which may be used with the -o"
 msgstr ""
 
-#: plugins/check_pgsql.c:556
+#: plugins/check_pgsql.c:529
 msgid ""
 "command line option, see the documentation for PQconnectdb() in the chapter"
 msgstr ""
 
-#: plugins/check_pgsql.c:557
+#: plugins/check_pgsql.c:530
 msgid ""
 "\"libpq - C Library\" of the PostgreSQL manual. For example, this may be"
 msgstr ""
 
-#: plugins/check_pgsql.c:558
+#: plugins/check_pgsql.c:531
 msgid ""
 "used to specify a service name in pg_service.conf to be used for additional"
 msgstr ""
 
-#: plugins/check_pgsql.c:559
+#: plugins/check_pgsql.c:532
 msgid "connection parameters: -o 'service=<name>' or to specify the SSL mode:"
 msgstr ""
 
-#: plugins/check_pgsql.c:560
+#: plugins/check_pgsql.c:533
 msgid "-o 'sslmode=require'."
 msgstr ""
 
-#: plugins/check_pgsql.c:562
+#: plugins/check_pgsql.c:535
 msgid ""
 "The plugin will connect to a local postmaster if no host is specified. To"
 msgstr ""
 
-#: plugins/check_pgsql.c:563
+#: plugins/check_pgsql.c:536
 msgid ""
 "connect to a remote host, be sure that the remote postmaster accepts TCP/IP"
 msgstr ""
 
-#: plugins/check_pgsql.c:564
+#: plugins/check_pgsql.c:537
 msgid "connections (start the postmaster with the -i option)."
 msgstr ""
 
-#: plugins/check_pgsql.c:566
+#: plugins/check_pgsql.c:539
 msgid ""
 "Typically, the monitoring user (unless the --logname option is used) should "
 "be"
 msgstr ""
 
-#: plugins/check_pgsql.c:567
+#: plugins/check_pgsql.c:540
 msgid ""
 "able to connect to the database without a password. The plugin can also send"
 msgstr ""
 
-#: plugins/check_pgsql.c:568
+#: plugins/check_pgsql.c:541
 msgid "a password, but no effort is made to obscure or encrypt the password."
 msgstr ""
 
-#: plugins/check_pgsql.c:601
+#: plugins/check_pgsql.c:575
 #, c-format
 msgid "QUERY %s - %s: %s.\n"
 msgstr ""
 
-#: plugins/check_pgsql.c:601
+#: plugins/check_pgsql.c:575
 msgid "Error with query"
 msgstr ""
 
-#: plugins/check_pgsql.c:607
+#: plugins/check_pgsql.c:581
 msgid "No rows returned"
 msgstr ""
 
-#: plugins/check_pgsql.c:612
+#: plugins/check_pgsql.c:586
 msgid "No columns returned"
 msgstr ""
 
-#: plugins/check_pgsql.c:618
+#: plugins/check_pgsql.c:592
 msgid "No data returned"
 msgstr ""
 
-#: plugins/check_pgsql.c:627
+#: plugins/check_pgsql.c:601
 msgid "Is not a numeric"
 msgstr ""
 
-#: plugins/check_pgsql.c:644
+#: plugins/check_pgsql.c:619
+#, c-format
+msgid "%s returned %f"
+msgstr ""
+
+#: plugins/check_pgsql.c:622
 #, c-format
 msgid "'%s' returned %f"
 msgstr ""
 
-#: plugins/check_ping.c:141
+#: plugins/check_ping.c:143
 msgid "CRITICAL - Could not interpret output from ping command\n"
 msgstr ""
 
-#: plugins/check_ping.c:157
+#: plugins/check_ping.c:159
 #, c-format
 msgid "PING %s - %sPacket loss = %d%%"
 msgstr ""
 
-#: plugins/check_ping.c:160
+#: plugins/check_ping.c:162
 #, c-format
 msgid "PING %s - %sPacket loss = %d%%, RTA = %2.2f ms"
 msgstr ""
 
-#: plugins/check_ping.c:257
+#: plugins/check_ping.c:263
 msgid "Could not realloc() addresses\n"
 msgstr ""
 
-#: plugins/check_ping.c:272 plugins/check_ping.c:352
+#: plugins/check_ping.c:278 plugins/check_ping.c:358
 #, c-format
 msgid "<max_packets> (%s) must be a non-negative number\n"
 msgstr ""
 
-#: plugins/check_ping.c:306
+#: plugins/check_ping.c:312
 #, c-format
 msgid "<wpl> (%s) must be an integer percentage\n"
 msgstr ""
 
-#: plugins/check_ping.c:317
+#: plugins/check_ping.c:323
 #, c-format
 msgid "<cpl> (%s) must be an integer percentage\n"
 msgstr ""
 
-#: plugins/check_ping.c:328
+#: plugins/check_ping.c:334
 #, c-format
 msgid "<wrta> (%s) must be a non-negative number\n"
 msgstr ""
 
-#: plugins/check_ping.c:339
+#: plugins/check_ping.c:345
 #, c-format
 msgid "<crta> (%s) must be a non-negative number\n"
 msgstr ""
 
-#: plugins/check_ping.c:372
+#: plugins/check_ping.c:378
 #, c-format
 msgid ""
 "%s: Warning threshold must be integer or percentage!\n"
 "\n"
 msgstr ""
 
-#: plugins/check_ping.c:385
+#: plugins/check_ping.c:391
 #, c-format
 msgid "<wrta> was not set\n"
 msgstr ""
 
-#: plugins/check_ping.c:389
+#: plugins/check_ping.c:395
 #, c-format
 msgid "<crta> was not set\n"
 msgstr ""
 
-#: plugins/check_ping.c:393
+#: plugins/check_ping.c:399
 #, c-format
 msgid "<wpl> was not set\n"
 msgstr ""
 
-#: plugins/check_ping.c:397
+#: plugins/check_ping.c:403
 #, c-format
 msgid "<cpl> was not set\n"
 msgstr ""
 
-#: plugins/check_ping.c:401
+#: plugins/check_ping.c:407
 #, c-format
 msgid "<wrta> (%f) cannot be larger than <crta> (%f)\n"
 msgstr ""
 
-#: plugins/check_ping.c:405
+#: plugins/check_ping.c:411
 #, c-format
 msgid "<wpl> (%d) cannot be larger than <cpl> (%d)\n"
 msgstr ""
 
-#: plugins/check_ping.c:442
+#: plugins/check_ping.c:448
 #, c-format
 msgid "Cannot open stderr for %s\n"
 msgstr ""
 
-#: plugins/check_ping.c:492 plugins/check_ping.c:494
+#: plugins/check_ping.c:505 plugins/check_ping.c:507
 msgid "System call sent warnings to stderr "
-msgstr ""
-
-#: plugins/check_ping.c:519
-#, c-format
-msgid "CRITICAL - Network Unreachable (%s)\n"
-msgstr ""
-
-#: plugins/check_ping.c:521
-#, c-format
-msgid "CRITICAL - Host Unreachable (%s)\n"
-msgstr ""
-
-#: plugins/check_ping.c:523
-#, c-format
-msgid "CRITICAL - Bogus ICMP: Port Unreachable (%s)\n"
-msgstr ""
-
-#: plugins/check_ping.c:525
-#, c-format
-msgid "CRITICAL - Bogus ICMP: Protocol Unreachable (%s)\n"
-msgstr ""
-
-#: plugins/check_ping.c:527
-#, c-format
-msgid "CRITICAL - Network Prohibited (%s)\n"
-msgstr ""
-
-#: plugins/check_ping.c:529
-#, c-format
-msgid "CRITICAL - Host Prohibited (%s)\n"
-msgstr ""
-
-#: plugins/check_ping.c:531
-#, c-format
-msgid "CRITICAL - Packet Filtered (%s)\n"
 msgstr ""
 
 #: plugins/check_ping.c:533
 #, c-format
-msgid "CRITICAL - Host not found (%s)\n"
+msgid "CRITICAL - Network Unreachable (%s)\n"
 msgstr ""
 
 #: plugins/check_ping.c:535
 #, c-format
-msgid "CRITICAL - Time to live exceeded (%s)\n"
+msgid "CRITICAL - Host Unreachable (%s)\n"
 msgstr ""
 
 #: plugins/check_ping.c:537
 #, c-format
+msgid "CRITICAL - Bogus ICMP: Port Unreachable (%s)\n"
+msgstr ""
+
+#: plugins/check_ping.c:539
+#, c-format
+msgid "CRITICAL - Bogus ICMP: Protocol Unreachable (%s)\n"
+msgstr ""
+
+#: plugins/check_ping.c:541
+#, c-format
+msgid "CRITICAL - Network Prohibited (%s)\n"
+msgstr ""
+
+#: plugins/check_ping.c:543
+#, c-format
+msgid "CRITICAL - Host Prohibited (%s)\n"
+msgstr ""
+
+#: plugins/check_ping.c:545
+#, c-format
+msgid "CRITICAL - Packet Filtered (%s)\n"
+msgstr ""
+
+#: plugins/check_ping.c:547
+#, c-format
+msgid "CRITICAL - Host not found (%s)\n"
+msgstr ""
+
+#: plugins/check_ping.c:549
+#, c-format
+msgid "CRITICAL - Time to live exceeded (%s)\n"
+msgstr ""
+
+#: plugins/check_ping.c:551
+#, c-format
 msgid "CRITICAL - Destination Unreachable (%s)\n"
 msgstr ""
 
-#: plugins/check_ping.c:544
+#: plugins/check_ping.c:558
 msgid "Unable to realloc warn_text\n"
 msgstr ""
 
-#: plugins/check_ping.c:561
+#: plugins/check_ping.c:575
 #, c-format
 msgid "Use ping to check connection statistics for a remote host."
 msgstr ""
 
-#: plugins/check_ping.c:573
+#: plugins/check_ping.c:587
 msgid "host to ping"
 msgstr ""
 
-#: plugins/check_ping.c:579
+#: plugins/check_ping.c:593
 msgid "number of ICMP ECHO packets to send"
 msgstr ""
 
-#: plugins/check_ping.c:580
+#: plugins/check_ping.c:594
 #, c-format
 msgid "(Default: %d)\n"
 msgstr ""
 
-#: plugins/check_ping.c:582
+#: plugins/check_ping.c:596
 msgid "show HTML in the plugin output (obsoleted by urlize)"
 msgstr ""
 
-#: plugins/check_ping.c:587
+#: plugins/check_ping.c:601
 msgid "THRESHOLD is <rta>,<pl>% where <rta> is the round trip average travel"
 msgstr ""
 
-#: plugins/check_ping.c:588
+#: plugins/check_ping.c:602
 msgid "time (ms) which triggers a WARNING or CRITICAL state, and <pl> is the"
 msgstr ""
 
-#: plugins/check_ping.c:589
+#: plugins/check_ping.c:603
 msgid "percentage of packet loss to trigger an alarm state."
 msgstr ""
 
-#: plugins/check_ping.c:592
+#: plugins/check_ping.c:606
 msgid ""
 "This plugin uses the ping command to probe the specified host for packet loss"
 msgstr ""
 
-#: plugins/check_ping.c:593
+#: plugins/check_ping.c:607
 msgid ""
 "(percentage) and round trip average (milliseconds). It can produce HTML "
 "output"
 msgstr ""
 
-#: plugins/check_ping.c:594
+#: plugins/check_ping.c:608
 msgid ""
 "linking to a traceroute CGI contributed by Ian Cass. The CGI can be found in"
 msgstr ""
 
-#: plugins/check_ping.c:595
+#: plugins/check_ping.c:609
 msgid "the contrib area of the downloads section at http://www.nagios.org/"
 msgstr ""
 
-#: plugins/check_procs.c:193
+#: plugins/check_procs.c:197
 #, c-format
 msgid "CMD: %s\n"
 msgstr ""
 
-#: plugins/check_procs.c:198
+#: plugins/check_procs.c:202
 msgid "System call sent warnings to stderr"
 msgstr ""
 
-#: plugins/check_procs.c:326
+#: plugins/check_procs.c:349
 #, c-format
 msgid "Not parseable: %s"
 msgstr ""
 
-#: plugins/check_procs.c:331
+#: plugins/check_procs.c:354
 #, c-format
 msgid "Unable to read output\n"
 msgstr ""
 
-#: plugins/check_procs.c:348
+#: plugins/check_procs.c:371
 #, c-format
 msgid "%d warn out of "
 msgstr ""
 
-#: plugins/check_procs.c:353
+#: plugins/check_procs.c:376
 #, c-format
 msgid "%d crit, %d warn out of "
 msgstr ""
 
-#: plugins/check_procs.c:359
+#: plugins/check_procs.c:382
 #, c-format
 msgid " with %s"
 msgstr ""
 
-#: plugins/check_procs.c:453
+#: plugins/check_procs.c:477
 msgid "Parent Process ID must be an integer!"
 msgstr ""
 
-#: plugins/check_procs.c:459 plugins/check_procs.c:586
+#: plugins/check_procs.c:483 plugins/check_procs.c:627
 #, c-format
 msgid "%s%sSTATE = %s"
 msgstr ""
 
-#: plugins/check_procs.c:468
+#: plugins/check_procs.c:492
 msgid "UID was not found"
 msgstr ""
 
-#: plugins/check_procs.c:474
+#: plugins/check_procs.c:498
 msgid "User name was not found"
 msgstr ""
 
-#: plugins/check_procs.c:489
+#: plugins/check_procs.c:513
 #, c-format
 msgid "%s%scommand name '%s'"
 msgstr ""
 
-#: plugins/check_procs.c:524
+#: plugins/check_procs.c:522
+#, c-format
+msgid "%s%sexclude progs '%s'"
+msgstr ""
+
+#: plugins/check_procs.c:565
 msgid "RSS must be an integer!"
 msgstr ""
 
-#: plugins/check_procs.c:531
+#: plugins/check_procs.c:572
 msgid "VSZ must be an integer!"
 msgstr ""
 
-#: plugins/check_procs.c:539
+#: plugins/check_procs.c:580
 msgid "PCPU must be a float!"
 msgstr ""
 
-#: plugins/check_procs.c:563
+#: plugins/check_procs.c:604
 msgid "Metric must be one of PROCS, VSZ, RSS, CPU, ELAPSED!"
 msgstr ""
 
-#: plugins/check_procs.c:694
+#: plugins/check_procs.c:735
 msgid ""
 "Checks all processes and generates WARNING or CRITICAL states if the "
 "specified"
 msgstr ""
 
-#: plugins/check_procs.c:695
+#: plugins/check_procs.c:736
 msgid ""
 "metric is outside the required threshold ranges. The metric defaults to "
 "number"
 msgstr ""
 
-#: plugins/check_procs.c:696
+#: plugins/check_procs.c:737
 msgid ""
 "of processes.  Search filters can be applied to limit the processes to check."
 msgstr ""
 
-#: plugins/check_procs.c:705
+#: plugins/check_procs.c:746
 msgid "Generate warning state if metric is outside this range"
 msgstr ""
 
-#: plugins/check_procs.c:707
+#: plugins/check_procs.c:748
 msgid "Generate critical state if metric is outside this range"
 msgstr ""
 
-#: plugins/check_procs.c:709
+#: plugins/check_procs.c:750
 msgid "Check thresholds against metric. Valid types:"
 msgstr ""
 
-#: plugins/check_procs.c:710
+#: plugins/check_procs.c:751
 msgid "PROCS   - number of processes (default)"
 msgstr ""
 
-#: plugins/check_procs.c:711
+#: plugins/check_procs.c:752
 msgid "VSZ     - virtual memory size"
 msgstr ""
 
-#: plugins/check_procs.c:712
+#: plugins/check_procs.c:753
 msgid "RSS     - resident set memory size"
 msgstr ""
 
-#: plugins/check_procs.c:713
+#: plugins/check_procs.c:754
 msgid "CPU     - percentage CPU"
 msgstr ""
 
-#: plugins/check_procs.c:716
+#: plugins/check_procs.c:757
 msgid "ELAPSED - time elapsed in seconds"
 msgstr ""
 
-#: plugins/check_procs.c:721
+#: plugins/check_procs.c:762
 msgid "Extra information. Up to 3 verbosity levels"
 msgstr ""
 
-#: plugins/check_procs.c:724
+#: plugins/check_procs.c:765
 msgid "Filter own process the traditional way by PID instead of /proc/pid/exe"
 msgstr ""
 
-#: plugins/check_procs.c:729
+#: plugins/check_procs.c:770
 msgid "Only scan for processes that have, in the output of `ps`, one or"
 msgstr ""
 
-#: plugins/check_procs.c:730
+#: plugins/check_procs.c:771
 msgid "more of the status flags you specify (for example R, Z, S, RS,"
 msgstr ""
 
-#: plugins/check_procs.c:731
+#: plugins/check_procs.c:772
 msgid "RSZDT, plus others based on the output of your 'ps' command)."
 msgstr ""
 
-#: plugins/check_procs.c:733
+#: plugins/check_procs.c:774
 msgid "Only scan for children of the parent process ID indicated."
 msgstr ""
 
-#: plugins/check_procs.c:735
+#: plugins/check_procs.c:776
 msgid "Only scan for processes with VSZ higher than indicated."
 msgstr ""
 
-#: plugins/check_procs.c:737
+#: plugins/check_procs.c:778
 msgid "Only scan for processes with RSS higher than indicated."
 msgstr ""
 
-#: plugins/check_procs.c:739
+#: plugins/check_procs.c:780
 msgid "Only scan for processes with PCPU higher than indicated."
 msgstr ""
 
-#: plugins/check_procs.c:741
+#: plugins/check_procs.c:782
 msgid "Only scan for processes with user name or ID indicated."
 msgstr ""
 
-#: plugins/check_procs.c:743
+#: plugins/check_procs.c:784
 msgid "Only scan for processes with args that contain STRING."
 msgstr ""
 
-#: plugins/check_procs.c:745
+#: plugins/check_procs.c:786
 msgid "Only scan for processes with args that contain the regex STRING."
 msgstr ""
 
-#: plugins/check_procs.c:747
+#: plugins/check_procs.c:788
 msgid "Only scan for exact matches of COMMAND (without path)."
 msgstr ""
 
-#: plugins/check_procs.c:749
+#: plugins/check_procs.c:790
+msgid "Exclude processes which match this comma separated list"
+msgstr ""
+
+#: plugins/check_procs.c:792
 msgid "Only scan for non kernel threads (works on Linux only)."
 msgstr ""
 
-#: plugins/check_procs.c:751
+#: plugins/check_procs.c:794
 #, c-format
 msgid ""
 "\n"
@@ -3963,7 +4212,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: plugins/check_procs.c:756
+#: plugins/check_procs.c:799
 #, c-format
 msgid ""
 "This plugin checks the number of currently running processes and\n"
@@ -3974,163 +4223,175 @@ msgid ""
 "\n"
 msgstr ""
 
-#: plugins/check_procs.c:765
+#: plugins/check_procs.c:808
 msgid "Warning if not two processes with command name portsentry."
 msgstr ""
 
-#: plugins/check_procs.c:766
+#: plugins/check_procs.c:809
 msgid "Critical if < 2 or > 1024 processes"
 msgstr ""
 
-#: plugins/check_procs.c:768
+#: plugins/check_procs.c:811
+msgid "Critical if not at least 1 process with command sshd"
+msgstr ""
+
+#: plugins/check_procs.c:813
+msgid "Warning if > 1024 processes with command name sshd."
+msgstr ""
+
+#: plugins/check_procs.c:814
+msgid "Critical if < 1 processes with command name sshd."
+msgstr ""
+
+#: plugins/check_procs.c:816
 msgid "Warning alert if > 10 processes with command arguments containing"
 msgstr ""
 
-#: plugins/check_procs.c:769
+#: plugins/check_procs.c:817
 msgid "'/usr/local/bin/perl' and owned by root"
 msgstr ""
 
-#: plugins/check_procs.c:771
+#: plugins/check_procs.c:819
 msgid "Alert if VSZ of any processes over 50K or 100K"
 msgstr ""
 
-#: plugins/check_procs.c:773
+#: plugins/check_procs.c:821
+msgid "Alert if CPU of any processes over 10% or 20%"
+msgstr ""
+
+#: plugins/check_radius.c:181
+msgid "Config file error\n"
+msgstr ""
+
+#: plugins/check_radius.c:190
+msgid "Out of Memory?\n"
+msgstr ""
+
+#: plugins/check_radius.c:194
+msgid "Invalid NAS-Identifier\n"
+msgstr ""
+
+#: plugins/check_radius.c:199 plugins/check_smtp.c:155
 #, c-format
-msgid "Alert if CPU of any processes over 10%% or 20%%"
+msgid "gethostname() failed!\n"
 msgstr ""
 
-#: plugins/check_radius.c:165
-msgid "Config file error"
+#: plugins/check_radius.c:203 plugins/check_radius.c:206
+msgid "Invalid NAS-IP-Address\n"
 msgstr ""
 
-#: plugins/check_radius.c:174
-msgid "Out of Memory?"
+#: plugins/check_radius.c:217
+msgid "Timeout\n"
 msgstr ""
 
-#: plugins/check_radius.c:178
-msgid "Invalid NAS-Identifier"
+#: plugins/check_radius.c:219
+msgid "Auth Error\n"
 msgstr ""
 
-#: plugins/check_radius.c:183 plugins/check_radius.c:185
-#: plugins/check_radius.c:191
-msgid "Invalid NAS-IP-Address"
+#: plugins/check_radius.c:221
+msgid "Auth Failed\n"
 msgstr ""
 
-#: plugins/check_radius.c:188
-msgid "Can't find local IP for NAS-IP-Address"
+#: plugins/check_radius.c:223
+msgid "Bad Response\n"
 msgstr ""
 
-#: plugins/check_radius.c:202
-msgid "Timeout"
+#: plugins/check_radius.c:227
+msgid "Auth OK\n"
 msgstr ""
 
-#: plugins/check_radius.c:204
-msgid "Auth Error"
-msgstr ""
-
-#: plugins/check_radius.c:206
-msgid "Auth Failed"
-msgstr ""
-
-#: plugins/check_radius.c:208
-msgid "Bad Response"
-msgstr ""
-
-#: plugins/check_radius.c:212
-msgid "Auth OK"
-msgstr ""
-
-#: plugins/check_radius.c:213
+#: plugins/check_radius.c:228
 #, c-format
 msgid "Unexpected result code %d"
 msgstr ""
 
-#: plugins/check_radius.c:302
+#: plugins/check_radius.c:317
 msgid "Number of retries must be a positive integer"
 msgstr ""
 
-#: plugins/check_radius.c:316
+#: plugins/check_radius.c:331
 msgid "User not specified"
 msgstr ""
 
-#: plugins/check_radius.c:318
+#: plugins/check_radius.c:333
 msgid "Password not specified"
 msgstr ""
 
-#: plugins/check_radius.c:320
+#: plugins/check_radius.c:335
 msgid "Configuration file not specified"
 msgstr ""
 
-#: plugins/check_radius.c:338
+#: plugins/check_radius.c:353
 msgid "Tests to see if a RADIUS server is accepting connections."
 msgstr ""
 
-#: plugins/check_radius.c:350
+#: plugins/check_radius.c:365
 msgid "The user to authenticate"
 msgstr ""
 
-#: plugins/check_radius.c:352
+#: plugins/check_radius.c:367
 msgid "Password for authentication (SECURITY RISK)"
 msgstr ""
 
-#: plugins/check_radius.c:354
+#: plugins/check_radius.c:369
 msgid "NAS identifier"
 msgstr ""
 
-#: plugins/check_radius.c:356
+#: plugins/check_radius.c:371
 msgid "NAS IP Address"
 msgstr ""
 
-#: plugins/check_radius.c:358
+#: plugins/check_radius.c:373
 msgid "Configuration file"
 msgstr ""
 
-#: plugins/check_radius.c:360
+#: plugins/check_radius.c:375
 msgid "Response string to expect from the server"
 msgstr ""
 
-#: plugins/check_radius.c:362
+#: plugins/check_radius.c:377
 msgid "Number of times to retry a failed connection"
 msgstr ""
 
-#: plugins/check_radius.c:367
+#: plugins/check_radius.c:382
 msgid ""
 "This plugin tests a RADIUS server to see if it is accepting connections."
 msgstr ""
 
-#: plugins/check_radius.c:368
+#: plugins/check_radius.c:383
 msgid ""
 "The server to test must be specified in the invocation, as well as a user"
 msgstr ""
 
-#: plugins/check_radius.c:369
+#: plugins/check_radius.c:384
 msgid ""
 "name and password. A configuration file may also be present. The format of"
 msgstr ""
 
-#: plugins/check_radius.c:370
+#: plugins/check_radius.c:385
 msgid ""
 "the configuration file is described in the radiusclient library sources."
 msgstr ""
 
-#: plugins/check_radius.c:371
+#: plugins/check_radius.c:386
 msgid "The password option presents a substantial security issue because the"
 msgstr ""
 
-#: plugins/check_radius.c:372
+#: plugins/check_radius.c:387
 msgid ""
 "password can possibly be determined by careful watching of the command line"
 msgstr ""
 
-#: plugins/check_radius.c:373
-msgid "in a process listing. This risk is exacerbated because the monitor will"
+#: plugins/check_radius.c:388
+msgid "in a process listing. This risk is exacerbated because the plugin will"
 msgstr ""
 
-#: plugins/check_radius.c:374
-msgid "run the plugin at regular predictable intervals. Please be sure that"
+#: plugins/check_radius.c:389
+msgid ""
+"typically be executed at regular predictable intervals. Please be sure that"
 msgstr ""
 
-#: plugins/check_radius.c:375
+#: plugins/check_radius.c:390
 msgid "the password used does not allow access to sensitive system resources."
 msgstr ""
 
@@ -4144,790 +4405,884 @@ msgstr ""
 msgid "No data received from %s\n"
 msgstr ""
 
-#: plugins/check_real.c:118 plugins/check_real.c:191
+#: plugins/check_real.c:118 plugins/check_real.c:192
 msgid "Invalid REAL response received from host"
 msgstr ""
 
-#: plugins/check_real.c:120 plugins/check_real.c:193
+#: plugins/check_real.c:120 plugins/check_real.c:194
 #, c-format
 msgid "Invalid REAL response received from host on port %d\n"
 msgstr ""
 
-#: plugins/check_real.c:184 plugins/check_tcp.c:311
+#: plugins/check_real.c:185 plugins/check_tcp.c:315
 #, c-format
 msgid "No data received from host\n"
 msgstr ""
 
-#: plugins/check_real.c:247
+#: plugins/check_real.c:248
 #, c-format
 msgid "REAL %s - %d second response time\n"
 msgstr ""
 
-#: plugins/check_real.c:336 plugins/check_ups.c:536
+#: plugins/check_real.c:337 plugins/check_ups.c:539
 msgid "Warning time must be a positive integer"
 msgstr ""
 
-#: plugins/check_real.c:345 plugins/check_ups.c:527
+#: plugins/check_real.c:346 plugins/check_ups.c:530
 msgid "Critical time must be a positive integer"
 msgstr ""
 
-#: plugins/check_real.c:381
+#: plugins/check_real.c:382
 msgid "You must provide a server to check"
 msgstr ""
 
-#: plugins/check_real.c:413
+#: plugins/check_real.c:414
 msgid "This plugin tests the REAL service on the specified host."
 msgstr ""
 
-#: plugins/check_real.c:425
+#: plugins/check_real.c:426
 msgid "Connect to this url"
 msgstr ""
 
-#: plugins/check_real.c:427
+#: plugins/check_real.c:428
 #, c-format
 msgid "String to expect in first line of server response (default: %s)\n"
 msgstr ""
 
-#: plugins/check_real.c:437
+#: plugins/check_real.c:438
 msgid "This plugin will attempt to open an RTSP connection with the host."
 msgstr ""
 
-#: plugins/check_real.c:438 plugins/check_smtp.c:830
+#: plugins/check_real.c:439 plugins/check_smtp.c:862
 msgid "Successful connects return STATE_OK, refusals and timeouts return"
-msgstr ""
-
-#: plugins/check_real.c:439
-msgid ""
-"STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful connects,"
 msgstr ""
 
 #: plugins/check_real.c:440
 msgid ""
-"but incorrect response messages from the host result in STATE_WARNING return"
+"STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful connects,"
 msgstr ""
 
 #: plugins/check_real.c:441
+msgid ""
+"but incorrect response messages from the host result in STATE_WARNING return"
+msgstr ""
+
+#: plugins/check_real.c:442
 msgid "values."
 msgstr ""
 
-#: plugins/check_smtp.c:150 plugins/check_swap.c:265 plugins/check_swap.c:271
+#: plugins/check_smtp.c:151 plugins/check_swap.c:283 plugins/check_swap.c:289
 #, c-format
 msgid "malloc() failed!\n"
 msgstr ""
 
-#: plugins/check_smtp.c:154
-#, c-format
-msgid "gethostname() failed!\n"
-msgstr ""
-
-#: plugins/check_smtp.c:189 plugins/check_smtp.c:213
+#: plugins/check_smtp.c:199 plugins/check_smtp.c:211
 #, c-format
 msgid "recv() failed\n"
 msgstr ""
 
-#: plugins/check_smtp.c:200
-#, c-format
-msgid "Invalid SMTP response received from host: %s\n"
-msgstr ""
-
-#: plugins/check_smtp.c:202
-#, c-format
-msgid "Invalid SMTP response received from host on port %d: %s\n"
-msgstr ""
-
-#: plugins/check_smtp.c:223
+#: plugins/check_smtp.c:221
 #, c-format
 msgid "WARNING - TLS not supported by server\n"
 msgstr ""
 
-#: plugins/check_smtp.c:235
+#: plugins/check_smtp.c:233
 #, c-format
 msgid "Server does not support STARTTLS\n"
 msgstr ""
 
-#: plugins/check_smtp.c:241
+#: plugins/check_smtp.c:239
 #, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr ""
 
-#: plugins/check_smtp.c:261
+#: plugins/check_smtp.c:259
 msgid "SMTP UNKNOWN - Cannot send EHLO command via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:266
+#: plugins/check_smtp.c:264
 #, c-format
 msgid "sent %s"
 msgstr ""
 
-#: plugins/check_smtp.c:268
+#: plugins/check_smtp.c:266
 msgid "SMTP UNKNOWN - Cannot read EHLO response via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:303 plugins/check_snmp.c:806
+#: plugins/check_smtp.c:296
+#, c-format
+msgid "Invalid SMTP response received from host: %s\n"
+msgstr ""
+
+#: plugins/check_smtp.c:298
+#, c-format
+msgid "Invalid SMTP response received from host on port %d: %s\n"
+msgstr ""
+
+#: plugins/check_smtp.c:321 plugins/check_snmp.c:865
 #, c-format
 msgid "Could Not Compile Regular Expression"
 msgstr ""
 
-#: plugins/check_smtp.c:312
+#: plugins/check_smtp.c:330
 #, c-format
 msgid "SMTP %s - Invalid response '%s' to command '%s'\n"
 msgstr ""
 
-#: plugins/check_smtp.c:316 plugins/check_snmp.c:511
+#: plugins/check_smtp.c:334 plugins/check_snmp.c:540
 #, c-format
 msgid "Execute Error: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:330
+#: plugins/check_smtp.c:348
 msgid "no authuser specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:335
+#: plugins/check_smtp.c:353
 msgid "no authpass specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:342 plugins/check_smtp.c:363 plugins/check_smtp.c:383
-#: plugins/check_smtp.c:688
+#: plugins/check_smtp.c:360 plugins/check_smtp.c:381 plugins/check_smtp.c:401
+#: plugins/check_smtp.c:714
 #, c-format
 msgid "sent %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:345
+#: plugins/check_smtp.c:363
 msgid "recv() failed after AUTH LOGIN, "
 msgstr ""
 
-#: plugins/check_smtp.c:350 plugins/check_smtp.c:371 plugins/check_smtp.c:391
-#: plugins/check_smtp.c:699
+#: plugins/check_smtp.c:368 plugins/check_smtp.c:389 plugins/check_smtp.c:409
+#: plugins/check_smtp.c:725
 #, c-format
 msgid "received %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:354
+#: plugins/check_smtp.c:372
 msgid "invalid response received after AUTH LOGIN, "
 msgstr ""
 
-#: plugins/check_smtp.c:367
+#: plugins/check_smtp.c:385
 msgid "recv() failed after sending authuser, "
 msgstr ""
 
-#: plugins/check_smtp.c:375
+#: plugins/check_smtp.c:393
 msgid "invalid response received after authuser, "
 msgstr ""
 
-#: plugins/check_smtp.c:387
+#: plugins/check_smtp.c:405
 msgid "recv() failed after sending authpass, "
 msgstr ""
 
-#: plugins/check_smtp.c:395
+#: plugins/check_smtp.c:413
 msgid "invalid response received after authpass, "
 msgstr ""
 
-#: plugins/check_smtp.c:402
+#: plugins/check_smtp.c:420
 msgid "only authtype LOGIN is supported, "
 msgstr ""
 
-#: plugins/check_smtp.c:426
+#: plugins/check_smtp.c:444
 #, c-format
 msgid "SMTP %s - %s%.3f sec. response time%s%s|%s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:536 plugins/check_smtp.c:548
+#: plugins/check_smtp.c:556 plugins/check_smtp.c:568
 #, c-format
 msgid "Could not realloc() units [%d]\n"
 msgstr ""
 
-#: plugins/check_smtp.c:556
+#: plugins/check_smtp.c:576
 msgid "Critical time must be a positive"
 msgstr ""
 
-#: plugins/check_smtp.c:564
+#: plugins/check_smtp.c:584
 msgid "Warning time must be a positive"
 msgstr ""
 
-#: plugins/check_smtp.c:611
+#: plugins/check_smtp.c:627
 msgid "SSL support not available - install OpenSSL and recompile"
 msgstr ""
 
-#: plugins/check_smtp.c:679 plugins/check_smtp.c:684
+#: plugins/check_smtp.c:705 plugins/check_smtp.c:710
 #, c-format
 msgid "Connection closed by server before sending QUIT command\n"
 msgstr ""
 
-#: plugins/check_smtp.c:694
+#: plugins/check_smtp.c:720
 #, c-format
 msgid "recv() failed after QUIT."
 msgstr ""
 
-#: plugins/check_smtp.c:696
+#: plugins/check_smtp.c:722
 #, c-format
 msgid "Connection reset by peer."
 msgstr ""
 
-#: plugins/check_smtp.c:784
+#: plugins/check_smtp.c:812
 msgid "This plugin will attempt to open an SMTP connection with the host."
 msgstr ""
 
-#: plugins/check_smtp.c:798
+#: plugins/check_smtp.c:826
 #, c-format
 msgid "    String to expect in first line of server response (default: '%s')\n"
 msgstr ""
 
-#: plugins/check_smtp.c:800
+#: plugins/check_smtp.c:828
 msgid "SMTP command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:802
+#: plugins/check_smtp.c:830
 msgid "Expected response to command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:804
+#: plugins/check_smtp.c:832
 msgid "FROM-address to include in MAIL command, required by Exchange 2000"
 msgstr ""
 
-#: plugins/check_smtp.c:806
+#: plugins/check_smtp.c:834
 msgid "FQDN used for HELO"
 msgstr ""
 
-#: plugins/check_smtp.c:809 plugins/check_tcp.c:665
+#: plugins/check_smtp.c:836
+msgid "Use PROXY protocol prefix for the connection."
+msgstr ""
+
+#: plugins/check_smtp.c:839 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."
 msgstr ""
 
-#: plugins/check_smtp.c:811
+#: plugins/check_smtp.c:841
 msgid "Use STARTTLS for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:815
+#: plugins/check_smtp.c:845
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"
 msgstr ""
 
-#: plugins/check_smtp.c:817
+#: plugins/check_smtp.c:847
 msgid "SMTP AUTH username"
 msgstr ""
 
-#: plugins/check_smtp.c:819
+#: plugins/check_smtp.c:849
 msgid "SMTP AUTH password"
 msgstr ""
 
-#: plugins/check_smtp.c:821
+#: plugins/check_smtp.c:851
+msgid "Send LHLO instead of HELO/EHLO"
+msgstr ""
+
+#: plugins/check_smtp.c:853
 msgid "Ignore failure when sending QUIT command to server"
 msgstr ""
 
-#: plugins/check_smtp.c:831
+#: plugins/check_smtp.c:863
 msgid "STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful"
 msgstr ""
 
-#: plugins/check_smtp.c:832
+#: plugins/check_smtp.c:864
 msgid "connects, but incorrect response messages from the host result in"
 msgstr ""
 
-#: plugins/check_smtp.c:833
+#: plugins/check_smtp.c:865
 msgid "STATE_WARNING return values."
 msgstr ""
 
-#: plugins/check_snmp.c:169 plugins/check_snmp.c:582
+#: plugins/check_snmp.c:177 plugins/check_snmp.c:626
 msgid "Cannot malloc"
 msgstr ""
 
-#: plugins/check_snmp.c:356
+#: plugins/check_snmp.c:368
 #, c-format
 msgid "External command error: %s\n"
 msgstr ""
 
-#: plugins/check_snmp.c:361
+#: plugins/check_snmp.c:373
 #, c-format
 msgid "External command error with no output (return code: %d)\n"
 msgstr ""
 
-#: plugins/check_snmp.c:464
+#: plugins/check_snmp.c:486 plugins/check_snmp.c:488 plugins/check_snmp.c:490
+#: plugins/check_snmp.c:492
 #, c-format
 msgid "No valid data returned (%s)\n"
 msgstr ""
 
-#: plugins/check_snmp.c:475
+#: plugins/check_snmp.c:504
 msgid "Time duration between plugin calls is invalid"
 msgstr ""
 
-#: plugins/check_snmp.c:588
+#: plugins/check_snmp.c:632
 msgid "Cannot asprintf()"
 msgstr ""
 
-#: plugins/check_snmp.c:594
+#: plugins/check_snmp.c:638
 msgid "Cannot realloc()"
 msgstr ""
 
-#: plugins/check_snmp.c:610
+#: plugins/check_snmp.c:654
 msgid "No previous data to calculate rate - assume okay"
 msgstr ""
 
-#: plugins/check_snmp.c:751
+#: plugins/check_snmp.c:804
 msgid "Retries interval must be a positive integer"
 msgstr ""
 
-#: plugins/check_snmp.c:831
+#: plugins/check_snmp.c:841
+msgid "Exit status must be a positive integer"
+msgstr ""
+
+#: plugins/check_snmp.c:890
 #, c-format
 msgid "Could not reallocate labels[%d]"
 msgstr ""
 
-#: plugins/check_snmp.c:844
+#: plugins/check_snmp.c:903
 msgid "Could not reallocate labels\n"
 msgstr ""
 
-#: plugins/check_snmp.c:860
+#: plugins/check_snmp.c:919
 #, c-format
 msgid "Could not reallocate units [%d]\n"
 msgstr ""
 
-#: plugins/check_snmp.c:872
+#: plugins/check_snmp.c:931
 msgid "Could not realloc() units\n"
 msgstr ""
 
-#: plugins/check_snmp.c:889
+#: plugins/check_snmp.c:948
 msgid "Rate multiplier must be a positive integer"
 msgstr ""
 
-#: plugins/check_snmp.c:947
+#: plugins/check_snmp.c:1023
 msgid "No host specified\n"
 msgstr ""
 
-#: plugins/check_snmp.c:951
+#: plugins/check_snmp.c:1027
 msgid "No OIDs specified\n"
 msgstr ""
 
-#: plugins/check_snmp.c:973
-msgid "Invalid seclevel"
-msgstr ""
-
-#: plugins/check_snmp.c:980 plugins/check_snmp.c:983 plugins/check_snmp.c:1001
+#: plugins/check_snmp.c:1050 plugins/check_snmp.c:1068
+#: plugins/check_snmp.c:1086
 #, c-format
 msgid "Required parameter: %s\n"
 msgstr ""
 
-#: plugins/check_snmp.c:1022
-msgid "Invalid SNMP version"
-msgstr ""
-
-#: plugins/check_snmp.c:1039
-msgid "Unbalanced quotes\n"
-msgstr ""
-
-#: plugins/check_snmp.c:1088
-msgid "Check status of remote machines and obtain system information via SNMP"
-msgstr ""
-
-#: plugins/check_snmp.c:1101
-msgid "Use SNMP GETNEXT instead of SNMP GET"
-msgstr ""
-
-#: plugins/check_snmp.c:1103
-msgid "SNMP protocol version"
-msgstr ""
-
-#: plugins/check_snmp.c:1105
-msgid "SNMPv3 securityLevel"
+#: plugins/check_snmp.c:1061
+msgid "Invalid seclevel"
 msgstr ""
 
 #: plugins/check_snmp.c:1107
-msgid "SNMPv3 auth proto"
-msgstr ""
-
-#: plugins/check_snmp.c:1109
-msgid "SNMPv3 priv proto (default DES)"
-msgstr ""
-
-#: plugins/check_snmp.c:1113
-msgid "Optional community string for SNMP communication"
-msgstr ""
-
-#: plugins/check_snmp.c:1114
-msgid "default is"
-msgstr ""
-
-#: plugins/check_snmp.c:1116
-msgid "SNMPv3 username"
-msgstr ""
-
-#: plugins/check_snmp.c:1118
-msgid "SNMPv3 authentication password"
-msgstr ""
-
-#: plugins/check_snmp.c:1120
-msgid "SNMPv3 privacy password"
+msgid "Invalid SNMP version"
 msgstr ""
 
 #: plugins/check_snmp.c:1124
+msgid "Unbalanced quotes\n"
+msgstr ""
+
+#: plugins/check_snmp.c:1182
+#, c-format
+msgid "multiplier set (%.1f), but input is not a number: %s"
+msgstr ""
+
+#: plugins/check_snmp.c:1211
+msgid "Check status of remote machines and obtain system information via SNMP"
+msgstr ""
+
+#: plugins/check_snmp.c:1225
+msgid "Use SNMP GETNEXT instead of SNMP GET"
+msgstr ""
+
+#: plugins/check_snmp.c:1227
+msgid "SNMP protocol version"
+msgstr ""
+
+#: plugins/check_snmp.c:1229
+msgid "SNMPv3 context"
+msgstr ""
+
+#: plugins/check_snmp.c:1231
+msgid "SNMPv3 securityLevel"
+msgstr ""
+
+#: plugins/check_snmp.c:1233
+msgid "SNMPv3 auth proto"
+msgstr ""
+
+#: plugins/check_snmp.c:1235
+msgid "SNMPv3 priv proto (default DES)"
+msgstr ""
+
+#: plugins/check_snmp.c:1239
+msgid "Optional community string for SNMP communication"
+msgstr ""
+
+#: plugins/check_snmp.c:1240
+msgid "default is"
+msgstr ""
+
+#: plugins/check_snmp.c:1242
+msgid "SNMPv3 username"
+msgstr ""
+
+#: plugins/check_snmp.c:1244
+msgid "SNMPv3 authentication password"
+msgstr ""
+
+#: plugins/check_snmp.c:1246
+msgid "SNMPv3 privacy password"
+msgstr ""
+
+#: plugins/check_snmp.c:1250
 msgid "Object identifier(s) or SNMP variables whose value you wish to query"
 msgstr ""
 
-#: plugins/check_snmp.c:1126
+#: plugins/check_snmp.c:1252
 msgid ""
 "List of MIBS to be loaded (default = none if using numeric OIDs or 'ALL'"
 msgstr ""
 
-#: plugins/check_snmp.c:1127
+#: plugins/check_snmp.c:1253
 msgid "for symbolic OIDs.)"
 msgstr ""
 
-#: plugins/check_snmp.c:1129
+#: plugins/check_snmp.c:1255
 msgid "Delimiter to use when parsing returned data. Default is"
 msgstr ""
 
-#: plugins/check_snmp.c:1130
+#: plugins/check_snmp.c:1256
 msgid "Any data on the right hand side of the delimiter is considered"
 msgstr ""
 
-#: plugins/check_snmp.c:1131
+#: plugins/check_snmp.c:1257
 msgid "to be the data that should be used in the evaluation."
 msgstr ""
 
-#: plugins/check_snmp.c:1135
+#: plugins/check_snmp.c:1259
+msgid "If the check returns a 0 length string or NULL value"
+msgstr ""
+
+#: plugins/check_snmp.c:1260
+msgid "This option allows you to choose what status you want it to exit"
+msgstr ""
+
+#: plugins/check_snmp.c:1261
+msgid "Excluding this option renders the default exit of 3(STATE_UNKNOWN)"
+msgstr ""
+
+#: plugins/check_snmp.c:1262
+msgid "0 = OK"
+msgstr ""
+
+#: plugins/check_snmp.c:1263
+msgid "1 = WARNING"
+msgstr ""
+
+#: plugins/check_snmp.c:1264
+msgid "2 = CRITICAL"
+msgstr ""
+
+#: plugins/check_snmp.c:1265
+msgid "3 = UNKNOWN"
+msgstr ""
+
+#: plugins/check_snmp.c:1269
 msgid "Warning threshold range(s)"
 msgstr ""
 
-#: plugins/check_snmp.c:1137
+#: plugins/check_snmp.c:1271
 msgid "Critical threshold range(s)"
 msgstr ""
 
-#: plugins/check_snmp.c:1139
+#: plugins/check_snmp.c:1273
 msgid "Enable rate calculation. See 'Rate Calculation' below"
 msgstr ""
 
-#: plugins/check_snmp.c:1141
+#: plugins/check_snmp.c:1275
 msgid ""
 "Converts rate per second. For example, set to 60 to convert to per minute"
 msgstr ""
 
-#: plugins/check_snmp.c:1143
+#: plugins/check_snmp.c:1277
 msgid "Add/subtract the specified OFFSET to numeric sensor data"
 msgstr ""
 
-#: plugins/check_snmp.c:1147
+#: plugins/check_snmp.c:1281
 msgid "Return OK state (for that OID) if STRING is an exact match"
 msgstr ""
 
-#: plugins/check_snmp.c:1149
+#: plugins/check_snmp.c:1283
 msgid ""
 "Return OK state (for that OID) if extended regular expression REGEX matches"
 msgstr ""
 
-#: plugins/check_snmp.c:1151
+#: plugins/check_snmp.c:1285
 msgid ""
 "Return OK state (for that OID) if case-insensitive extended REGEX matches"
 msgstr ""
 
-#: plugins/check_snmp.c:1153
+#: plugins/check_snmp.c:1287
 msgid "Invert search result (CRITICAL if found)"
 msgstr ""
 
-#: plugins/check_snmp.c:1157
+#: plugins/check_snmp.c:1291
 msgid "Prefix label for output from plugin"
 msgstr ""
 
-#: plugins/check_snmp.c:1159
+#: plugins/check_snmp.c:1293
 msgid "Units label(s) for output data (e.g., 'sec.')."
 msgstr ""
 
-#: plugins/check_snmp.c:1161
+#: plugins/check_snmp.c:1295
 msgid "Separates output on multiple OID requests"
 msgstr ""
 
-#: plugins/check_snmp.c:1165
-msgid "Number of retries to be used in the requests"
+#: plugins/check_snmp.c:1297
+msgid "Multiplies current value, 0 < n < 1 works as divider, defaults to 1"
 msgstr ""
 
-#: plugins/check_snmp.c:1168
+#: plugins/check_snmp.c:1299
+msgid "C-style format string for float values (see option -M)"
+msgstr ""
+
+#: plugins/check_snmp.c:1302
+msgid ""
+"NOTE the final timeout value is calculated using this formula: "
+"timeout_interval * retries + 5"
+msgstr ""
+
+#: plugins/check_snmp.c:1304
+msgid "Number of retries to be used in the requests, default: "
+msgstr ""
+
+#: plugins/check_snmp.c:1307
 msgid "Label performance data with OIDs instead of --label's"
 msgstr ""
 
-#: plugins/check_snmp.c:1173
+#: plugins/check_snmp.c:1312
 msgid ""
 "This plugin uses the 'snmpget' command included with the NET-SNMP package."
 msgstr ""
 
-#: plugins/check_snmp.c:1174
+#: plugins/check_snmp.c:1313
 msgid ""
 "if you don't have the package installed, you will need to download it from"
 msgstr ""
 
-#: plugins/check_snmp.c:1175
+#: plugins/check_snmp.c:1314
 msgid "http://net-snmp.sourceforge.net before you can use this plugin."
 msgstr ""
 
-#: plugins/check_snmp.c:1179
+#: plugins/check_snmp.c:1318
 msgid ""
 "- Multiple OIDs (and labels) may be indicated by a comma or space-delimited  "
 msgstr ""
 
-#: plugins/check_snmp.c:1180
+#: plugins/check_snmp.c:1319
 msgid "list (lists with internal spaces must be quoted)."
 msgstr ""
 
-#: plugins/check_snmp.c:1184
+#: plugins/check_snmp.c:1323
 msgid ""
 "- When checking multiple OIDs, separate ranges by commas like '-w "
 "1:10,1:,:20'"
 msgstr ""
 
-#: plugins/check_snmp.c:1185
+#: plugins/check_snmp.c:1324
 msgid "- Note that only one string and one regex may be checked at present"
 msgstr ""
 
-#: plugins/check_snmp.c:1186
+#: plugins/check_snmp.c:1325
 msgid ""
 "- All evaluation methods other than PR, STR, and SUBSTR expect that the value"
 msgstr ""
 
-#: plugins/check_snmp.c:1187
+#: plugins/check_snmp.c:1326
 msgid "returned from the SNMP query is an unsigned integer."
 msgstr ""
 
-#: plugins/check_snmp.c:1190
+#: plugins/check_snmp.c:1329
 msgid "Rate Calculation:"
 msgstr ""
 
-#: plugins/check_snmp.c:1191
+#: plugins/check_snmp.c:1330
 msgid "In many places, SNMP returns counters that are only meaningful when"
 msgstr ""
 
-#: plugins/check_snmp.c:1192
+#: plugins/check_snmp.c:1331
 msgid "calculating the counter difference since the last check. check_snmp"
 msgstr ""
 
-#: plugins/check_snmp.c:1193
+#: plugins/check_snmp.c:1332
 msgid "saves the last state information in a file so that the rate per second"
 msgstr ""
 
-#: plugins/check_snmp.c:1194
+#: plugins/check_snmp.c:1333
 msgid "can be calculated. Use the --rate option to save state information."
 msgstr ""
 
-#: plugins/check_snmp.c:1195
+#: plugins/check_snmp.c:1334
 msgid ""
 "On the first run, there will be no prior state - this will return with OK."
 msgstr ""
 
-#: plugins/check_snmp.c:1196
+#: plugins/check_snmp.c:1335
 msgid "The state is uniquely determined by the arguments to the plugin, so"
 msgstr ""
 
-#: plugins/check_snmp.c:1197
+#: plugins/check_snmp.c:1336
 msgid "changing the arguments will create a new state file."
 msgstr ""
 
-#: plugins/check_ssh.c:165
+#: plugins/check_ssh.c:170
 msgid "Port number must be a positive integer"
 msgstr ""
 
-#: plugins/check_ssh.c:232
+#: plugins/check_ssh.c:237
 #, c-format
 msgid "Server answer: %s"
 msgstr ""
 
-#: plugins/check_ssh.c:251
+#: plugins/check_ssh.c:256
 #, c-format
-msgid "SSH WARNING - %s (protocol %s) version mismatch, expected '%s'\n"
+msgid "SSH CRITICAL - %s (protocol %s) version mismatch, expected '%s'\n"
 msgstr ""
 
-#: plugins/check_ssh.c:260
+#: plugins/check_ssh.c:264
+#, c-format
+msgid ""
+"SSH CRITICAL - %s (protocol %s) protocol version mismatch, expected '%s'\n"
+msgstr ""
+
+#: plugins/check_ssh.c:273
 #, c-format
 msgid "SSH OK - %s (protocol %s) | %s\n"
 msgstr ""
 
-#: plugins/check_ssh.c:281
+#: plugins/check_ssh.c:294
 msgid "Try to connect to an SSH server at specified server and port"
 msgstr ""
 
-#: plugins/check_ssh.c:297
+#: plugins/check_ssh.c:310
 msgid ""
-"Warn if string doesn't match expected server version (ex: OpenSSH_3.9p1)"
+"Alert if string doesn't match expected server version (ex: OpenSSH_3.9p1)"
 msgstr ""
 
-#: plugins/check_swap.c:169
+#: plugins/check_ssh.c:313
+msgid "Alert if protocol doesn't match expected protocol version (ex: 2.0)"
+msgstr ""
+
+#: plugins/check_swap.c:187
 #, c-format
 msgid "Command: %s\n"
 msgstr ""
 
-#: plugins/check_swap.c:171
+#: plugins/check_swap.c:189
 #, c-format
 msgid "Format: %s\n"
 msgstr ""
 
-#: plugins/check_swap.c:207
+#: plugins/check_swap.c:225
 #, c-format
 msgid "total=%.0f, used=%.0f, free=%.0f\n"
 msgstr ""
 
-#: plugins/check_swap.c:221
+#: plugins/check_swap.c:239
 #, c-format
 msgid "total=%.0f, free=%.0f\n"
 msgstr ""
 
-#: plugins/check_swap.c:253
+#: plugins/check_swap.c:271
 msgid "Error getting swap devices\n"
 msgstr ""
 
-#: plugins/check_swap.c:256
+#: plugins/check_swap.c:274
 msgid "SWAP OK: No swap devices defined\n"
 msgstr ""
 
-#: plugins/check_swap.c:277 plugins/check_swap.c:319
+#: plugins/check_swap.c:295 plugins/check_swap.c:337
 msgid "swapctl failed: "
 msgstr ""
 
-#: plugins/check_swap.c:278 plugins/check_swap.c:320
+#: plugins/check_swap.c:296 plugins/check_swap.c:338
 msgid "Error in swapctl call\n"
 msgstr ""
 
-#: plugins/check_swap.c:357
+#: plugins/check_swap.c:376
 #, c-format
-msgid "SWAP %s - %d%% free (%d MB out of %d MB) %s|"
+msgid "SWAP %s - %d%% free (%dMB out of %dMB) %s|"
 msgstr ""
 
-#: plugins/check_swap.c:435
-msgid "Warning threshold must be integer or percentage!"
+#: plugins/check_swap.c:472
+msgid "Warning threshold percentage must be <= 100!"
 msgstr ""
 
-#: plugins/check_swap.c:453
-msgid "Critical threshold must be integer or percentage!"
+#: plugins/check_swap.c:482
+msgid "Warning threshold be positive integer or percentage!"
 msgstr ""
 
-#: plugins/check_swap.c:507
-msgid "Warning percentage should be more than critical percentage"
+#: plugins/check_swap.c:502
+msgid "Critical threshold percentage must be <= 100!"
 msgstr ""
 
-#: plugins/check_swap.c:511
-msgid "Warning free space should be more than critical free space"
+#: plugins/check_swap.c:512
+msgid "Critical threshold be positive integer or percentage!"
 msgstr ""
 
-#: plugins/check_swap.c:525
+#: plugins/check_swap.c:521
+msgid ""
+"no-swap result must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) "
+"or integer (0-3)."
+msgstr ""
+
+#: plugins/check_swap.c:558
+msgid "Warning should be more than critical"
+msgstr ""
+
+#: plugins/check_swap.c:572
 msgid "Check swap space on local machine."
 msgstr ""
 
-#: plugins/check_swap.c:535
+#: plugins/check_swap.c:582
 msgid ""
 "Exit with WARNING status if less than INTEGER bytes of swap space are free"
 msgstr ""
 
-#: plugins/check_swap.c:537
+#: plugins/check_swap.c:584
 msgid "Exit with WARNING status if less than PERCENT of swap space is free"
 msgstr ""
 
-#: plugins/check_swap.c:539
+#: plugins/check_swap.c:586
 msgid ""
 "Exit with CRITICAL status if less than INTEGER bytes of swap space are free"
 msgstr ""
 
-#: plugins/check_swap.c:541
+#: plugins/check_swap.c:588
 msgid "Exit with CRITICAL status if less than PERCENT of swap space is free"
 msgstr ""
 
-#: plugins/check_swap.c:543
+#: plugins/check_swap.c:590
 msgid "Conduct comparisons for all swap partitions, one by one"
 msgstr ""
 
-#: plugins/check_swap.c:548
+#: plugins/check_swap.c:592
+msgid ""
+"Resulting state when there is no swap regardless of thresholds. Default:"
+msgstr ""
+
+#: plugins/check_swap.c:597
+msgid ""
+"Both INTEGER and PERCENT thresholds can be specified, they are all checked."
+msgstr ""
+
+#: plugins/check_swap.c:598
 msgid "On AIX, if -a is specified, uses lsps -a, otherwise uses lsps -s."
 msgstr ""
 
-#: plugins/check_tcp.c:206
+#: plugins/check_tcp.c:210
 msgid "CRITICAL - Generic check_tcp called with unknown service\n"
 msgstr ""
 
-#: plugins/check_tcp.c:230
+#: plugins/check_tcp.c:234
 msgid "With UDP checks, a send/expect string must be specified."
 msgstr ""
 
-#: plugins/check_tcp.c:431
+#: plugins/check_tcp.c:445
 msgid "No arguments found"
 msgstr ""
 
-#: plugins/check_tcp.c:534
+#: plugins/check_tcp.c:548
 msgid "Maxbytes must be a positive integer"
 msgstr ""
 
-#: plugins/check_tcp.c:552
+#: plugins/check_tcp.c:566
 msgid "Refuse must be one of ok, warn, crit"
 msgstr ""
 
-#: plugins/check_tcp.c:562
+#: plugins/check_tcp.c:576
 msgid "Mismatch must be one of ok, warn, crit"
 msgstr ""
 
-#: plugins/check_tcp.c:568
+#: plugins/check_tcp.c:582
 msgid "Delay must be a positive integer"
 msgstr ""
 
-#: plugins/check_tcp.c:613
+#: plugins/check_tcp.c:637
 msgid "You must provide a server address"
 msgstr ""
 
-#: plugins/check_tcp.c:615
+#: plugins/check_tcp.c:639
 msgid "Invalid hostname, address or socket"
 msgstr ""
 
-#: plugins/check_tcp.c:629
+#: plugins/check_tcp.c:653
 #, c-format
 msgid ""
 "This plugin tests %s connections with the specified host (or unix socket).\n"
 "\n"
 msgstr ""
 
-#: plugins/check_tcp.c:642
+#: plugins/check_tcp.c:666
 msgid ""
-"Can use \\n, \\r, \\t or \\ in send or quit string. Must come before send or "
-"quit option"
+"Can use \\n, \\r, \\t or \\\\ in send or quit string. Must come before send "
+"or quit option"
 msgstr ""
 
-#: plugins/check_tcp.c:643
+#: plugins/check_tcp.c:667
 msgid "Default: nothing added to send, \\r\\n added to end of quit"
 msgstr ""
 
-#: plugins/check_tcp.c:645
+#: plugins/check_tcp.c:669
 msgid "String to send to the server"
 msgstr ""
 
-#: plugins/check_tcp.c:647
+#: plugins/check_tcp.c:671
 msgid "String to expect in server response"
 msgstr ""
 
-#: plugins/check_tcp.c:647
+#: plugins/check_tcp.c:671
 msgid "(may be repeated)"
 msgstr ""
 
-#: plugins/check_tcp.c:649
+#: plugins/check_tcp.c:673
 msgid "All expect strings need to occur in server response. Default is any"
 msgstr ""
 
-#: plugins/check_tcp.c:651
+#: plugins/check_tcp.c:675
 msgid "String to send server to initiate a clean close of the connection"
 msgstr ""
 
-#: plugins/check_tcp.c:653
+#: plugins/check_tcp.c:677
 msgid "Accept TCP refusals with states ok, warn, crit (default: crit)"
 msgstr ""
 
-#: plugins/check_tcp.c:655
+#: plugins/check_tcp.c:679
 msgid ""
 "Accept expected string mismatches with states ok, warn, crit (default: warn)"
 msgstr ""
 
-#: plugins/check_tcp.c:657
+#: plugins/check_tcp.c:681
 msgid "Hide output from TCP socket"
 msgstr ""
 
-#: plugins/check_tcp.c:659
+#: plugins/check_tcp.c:683
 msgid "Close connection once more than this number of bytes are received"
 msgstr ""
 
-#: plugins/check_tcp.c:661
+#: plugins/check_tcp.c:685
 msgid "Seconds to wait between sending string and polling for response"
 msgstr ""
 
-#: plugins/check_tcp.c:666
+#: plugins/check_tcp.c:690
 msgid "1st is #days for warning, 2nd is critical (if not specified - 0)."
 msgstr ""
 
-#: plugins/check_tcp.c:668
+#: plugins/check_tcp.c:692
 msgid "Use SSL for the connection."
+msgstr ""
+
+#: plugins/check_tcp.c:694
+msgid "SSL server_name"
 msgstr ""
 
 #: plugins/check_time.c:102
@@ -5043,358 +5398,403 @@ msgstr ""
 msgid "UPS does not support any available options\n"
 msgstr ""
 
-#: plugins/check_ups.c:348 plugins/check_ups.c:411
+#: plugins/check_ups.c:348 plugins/check_ups.c:414
 msgid "Invalid response received from host"
 msgstr ""
 
-#: plugins/check_ups.c:420
+#: plugins/check_ups.c:406
+msgid "UPS name to long for buffer"
+msgstr ""
+
+#: plugins/check_ups.c:423
 #, c-format
 msgid "CRITICAL - no such UPS '%s' on that host\n"
 msgstr ""
 
-#: plugins/check_ups.c:430
+#: plugins/check_ups.c:433
 msgid "CRITICAL - UPS data is stale"
 msgstr ""
 
-#: plugins/check_ups.c:435
+#: plugins/check_ups.c:438
 #, c-format
 msgid "Unknown error: %s\n"
 msgstr ""
 
-#: plugins/check_ups.c:442
+#: plugins/check_ups.c:445
 msgid "Error: unable to parse variable"
 msgstr ""
 
-#: plugins/check_ups.c:549
+#: plugins/check_ups.c:552
 msgid "Unrecognized UPS variable"
 msgstr ""
 
-#: plugins/check_ups.c:587
+#: plugins/check_ups.c:590
 msgid "Error : no UPS indicated"
 msgstr ""
 
-#: plugins/check_ups.c:607
+#: plugins/check_ups.c:610
 msgid ""
 "This plugin tests the UPS service on the specified host. Network UPS Tools"
 msgstr ""
 
-#: plugins/check_ups.c:608
+#: plugins/check_ups.c:611
 msgid "from www.networkupstools.org must be running for this plugin to work."
 msgstr ""
 
-#: plugins/check_ups.c:620
+#: plugins/check_ups.c:623
 msgid "Name of UPS"
 msgstr ""
 
-#: plugins/check_ups.c:622
+#: plugins/check_ups.c:625
 msgid "Output of temperatures in Celsius"
 msgstr ""
 
-#: plugins/check_ups.c:624
+#: plugins/check_ups.c:627
 msgid "Valid values for STRING are"
 msgstr ""
 
-#: plugins/check_ups.c:635
+#: plugins/check_ups.c:638
 msgid ""
 "This plugin attempts to determine the status of a UPS (Uninterruptible Power"
 msgstr ""
 
-#: plugins/check_ups.c:636
+#: plugins/check_ups.c:639
 msgid ""
 "Supply) on a local or remote host. If the UPS is online or calibrating, the"
 msgstr ""
 
-#: plugins/check_ups.c:637
+#: plugins/check_ups.c:640
 msgid ""
 "plugin will return an OK state. If the battery is on it will return a WARNING"
 msgstr ""
 
-#: plugins/check_ups.c:638
+#: plugins/check_ups.c:641
 msgid ""
 "state. If the UPS is off or has a low battery the plugin will return a "
 "CRITICAL"
 msgstr ""
 
-#: plugins/check_ups.c:643
+#: plugins/check_ups.c:646
 msgid ""
 "You may also specify a variable to check (such as temperature, utility "
 "voltage,"
 msgstr ""
 
-#: plugins/check_ups.c:644
+#: plugins/check_ups.c:647
 msgid ""
 "battery load, etc.) as well as warning and critical thresholds for the value"
 msgstr ""
 
-#: plugins/check_ups.c:645
+#: plugins/check_ups.c:648
 msgid ""
 "of that variable.  If the remote host has multiple UPS that are being "
 "monitored"
 msgstr ""
 
-#: plugins/check_ups.c:646
+#: plugins/check_ups.c:649
 msgid "you will have to use the --ups option to specify which UPS to check."
 msgstr ""
 
-#: plugins/check_ups.c:648
+#: plugins/check_ups.c:651
 msgid ""
 "This plugin requires that the UPSD daemon distributed with Russell Kroll's"
 msgstr ""
 
-#: plugins/check_ups.c:649
+#: plugins/check_ups.c:652
 msgid ""
 "Network UPS Tools be installed on the remote host. If you do not have the"
 msgstr ""
 
-#: plugins/check_ups.c:650
+#: plugins/check_ups.c:653
 msgid "package installed on your system, you can download it from"
 msgstr ""
 
-#: plugins/check_ups.c:651
+#: plugins/check_ups.c:654
 msgid "http://www.networkupstools.org"
 msgstr ""
 
-#: plugins/check_users.c:110
+#: plugins/check_users.c:91
+#, c-format
+msgid "Could not enumerate RD sessions: %d\n"
+msgstr ""
+
+#: plugins/check_users.c:146
 #, c-format
 msgid "# users=%d"
 msgstr ""
 
-#: plugins/check_users.c:133
+#: plugins/check_users.c:164
 msgid "Unable to read output"
 msgstr ""
 
-#: plugins/check_users.c:140
+#: plugins/check_users.c:166
 #, c-format
 msgid "USERS %s - %d users currently logged in |%s\n"
 msgstr ""
 
-#: plugins/check_users.c:219
+#: plugins/check_users.c:241
 msgid "This plugin checks the number of users currently logged in on the local"
 msgstr ""
 
-#: plugins/check_users.c:220
+#: plugins/check_users.c:242
 msgid ""
 "system and generates an error if the number exceeds the thresholds specified."
 msgstr ""
 
-#: plugins/check_users.c:230
+#: plugins/check_users.c:252
 msgid "Set WARNING status if more than INTEGER users are logged in"
 msgstr ""
 
-#: plugins/check_users.c:232
+#: plugins/check_users.c:254
 msgid "Set CRITICAL status if more than INTEGER users are logged in"
 msgstr ""
 
-#: plugins/check_ide_smart.c:256
+#: plugins/check_ide_smart.c:218
+msgid ""
+"DEPRECATION WARNING: the -q switch (quiet output) is no longer \"quiet\"."
+msgstr ""
+
+#: plugins/check_ide_smart.c:219
+msgid "Nagios-compatible output is now always returned."
+msgstr ""
+
+#: plugins/check_ide_smart.c:224
+msgid "SMART commands are broken and have been disabled (See Notes in --help)."
+msgstr ""
+
+#: plugins/check_ide_smart.c:228
+msgid ""
+"DEPRECATION WARNING: the -n switch (Nagios-compatible output) is now the"
+msgstr ""
+
+#: plugins/check_ide_smart.c:229
+msgid "default and will be removed from future releases."
+msgstr ""
+
+#: plugins/check_ide_smart.c:257
 #, c-format
 msgid "CRITICAL - Couldn't open device %s: %s\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:261
+#: plugins/check_ide_smart.c:262
 #, c-format
 msgid "CRITICAL - SMART_CMD_ENABLE\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:323 plugins/check_ide_smart.c:350
+#: plugins/check_ide_smart.c:303 plugins/check_ide_smart.c:330
 #, c-format
 msgid "CRITICAL - SMART_READ_VALUES: %s\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:421
+#: plugins/check_ide_smart.c:376
 #, c-format
 msgid "CRITICAL - %d Harddrive PreFailure%cDetected! %d/%d tests failed.\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:429
+#: plugins/check_ide_smart.c:384
 #, c-format
 msgid "WARNING - %d Harddrive Advisor%s Detected. %d/%d tests failed.\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:437
+#: plugins/check_ide_smart.c:392
 #, c-format
 msgid "OK - Operational (%d/%d tests passed)\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:441
+#: plugins/check_ide_smart.c:396
 #, c-format
 msgid "ERROR - Status '%d' unknown. %d/%d tests passed\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:474
+#: plugins/check_ide_smart.c:429
 #, c-format
 msgid "OffLineStatus=%d {%s}, AutoOffLine=%s, OffLineTimeout=%d minutes\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:480
+#: plugins/check_ide_smart.c:435
 #, c-format
 msgid "OffLineCapability=%d {%s %s %s}\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:486
+#: plugins/check_ide_smart.c:441
 #, c-format
 msgid "SmartRevision=%d, CheckSum=%d, SmartCapability=%d {%s %s}\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:508 plugins/check_ide_smart.c:532
+#: plugins/check_ide_smart.c:463 plugins/check_ide_smart.c:492
 #, c-format
 msgid "CRITICAL - %s: %s\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:553 plugins/check_ide_smart.c:580
+#: plugins/check_ide_smart.c:467 plugins/check_ide_smart.c:496
+#, c-format
+msgid "OK - Command sent (%s)\n"
+msgstr ""
+
+#: plugins/check_ide_smart.c:517 plugins/check_ide_smart.c:544
 #, c-format
 msgid "CRITICAL - SMART_READ_THRESHOLDS: %s\n"
 msgstr ""
 
-#: plugins/check_ide_smart.c:599
+#: plugins/check_ide_smart.c:563
 #, c-format
 msgid ""
 "This plugin checks a local hard drive with the (Linux specific) SMART "
 "interface [http://smartlinux.sourceforge.net/smart/index.php]."
 msgstr ""
 
-#: plugins/check_ide_smart.c:609
+#: plugins/check_ide_smart.c:573
 msgid "Select device DEVICE"
 msgstr ""
 
-#: plugins/check_ide_smart.c:610
+#: plugins/check_ide_smart.c:574
 msgid ""
-"Note: if the device is selected with this option, _no_ other options are "
-"accepted"
+"Note: if the device is specified without this option, any further option will"
 msgstr ""
 
-#: plugins/check_ide_smart.c:612
-msgid "Perform immediately offline tests"
+#: plugins/check_ide_smart.c:575
+msgid "be ignored."
 msgstr ""
 
-#: plugins/check_ide_smart.c:614
-msgid "Returns the number of failed tests"
+#: plugins/check_ide_smart.c:581
+msgid ""
+"The SMART command modes (-i/--immediate, -0/--auto-off and -1/--auto-on) were"
 msgstr ""
 
-#: plugins/check_ide_smart.c:616
-msgid "Turn on automatic offline tests"
+#: plugins/check_ide_smart.c:582
+msgid ""
+"broken in an underhand manner and have been disabled. You can use smartctl"
 msgstr ""
 
-#: plugins/check_ide_smart.c:618
-msgid "Turn off automatic offline tests"
+#: plugins/check_ide_smart.c:583
+msgid "instead:"
 msgstr ""
 
-#: plugins/check_ide_smart.c:620
-msgid "Output suitable for the monitoring system"
+#: plugins/check_ide_smart.c:584
+msgid "-0/--auto-off:  use \"smartctl --offlineauto=off\""
 msgstr ""
 
-#: plugins/negate.c:99
+#: plugins/check_ide_smart.c:585
+msgid "-1/--auto-on:   use \"smartctl --offlineauto=on\""
+msgstr ""
+
+#: plugins/check_ide_smart.c:586
+msgid "-i/--immediate: use \"smartctl --test=offline\""
+msgstr ""
+
+#: plugins/negate.c:96
 msgid "No data returned from command\n"
 msgstr ""
 
-#: plugins/negate.c:170
+#: plugins/negate.c:166
 msgid ""
 "Timeout result must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) "
 "or integer (0-3)."
 msgstr ""
 
-#: plugins/negate.c:174
+#: plugins/negate.c:170
 msgid ""
 "Ok must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer "
 "(0-3)."
 msgstr ""
 
-#: plugins/negate.c:180
+#: plugins/negate.c:176
 msgid ""
 "Warning must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or "
 "integer (0-3)."
 msgstr ""
 
-#: plugins/negate.c:185
+#: plugins/negate.c:181
 msgid ""
 "Critical must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or "
 "integer (0-3)."
 msgstr ""
 
-#: plugins/negate.c:190
+#: plugins/negate.c:186
 msgid ""
 "Unknown must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or "
 "integer (0-3)."
 msgstr ""
 
-#: plugins/negate.c:217
+#: plugins/negate.c:213
 msgid "Require path to command"
 msgstr ""
 
-#: plugins/negate.c:246
+#: plugins/negate.c:224
 msgid ""
 "Negates the status of a plugin (returns OK for CRITICAL and vice-versa)."
 msgstr ""
 
-#: plugins/negate.c:247
+#: plugins/negate.c:225
 msgid "Additional switches can be used to control which state becomes what."
 msgstr ""
 
-#: plugins/negate.c:256
+#: plugins/negate.c:234
 msgid "Keep timeout longer than the plugin timeout to retain CRITICAL status."
 msgstr ""
 
-#: plugins/negate.c:258
+#: plugins/negate.c:236
 msgid "Custom result on Negate timeouts; see below for STATUS definition\n"
 msgstr ""
 
-#: plugins/negate.c:264
+#: plugins/negate.c:242
 #, c-format
 msgid ""
 "    STATUS can be 'OK', 'WARNING', 'CRITICAL' or 'UNKNOWN' without single\n"
 msgstr ""
 
-#: plugins/negate.c:265
+#: plugins/negate.c:243
 #, c-format
 msgid ""
 "    quotes. Numeric values are accepted. If nothing is specified, permutes\n"
 msgstr ""
 
-#: plugins/negate.c:266
+#: plugins/negate.c:244
 #, c-format
 msgid "    OK and CRITICAL.\n"
 msgstr ""
 
-#: plugins/negate.c:268
+#: plugins/negate.c:246
 #, c-format
 msgid ""
 "    Substitute output text as well. Will only substitute text in CAPITALS\n"
 msgstr ""
 
-#: plugins/negate.c:273
+#: plugins/negate.c:251
 msgid "Run check_ping and invert result. Must use full path to plugin"
 msgstr ""
 
-#: plugins/negate.c:275
+#: plugins/negate.c:253
 msgid "This will return OK instead of WARNING and UNKNOWN instead of CRITICAL"
 msgstr ""
 
-#: plugins/negate.c:278
+#: plugins/negate.c:256
 msgid ""
 "This plugin is a wrapper to take the output of another plugin and invert it."
 msgstr ""
 
-#: plugins/negate.c:279
+#: plugins/negate.c:257
 msgid "The full path of the plugin must be provided."
 msgstr ""
 
-#: plugins/negate.c:280
+#: plugins/negate.c:258
 msgid "If the wrapped plugin returns OK, the wrapper will return CRITICAL."
 msgstr ""
 
-#: plugins/negate.c:281
+#: plugins/negate.c:259
 msgid "If the wrapped plugin returns CRITICAL, the wrapper will return OK."
 msgstr ""
 
-#: plugins/negate.c:282
+#: plugins/negate.c:260
 msgid "Otherwise, the output state of the wrapped plugin is unchanged."
 msgstr ""
 
-#: plugins/negate.c:284
+#: plugins/negate.c:262
 msgid ""
 "Using timeout-result, it is possible to override the timeout behaviour or a"
 msgstr ""
 
-#: plugins/negate.c:285
+#: plugins/negate.c:263
 msgid "plugin by setting the negate timeout a bit lower."
 msgstr ""
 
@@ -5408,134 +5808,129 @@ msgstr ""
 msgid "%s - Abnormal timeout after %d seconds\n"
 msgstr ""
 
-#: plugins/netutils.c:79 plugins/netutils.c:281
+#: plugins/netutils.c:79 plugins/netutils.c:292
 msgid "Send failed"
 msgstr ""
 
-#: plugins/netutils.c:96 plugins/netutils.c:296
+#: plugins/netutils.c:96 plugins/netutils.c:307
 msgid "No data was received from host!"
 msgstr ""
 
-#: plugins/netutils.c:204 plugins/netutils.c:240
+#: plugins/netutils.c:209 plugins/netutils.c:245
 msgid "Socket creation failed"
 msgstr ""
 
-#: plugins/netutils.c:233
+#: plugins/netutils.c:238
 msgid "Supplied path too long unix domain socket"
 msgstr ""
 
-#: plugins/netutils.c:305
+#: plugins/netutils.c:316
 msgid "Receive failed"
 msgstr ""
 
-#: plugins/netutils.c:331 plugins-root/check_dhcp.c:1342
+#: plugins/netutils.c:342 plugins-root/check_dhcp.c:1310
 #, c-format
 msgid "Invalid hostname/address - %s"
 msgstr ""
 
-#: plugins/popen.c:142
+#: plugins/popen.c:133
 msgid "Could not malloc argv array in popen()"
 msgstr ""
 
-#: plugins/popen.c:152
+#: plugins/popen.c:143
 msgid "CRITICAL - You need more args!!!"
 msgstr ""
 
-#: plugins/popen.c:209
+#: plugins/popen.c:201
 msgid "Cannot catch SIGCHLD"
 msgstr ""
 
-#: plugins/popen.c:304
+#: plugins/popen.c:287
 #, c-format
 msgid "CRITICAL - Plugin timed out after %d seconds\n"
 msgstr ""
 
-#: plugins/popen.c:307
+#: plugins/popen.c:290
 msgid "CRITICAL - popen timeout received, but no child process"
 msgstr ""
 
-#: plugins/popen.c:323
-msgid "sysconf error for _SC_OPEN_MAX"
-msgstr ""
-
-#: plugins/urlize.c:130
+#: plugins/urlize.c:129
 #, c-format
 msgid ""
 "%s UNKNOWN - No data received from host\n"
 "CMD: %s</A>\n"
 msgstr ""
 
-#: plugins/urlize.c:169
+#: plugins/urlize.c:168
 msgid ""
 "This plugin wraps the text output of another command (plugin) in HTML <A>"
 msgstr ""
 
-#: plugins/urlize.c:170
+#: plugins/urlize.c:169
 msgid ""
 "tags, thus displaying the child plugin's output as a clickable link in "
 "compatible"
 msgstr ""
 
-#: plugins/urlize.c:171
+#: plugins/urlize.c:170
 msgid ""
 "monitoring status screen. This plugin returns the status of the invoked "
 "plugin."
 msgstr ""
 
-#: plugins/urlize.c:181
+#: plugins/urlize.c:180
 msgid ""
 "Pay close attention to quoting to ensure that the shell passes the expected"
 msgstr ""
 
-#: plugins/urlize.c:182
+#: plugins/urlize.c:181
 msgid "data to the plugin. For example, in:"
 msgstr ""
 
-#: plugins/urlize.c:183
+#: plugins/urlize.c:182
 msgid "urlize http://example.com/ check_http -H example.com -r 'two words'"
 msgstr ""
 
-#: plugins/urlize.c:184
+#: plugins/urlize.c:183
 msgid "the shell will remove the single quotes and urlize will see:"
 msgstr ""
 
-#: plugins/urlize.c:185
+#: plugins/urlize.c:184
 msgid "urlize http://example.com/ check_http -H example.com -r two words"
 msgstr ""
 
-#: plugins/urlize.c:186
+#: plugins/urlize.c:185
 msgid "You probably want:"
 msgstr ""
 
-#: plugins/urlize.c:187
+#: plugins/urlize.c:186
 msgid "urlize http://example.com/ \"check_http -H example.com -r 'two words'\""
 msgstr ""
 
-#: plugins/utils.c:174
-#, c-format
-msgid "%s - Plugin timed out after %d seconds\n"
-msgstr ""
-
-#: plugins/utils.c:469
+#: plugins/utils.c:479
 msgid "failed realloc in strpcpy\n"
 msgstr ""
 
-#: plugins/utils.c:511
+#: plugins/utils.c:521
 msgid "failed malloc in strscat\n"
 msgstr ""
 
-#: plugins/utils.c:531
+#: plugins/utils.c:541
 msgid "failed malloc in xvasprintf\n"
 msgstr ""
 
-#: plugins/utils.h:137
+#: plugins/utils.c:819
+msgid "sysconf error for _SC_OPEN_MAX\n"
+msgstr ""
+
+#: plugins/utils.h:127
 #, c-format
 msgid ""
 "       %s (-h | --help) for detailed help\n"
 "       %s (-V | --version) for version information\n"
 msgstr ""
 
-#: plugins/utils.h:141
+#: plugins/utils.h:131
 msgid ""
 "\n"
 "Options:\n"
@@ -5545,7 +5940,7 @@ msgid ""
 "    Print version information\n"
 msgstr ""
 
-#: plugins/utils.h:148
+#: plugins/utils.h:138
 #, c-format
 msgid ""
 " -H, --hostname=ADDRESS\n"
@@ -5554,7 +5949,7 @@ msgid ""
 "    Port number (default: %s)\n"
 msgstr ""
 
-#: plugins/utils.h:154
+#: plugins/utils.h:144
 msgid ""
 " -4, --use-ipv4\n"
 "    Use IPv4 connection\n"
@@ -5562,14 +5957,14 @@ msgid ""
 "    Use IPv6 connection\n"
 msgstr ""
 
-#: plugins/utils.h:160
+#: plugins/utils.h:150
 msgid ""
 " -v, --verbose\n"
 "    Show details for command-line debugging (output may be truncated by\n"
-"\t\tthe monitoring system)\n"
+"    the monitoring system)\n"
 msgstr ""
 
-#: plugins/utils.h:165
+#: plugins/utils.h:155
 msgid ""
 " -w, --warning=DOUBLE\n"
 "    Response time to result in warning status (seconds)\n"
@@ -5577,7 +5972,7 @@ msgid ""
 "    Response time to result in critical status (seconds)\n"
 msgstr ""
 
-#: plugins/utils.h:171
+#: plugins/utils.h:161
 msgid ""
 " -w, --warning=RANGE\n"
 "    Warning range (format: start:end). Alert if outside this range\n"
@@ -5585,14 +5980,21 @@ msgid ""
 "    Critical range\n"
 msgstr ""
 
-#: plugins/utils.h:177
+#: plugins/utils.h:167
 #, c-format
 msgid ""
 " -t, --timeout=INTEGER\n"
 "    Seconds before connection times out (default: %d)\n"
 msgstr ""
 
-#: plugins/utils.h:182
+#: plugins/utils.h:171
+#, c-format
+msgid ""
+" -t, --timeout=INTEGER\n"
+"    Seconds before plugin times out (default: %d)\n"
+msgstr ""
+
+#: plugins/utils.h:176
 msgid ""
 " --extra-opts=[section][@file]\n"
 "    Read options from an ini file. See\n"
@@ -5600,14 +6002,14 @@ msgid ""
 "    for usage and examples.\n"
 msgstr ""
 
-#: plugins/utils.h:190
+#: plugins/utils.h:185
 msgid ""
 " See:\n"
 " https://www.monitoring-plugins.org/doc/guidelines.html#THRESHOLDFORMAT\n"
 " for THRESHOLD format and examples.\n"
 msgstr ""
 
-#: plugins/utils.h:195
+#: plugins/utils.h:190
 msgid ""
 "\n"
 "Send email to help@monitoring-plugins.org if you have questions regarding\n"
@@ -5616,7 +6018,7 @@ msgid ""
 "\n"
 msgstr ""
 
-#: plugins/utils.h:200
+#: plugins/utils.h:195
 msgid ""
 "\n"
 "The Monitoring Plugins come with ABSOLUTELY NO WARRANTY. You may "
@@ -5625,398 +6027,406 @@ msgid ""
 "For more information about these matters, see the file named COPYING.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:320
+#: plugins-root/check_dhcp.c:317
 #, c-format
 msgid "Error: Could not get hardware address of interface '%s'\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:342
+#: plugins-root/check_dhcp.c:340
 #, c-format
 msgid "Error: if_nametoindex error - %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:347
+#: plugins-root/check_dhcp.c:345
 #, c-format
 msgid "Error: Couldn't get hardware address from %s. sysctl 1 error - %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:352
+#: plugins-root/check_dhcp.c:350
 #, c-format
 msgid ""
 "Error: Couldn't get hardware address from interface %s. malloc error - %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:357
+#: plugins-root/check_dhcp.c:355
 #, c-format
 msgid "Error: Couldn't get hardware address from %s. sysctl 2 error - %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:388
+#: plugins-root/check_dhcp.c:386
 #, c-format
 msgid ""
 "Error: can't find unit number in interface_name (%s) - expecting TypeNumber "
 "eg lnc0.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:393 plugins-root/check_dhcp.c:405
+#: plugins-root/check_dhcp.c:391 plugins-root/check_dhcp.c:403
 #, c-format
 msgid ""
 "Error: can't read MAC address from DLPI streams interface for device %s unit "
 "%d.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:411
+#: plugins-root/check_dhcp.c:409
 #, c-format
 msgid ""
 "Error: can't get MAC address for this architecture.  Use the --mac option.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:430
+#: plugins-root/check_dhcp.c:428
 #, c-format
 msgid "Error: Cannot determine IP address of interface %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:438
+#: plugins-root/check_dhcp.c:436
 #, c-format
 msgid "Error: Cannot get interface IP address on this platform.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:443
+#: plugins-root/check_dhcp.c:441
 #, c-format
 msgid "Pretending to be relay client %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:528
+#: plugins-root/check_dhcp.c:521
 #, c-format
 msgid "DHCPDISCOVER to %s port %d\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:580
+#: plugins-root/check_dhcp.c:573
 #, c-format
 msgid "Result=ERROR\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:586
+#: plugins-root/check_dhcp.c:579
 #, c-format
 msgid "Result=OK\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:596
+#: plugins-root/check_dhcp.c:589
 #, c-format
 msgid "DHCPOFFER from IP address %s"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:597
+#: plugins-root/check_dhcp.c:590
 #, c-format
 msgid " via %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:604
+#: plugins-root/check_dhcp.c:597
 #, c-format
 msgid ""
 "DHCPOFFER XID (%u) did not match DHCPDISCOVER XID (%u) - ignoring packet\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:626
+#: plugins-root/check_dhcp.c:619
 #, c-format
 msgid "DHCPOFFER hardware address did not match our own - ignoring packet\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:644
+#: plugins-root/check_dhcp.c:637
 #, c-format
 msgid "Total responses seen on the wire: %d\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:645
+#: plugins-root/check_dhcp.c:638
 #, c-format
 msgid "Valid responses for this machine: %d\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:660
+#: plugins-root/check_dhcp.c:653
 #, c-format
 msgid "send_dhcp_packet result: %d\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:693
+#: plugins-root/check_dhcp.c:686
 #, c-format
 msgid "No (more) data received (nfound: %d)\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:712
+#: plugins-root/check_dhcp.c:699
 #, c-format
 msgid "recvfrom() failed, "
 msgstr ""
 
-#: plugins-root/check_dhcp.c:719
+#: plugins-root/check_dhcp.c:706
 #, c-format
 msgid "receive_dhcp_packet() result: %d\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:720
+#: plugins-root/check_dhcp.c:707
 #, c-format
 msgid "receive_dhcp_packet() source: %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:750
+#: plugins-root/check_dhcp.c:737
 #, c-format
 msgid "Error: Could not create socket!\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:760
+#: plugins-root/check_dhcp.c:747
 #, c-format
 msgid "Error: Could not set reuse address option on DHCP socket!\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:766
+#: plugins-root/check_dhcp.c:753
 #, c-format
 msgid "Error: Could not set broadcast option on DHCP socket!\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:775
+#: plugins-root/check_dhcp.c:762
 #, c-format
 msgid ""
 "Error: Could not bind socket to interface %s.  Check your privileges...\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:786
+#: plugins-root/check_dhcp.c:773
 #, c-format
 msgid ""
 "Error: Could not bind to DHCP socket (port %d)!  Check your privileges...\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:820
+#: plugins-root/check_dhcp.c:807
 #, c-format
 msgid "Requested server address: %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:882
+#: plugins-root/check_dhcp.c:869
 #, c-format
 msgid "Lease Time: Infinite\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:884
+#: plugins-root/check_dhcp.c:871
 #, c-format
 msgid "Lease Time: %lu seconds\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:886
+#: plugins-root/check_dhcp.c:873
 #, c-format
 msgid "Renewal Time: Infinite\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:888
+#: plugins-root/check_dhcp.c:875
 #, c-format
 msgid "Renewal Time: %lu seconds\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:890
+#: plugins-root/check_dhcp.c:877
 #, c-format
 msgid "Rebinding Time: Infinite\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:891
+#: plugins-root/check_dhcp.c:878
 #, c-format
 msgid "Rebinding Time: %lu seconds\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:919
+#: plugins-root/check_dhcp.c:906
 #, c-format
 msgid "Added offer from server @ %s"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:920
+#: plugins-root/check_dhcp.c:907
 #, c-format
 msgid " of IP address %s\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:987
+#: plugins-root/check_dhcp.c:974
 #, c-format
 msgid "DHCP Server Match: Offerer=%s"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:988
+#: plugins-root/check_dhcp.c:975
 #, c-format
 msgid " Requested=%s"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:990
+#: plugins-root/check_dhcp.c:977
 #, c-format
 msgid " (duplicate)"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:991
+#: plugins-root/check_dhcp.c:978
 #, c-format
 msgid "\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1039
+#: plugins-root/check_dhcp.c:1026
 #, c-format
 msgid "No DHCPOFFERs were received.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1043
+#: plugins-root/check_dhcp.c:1030
 #, c-format
 msgid "Received %d DHCPOFFER(s)"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1046
+#: plugins-root/check_dhcp.c:1033
 #, c-format
 msgid ", %s%d of %d requested servers responded"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1049
+#: plugins-root/check_dhcp.c:1036
 #, c-format
 msgid ", requested address (%s) was %soffered"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1049
+#: plugins-root/check_dhcp.c:1036
 msgid "not "
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1051
+#: plugins-root/check_dhcp.c:1038
 #, c-format
 msgid ", max lease time = "
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1053
+#: plugins-root/check_dhcp.c:1040
 #, c-format
 msgid "Infinity"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1234
+#: plugins-root/check_dhcp.c:1160
+msgid "Got unexpected non-option argument"
+msgstr ""
+
+#: plugins-root/check_dhcp.c:1202
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in check_ctrl: %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1246
+#: plugins-root/check_dhcp.c:1214
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in put_ctrl/putmsg(): %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1259
+#: plugins-root/check_dhcp.c:1227
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in put_both/putmsg().\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1271
+#: plugins-root/check_dhcp.c:1239
 #, c-format
 msgid ""
 "Error: DLPI stream API failed to get MAC in dl_attach_req/open(%s..): %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1295
+#: plugins-root/check_dhcp.c:1263
 #, c-format
 msgid "Error: DLPI stream API failed to get MAC in dl_bind/check_ctrl(): %s.\n"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1374
+#: plugins-root/check_dhcp.c:1342
 #, c-format
 msgid "Hardware address: "
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1390
+#: plugins-root/check_dhcp.c:1358
 msgid "This plugin tests the availability of DHCP servers on a network."
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1402
+#: plugins-root/check_dhcp.c:1370
 msgid "IP address of DHCP server that we must hear from"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1404
+#: plugins-root/check_dhcp.c:1372
 msgid "IP address that should be offered by at least one DHCP server"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1406
+#: plugins-root/check_dhcp.c:1374
 msgid "Seconds to wait for DHCPOFFER before timeout occurs"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1408
+#: plugins-root/check_dhcp.c:1376
 msgid "Interface to to use for listening (i.e. eth0)"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1410
+#: plugins-root/check_dhcp.c:1378
 msgid "MAC address to use in the DHCP request"
 msgstr ""
 
-#: plugins-root/check_dhcp.c:1412
+#: plugins-root/check_dhcp.c:1380
 msgid "Unicast testing: mimic a DHCP relay, requires -s"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1295
+#: plugins-root/check_icmp.c:1567
 msgid "specify a target"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1297
+#: plugins-root/check_icmp.c:1569
+msgid "Use IPv4 (default) or IPv6 to communicate with the targets"
+msgstr ""
+
+#: plugins-root/check_icmp.c:1571
 msgid "warning threshold (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1300
+#: plugins-root/check_icmp.c:1574
 msgid "critical threshold (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1303
+#: plugins-root/check_icmp.c:1577
 msgid "specify a source IP address or device name"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1305
+#: plugins-root/check_icmp.c:1579
 msgid "number of packets to send (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1308
+#: plugins-root/check_icmp.c:1582
 msgid "max packet interval (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1311
+#: plugins-root/check_icmp.c:1585
 msgid "max target interval (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1314
+#: plugins-root/check_icmp.c:1588
 msgid "number of alive hosts required for success"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1317
+#: plugins-root/check_icmp.c:1591
 msgid "TTL on outgoing packets (currently "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1320
+#: plugins-root/check_icmp.c:1594
 msgid "timeout value (seconds, currently  "
 msgstr ""
 
-#: plugins-root/check_icmp.c:1323
+#: plugins-root/check_icmp.c:1597
 msgid "Number of icmp data bytes to send"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1324
+#: plugins-root/check_icmp.c:1598
 msgid "Packet size will be data bytes + icmp header (currently"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1326
+#: plugins-root/check_icmp.c:1600
 msgid "verbose"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1330
+#: plugins-root/check_icmp.c:1604
 msgid "The -H switch is optional. Naming a host (or several) to check is not."
 msgstr ""
 
-#: plugins-root/check_icmp.c:1332
+#: plugins-root/check_icmp.c:1606
 msgid ""
 "Threshold format for -w and -c is 200.25,60% for 200.25 msec RTA and 60%"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1333
+#: plugins-root/check_icmp.c:1607
 msgid "packet loss.  The default values should work well for most users."
 msgstr ""
 
-#: plugins-root/check_icmp.c:1334
+#: plugins-root/check_icmp.c:1608
 msgid ""
 "You can specify different RTA factors using the standardized abbreviations"
 msgstr ""
 
-#: plugins-root/check_icmp.c:1335
+#: plugins-root/check_icmp.c:1609
 msgid ""
 "us (microseconds), ms (milliseconds, default) or just plain s for seconds."
 msgstr ""
 
-#: plugins-root/check_icmp.c:1341
+#: plugins-root/check_icmp.c:1615
 msgid "The -v switch can be specified several times for increased verbosity."
 msgstr ""


### PR DESCRIPTION
check_smtp: Add option to prefix PROXY header

This enables checks of SMTP servers that expect the haproxy
PROXY protocol:  -o smtpd_upstream_proxy_protocol=haproxy.

Backported from nagios-plugins:
https://github.com/nagios-plugins/nagios-plugins/commit/3246efe923b5482c5024c40e593ce942e628a3cb

Compiled the code and successfully tested the new -r/--proxy option of the resulting check_smtp plugin in a live setup.