### PR TITLE
Add support for SNI in check_smtp

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -103,6 +103,7 @@ double critical_time = 0;
 int check_critical_time = FALSE;
 int verbose = 0;
 int use_ssl = FALSE;
+int use_sni = FALSE;
 short use_proxy_prefix = FALSE;
 short use_ehlo = FALSE;
 short use_lhlo = FALSE;
@@ -234,7 +235,7 @@ main (int argc, char **argv)
 		    smtp_quit();
 		    return STATE_UNKNOWN;
 		  }
-		  result = np_net_ssl_init(sd);
+		  result = np_net_ssl_init_with_hostname(sd, (use_sni ? server_address : NULL));
 		  if(result != STATE_OK) {
 		    printf (_("CRITICAL - Cannot create SSL context.\n"));
 		    close(sd);
@@ -463,6 +464,10 @@ process_arguments (int argc, char **argv)
 	int c;
 	char* temp;
 
+	enum {
+	  SNI_OPTION
+	};
+
 	int option = 0;
 	static struct option longopts[] = {
 		{"hostname", required_argument, 0, 'H'},
@@ -485,6 +490,7 @@ process_arguments (int argc, char **argv)
 		{"help", no_argument, 0, 'h'},
 		{"lmtp", no_argument, 0, 'L'},
 		{"starttls",no_argument,0,'S'},
+		{"sni", no_argument, 0, SNI_OPTION},
 		{"certificate",required_argument,0,'D'},
 		{"ignore-quit-failure",no_argument,0,'q'},
 		{"proxy",no_argument,0,'r'},
@@ -630,6 +636,13 @@ process_arguments (int argc, char **argv)
 		/* starttls */
 			use_ssl = TRUE;
 			use_ehlo = TRUE;
+			break;
+		case SNI_OPTION:
+#ifdef HAVE_SSL
+			use_sni = TRUE;
+#else
+			usage (_("SSL support not available - install OpenSSL and recompile"));
+#endif
 			break;
 		case 'r':
 			use_proxy_prefix = TRUE;
@@ -839,6 +852,8 @@ print_help (void)
   printf ("    %s\n", _("Minimum number of days a certificate has to be valid."));
   printf (" %s\n", "-S, --starttls");
   printf ("    %s\n", _("Use STARTTLS for the connection."));
+  printf (" %s\n", "--sni");
+  printf ("    %s\n", _("Enable SSL/TLS hostname extension support (SNI)"));
 #endif
 
 	printf (" %s\n", "-A, --authtype=STRING");
@@ -875,6 +890,6 @@ print_usage (void)
   printf ("%s\n", _("Usage:"));
   printf ("%s -H host [-p port] [-4|-6] [-e expect] [-C command] [-R response] [-f from addr]\n", progname);
   printf ("[-A authtype -U authuser -P authpass] [-w warn] [-c crit] [-t timeout] [-q]\n");
-  printf ("[-F fqdn] [-S] [-L] [-D warn days cert expire[,crit days cert expire]] [-r] [-v] \n");
+  printf ("[-F fqdn] [-S] [-L] [-D warn days cert expire[,crit days cert expire]] [-r] [--sni] [-v] \n");
 }
 

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nagiosplug\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2023-06-12 16:29+0200\n"
+"POT-Creation-Date: 2023-06-12 20:31+0200\n"
 "PO-Revision-Date: 2004-12-23 17:46+0100\n"
 "Last-Translator:  <>\n"
 "Language-Team: English <en@li.org>\n"
@@ -28,7 +28,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:557
 #: plugins/check_nwstat.c:173 plugins/check_overcr.c:102
 #: plugins/check_pgsql.c:174 plugins/check_ping.c:97 plugins/check_procs.c:176
-#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:145
+#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:146
 #: plugins/check_snmp.c:248 plugins/check_ssh.c:74 plugins/check_swap.c:115
 #: plugins/check_tcp.c:222 plugins/check_time.c:78 plugins/check_ups.c:122
 #: plugins/check_users.c:84 plugins/negate.c:210 plugins-root/check_dhcp.c:270
@@ -68,14 +68,14 @@ msgstr ""
 
 #: plugins/check_by_ssh.c:242 plugins/check_disk.c:568 plugins/check_http.c:292
 #: plugins/check_ldap.c:334 plugins/check_pgsql.c:314 plugins/check_procs.c:461
-#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:601
+#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:607
 #: plugins/check_snmp.c:789 plugins/check_ssh.c:140 plugins/check_tcp.c:519
 #: plugins/check_time.c:302 plugins/check_ups.c:559 plugins/negate.c:160
 msgid "Timeout interval must be a positive integer"
 msgstr "Timeout interval muss ein positiver Integer sein"
 
 #: plugins/check_by_ssh.c:254 plugins/check_pgsql.c:344
-#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:526
+#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:532
 #: plugins/check_tcp.c:525 plugins/check_time.c:296 plugins/check_ups.c:521
 msgid "Port must be a positive integer"
 msgstr "Port muss ein positiver Integer sein"
@@ -252,7 +252,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:753 plugins/check_ntp_time.c:651
 #: plugins/check_nwstat.c:1685 plugins/check_overcr.c:467
 #: plugins/check_pgsql.c:551 plugins/check_ping.c:617 plugins/check_procs.c:829
-#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:875
+#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:890
 #: plugins/check_snmp.c:1346 plugins/check_ssh.c:325 plugins/check_swap.c:607
 #: plugins/check_tcp.c:710 plugins/check_time.c:371 plugins/check_ups.c:663
 #: plugins/check_users.c:262 plugins/check_ide_smart.c:606 plugins/negate.c:273
@@ -957,8 +957,8 @@ msgstr "FPING %s - %s (verloren=%.0f%% )|%s\n"
 #: plugins/check_ntp.c:719 plugins/check_ntp_peer.c:497
 #: plugins/check_ntp_time.c:498 plugins/check_pgsql.c:338
 #: plugins/check_ping.c:301 plugins/check_ping.c:424 plugins/check_radius.c:279
-#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:519
-#: plugins/check_smtp.c:667 plugins/check_ssh.c:162 plugins/check_time.c:240
+#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:525
+#: plugins/check_smtp.c:680 plugins/check_ssh.c:162 plugins/check_time.c:240
 #: plugins/check_time.c:315 plugins/check_ups.c:507 plugins/check_ups.c:576
 msgid "Invalid hostname/address"
 msgstr "Ungültige(r) Hostname/Adresse"
@@ -1227,7 +1227,7 @@ msgid "file does not exist or is not readable"
 msgstr ""
 
 #: plugins/check_http.c:324 plugins/check_http.c:329 plugins/check_http.c:335
-#: plugins/check_smtp.c:615 plugins/check_tcp.c:590 plugins/check_tcp.c:595
+#: plugins/check_smtp.c:621 plugins/check_tcp.c:590 plugins/check_tcp.c:595
 #: plugins/check_tcp.c:601
 msgid "Invalid certificate expiration period"
 msgstr "Ungültiger Zertifikatsablauftermin"
@@ -1267,7 +1267,7 @@ msgstr ""
 
 #: plugins/check_http.c:521 plugins/check_ntp.c:732
 #: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:517
-#: plugins/check_smtp.c:647 plugins/check_ssh.c:151 plugins/check_tcp.c:491
+#: plugins/check_smtp.c:660 plugins/check_ssh.c:151 plugins/check_tcp.c:491
 msgid "IPv6 support not available"
 msgstr "IPv6 Unterstützung nicht vorhanden"
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."
 msgstr ""
 
-#: plugins/check_http.c:1749
+#: plugins/check_http.c:1749 plugins/check_smtp.c:856
 msgid "Enable SSL/TLS hostname extension support (SNI)"
 msgstr ""
 
@@ -4376,7 +4376,7 @@ msgstr "Kein Papier"
 msgid "Invalid NAS-Identifier\n"
 msgstr "Ungültige(r) Hostname/Adresse"
 
-#: plugins/check_radius.c:199 plugins/check_smtp.c:155
+#: plugins/check_radius.c:199 plugins/check_smtp.c:156
 #, c-format
 msgid "gethostname() failed!\n"
 msgstr ""
@@ -4568,7 +4568,7 @@ msgstr ""
 msgid "This plugin will attempt to open an RTSP connection with the host."
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_real.c:439 plugins/check_smtp.c:862
+#: plugins/check_real.c:439 plugins/check_smtp.c:877
 msgid "Successful connects return STATE_OK, refusals and timeouts return"
 msgstr ""
 
@@ -4586,227 +4586,227 @@ msgstr ""
 msgid "values."
 msgstr ""
 
-#: plugins/check_smtp.c:151 plugins/check_swap.c:283 plugins/check_swap.c:289
+#: plugins/check_smtp.c:152 plugins/check_swap.c:283 plugins/check_swap.c:289
 #, c-format
 msgid "malloc() failed!\n"
 msgstr ""
 
-#: plugins/check_smtp.c:199 plugins/check_smtp.c:211
+#: plugins/check_smtp.c:200 plugins/check_smtp.c:212
 #, c-format
 msgid "recv() failed\n"
 msgstr ""
 
-#: plugins/check_smtp.c:221
+#: plugins/check_smtp.c:222
 #, c-format
 msgid "WARNING - TLS not supported by server\n"
 msgstr ""
 
-#: plugins/check_smtp.c:233
+#: plugins/check_smtp.c:234
 #, c-format
 msgid "Server does not support STARTTLS\n"
 msgstr ""
 
-#: plugins/check_smtp.c:239
+#: plugins/check_smtp.c:240
 #, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr ""
 
-#: plugins/check_smtp.c:259
+#: plugins/check_smtp.c:260
 msgid "SMTP UNKNOWN - Cannot send EHLO command via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:264
+#: plugins/check_smtp.c:265
 #, c-format
 msgid "sent %s"
 msgstr ""
 
-#: plugins/check_smtp.c:266
+#: plugins/check_smtp.c:267
 msgid "SMTP UNKNOWN - Cannot read EHLO response via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:296
+#: plugins/check_smtp.c:297
 #, fuzzy, c-format
 msgid "Invalid SMTP response received from host: %s\n"
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:298
+#: plugins/check_smtp.c:299
 #, fuzzy, c-format
 msgid "Invalid SMTP response received from host on port %d: %s\n"
 msgstr "Ungültige HTTP Antwort von Host erhalten auf Port %d\n"
 
-#: plugins/check_smtp.c:321 plugins/check_snmp.c:865
+#: plugins/check_smtp.c:322 plugins/check_snmp.c:865
 #, c-format
 msgid "Could Not Compile Regular Expression"
 msgstr ""
 
-#: plugins/check_smtp.c:330
+#: plugins/check_smtp.c:331
 #, c-format
 msgid "SMTP %s - Invalid response '%s' to command '%s'\n"
 msgstr ""
 
-#: plugins/check_smtp.c:334 plugins/check_snmp.c:540
+#: plugins/check_smtp.c:335 plugins/check_snmp.c:540
 #, c-format
 msgid "Execute Error: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:348
+#: plugins/check_smtp.c:349
 msgid "no authuser specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:353
+#: plugins/check_smtp.c:354
 msgid "no authpass specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:360 plugins/check_smtp.c:381 plugins/check_smtp.c:401
-#: plugins/check_smtp.c:714
+#: plugins/check_smtp.c:361 plugins/check_smtp.c:382 plugins/check_smtp.c:402
+#: plugins/check_smtp.c:727
 #, c-format
 msgid "sent %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:363
+#: plugins/check_smtp.c:364
 #, fuzzy
 msgid "recv() failed after AUTH LOGIN, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:368 plugins/check_smtp.c:389 plugins/check_smtp.c:409
-#: plugins/check_smtp.c:725
+#: plugins/check_smtp.c:369 plugins/check_smtp.c:390 plugins/check_smtp.c:410
+#: plugins/check_smtp.c:738
 #, fuzzy, c-format
 msgid "received %s\n"
 msgstr "Keine Daten empfangen %s\n"
 
-#: plugins/check_smtp.c:372
+#: plugins/check_smtp.c:373
 #, fuzzy
 msgid "invalid response received after AUTH LOGIN, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:385
+#: plugins/check_smtp.c:386
 msgid "recv() failed after sending authuser, "
 msgstr ""
 
-#: plugins/check_smtp.c:393
+#: plugins/check_smtp.c:394
 #, fuzzy
 msgid "invalid response received after authuser, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:405
+#: plugins/check_smtp.c:406
 msgid "recv() failed after sending authpass, "
 msgstr ""
 
-#: plugins/check_smtp.c:413
+#: plugins/check_smtp.c:414
 #, fuzzy
 msgid "invalid response received after authpass, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:420
+#: plugins/check_smtp.c:421
 msgid "only authtype LOGIN is supported, "
 msgstr ""
 
-#: plugins/check_smtp.c:444
+#: plugins/check_smtp.c:445
 #, fuzzy, c-format
 msgid "SMTP %s - %s%.3f sec. response time%s%s|%s\n"
 msgstr " - %s - %.3f Sekunden Antwortzeit %s%s|%s %s\n"
 
-#: plugins/check_smtp.c:556 plugins/check_smtp.c:568
+#: plugins/check_smtp.c:562 plugins/check_smtp.c:574
 #, c-format
 msgid "Could not realloc() units [%d]\n"
 msgstr ""
 
-#: plugins/check_smtp.c:576
+#: plugins/check_smtp.c:582
 #, fuzzy
 msgid "Critical time must be a positive"
 msgstr "Critical time muss ein positiver Integer sein"
 
-#: plugins/check_smtp.c:584
+#: plugins/check_smtp.c:590
 #, fuzzy
 msgid "Warning time must be a positive"
 msgstr "Warnung time muss ein positiver Integer sein"
 
-#: plugins/check_smtp.c:627
+#: plugins/check_smtp.c:633 plugins/check_smtp.c:644
 msgid "SSL support not available - install OpenSSL and recompile"
 msgstr ""
 
-#: plugins/check_smtp.c:705 plugins/check_smtp.c:710
+#: plugins/check_smtp.c:718 plugins/check_smtp.c:723
 #, c-format
 msgid "Connection closed by server before sending QUIT command\n"
 msgstr ""
 
-#: plugins/check_smtp.c:720
+#: plugins/check_smtp.c:733
 #, fuzzy, c-format
 msgid "recv() failed after QUIT."
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:722
+#: plugins/check_smtp.c:735
 #, c-format
 msgid "Connection reset by peer."
 msgstr ""
 
-#: plugins/check_smtp.c:812
+#: plugins/check_smtp.c:825
 #, fuzzy
 msgid "This plugin will attempt to open an SMTP connection with the host."
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_smtp.c:826
+#: plugins/check_smtp.c:839
 #, c-format
 msgid "    String to expect in first line of server response (default: '%s')\n"
 msgstr ""
 
-#: plugins/check_smtp.c:828
+#: plugins/check_smtp.c:841
 msgid "SMTP command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:830
+#: plugins/check_smtp.c:843
 msgid "Expected response to command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:832
+#: plugins/check_smtp.c:845
 msgid "FROM-address to include in MAIL command, required by Exchange 2000"
 msgstr ""
 
-#: plugins/check_smtp.c:834
+#: plugins/check_smtp.c:847
 msgid "FQDN used for HELO"
 msgstr ""
 
-#: plugins/check_smtp.c:836
+#: plugins/check_smtp.c:849
 msgid "Use PROXY protocol prefix for the connection."
 msgstr "Benutze PROXY-Protokoll-Präfix für die Verbindung."
 
-#: plugins/check_smtp.c:839 plugins/check_tcp.c:689
+#: plugins/check_smtp.c:852 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."
 msgstr ""
 
-#: plugins/check_smtp.c:841
+#: plugins/check_smtp.c:854
 msgid "Use STARTTLS for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:845
+#: plugins/check_smtp.c:860
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"
 msgstr ""
 
-#: plugins/check_smtp.c:847
+#: plugins/check_smtp.c:862
 msgid "SMTP AUTH username"
 msgstr ""
 
-#: plugins/check_smtp.c:849
+#: plugins/check_smtp.c:864
 msgid "SMTP AUTH password"
 msgstr ""
 
-#: plugins/check_smtp.c:851
+#: plugins/check_smtp.c:866
 msgid "Send LHLO instead of HELO/EHLO"
 msgstr ""
 
-#: plugins/check_smtp.c:853
+#: plugins/check_smtp.c:868
 msgid "Ignore failure when sending QUIT command to server"
 msgstr ""
 
-#: plugins/check_smtp.c:863
+#: plugins/check_smtp.c:878
 msgid "STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful"
 msgstr ""
 
-#: plugins/check_smtp.c:864
+#: plugins/check_smtp.c:879
 msgid "connects, but incorrect response messages from the host result in"
 msgstr ""
 
-#: plugins/check_smtp.c:865
+#: plugins/check_smtp.c:880
 msgid "STATE_WARNING return values."
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2023-06-12 16:29+0200\n"
+"POT-Creation-Date: 2023-06-12 20:31+0200\n"
 "PO-Revision-Date: 2010-04-21 23:38-0400\n"
 "Last-Translator: Thomas Guyot-Sionnest <dermoth@aei.ca>\n"
 "Language-Team: Nagios Plugin Development Mailing List <nagiosplug-"
@@ -31,7 +31,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:557
 #: plugins/check_nwstat.c:173 plugins/check_overcr.c:102
 #: plugins/check_pgsql.c:174 plugins/check_ping.c:97 plugins/check_procs.c:176
-#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:145
+#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:146
 #: plugins/check_snmp.c:248 plugins/check_ssh.c:74 plugins/check_swap.c:115
 #: plugins/check_tcp.c:222 plugins/check_time.c:78 plugins/check_ups.c:122
 #: plugins/check_users.c:84 plugins/negate.c:210 plugins-root/check_dhcp.c:270
@@ -71,14 +71,14 @@ msgstr "%s: Erreur d'analyse du résultat\n"
 
 #: plugins/check_by_ssh.c:242 plugins/check_disk.c:568 plugins/check_http.c:292
 #: plugins/check_ldap.c:334 plugins/check_pgsql.c:314 plugins/check_procs.c:461
-#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:601
+#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:607
 #: plugins/check_snmp.c:789 plugins/check_ssh.c:140 plugins/check_tcp.c:519
 #: plugins/check_time.c:302 plugins/check_ups.c:559 plugins/negate.c:160
 msgid "Timeout interval must be a positive integer"
 msgstr "Le délai d'attente doit être un entier positif"
 
 #: plugins/check_by_ssh.c:254 plugins/check_pgsql.c:344
-#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:526
+#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:532
 #: plugins/check_tcp.c:525 plugins/check_time.c:296 plugins/check_ups.c:521
 msgid "Port must be a positive integer"
 msgstr "Le numéro du port doit être un entier positif"
@@ -258,7 +258,7 @@ msgstr "Exemples:"
 #: plugins/check_ntp_peer.c:753 plugins/check_ntp_time.c:651
 #: plugins/check_nwstat.c:1685 plugins/check_overcr.c:467
 #: plugins/check_pgsql.c:551 plugins/check_ping.c:617 plugins/check_procs.c:829
-#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:875
+#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:890
 #: plugins/check_snmp.c:1346 plugins/check_ssh.c:325 plugins/check_swap.c:607
 #: plugins/check_tcp.c:710 plugins/check_time.c:371 plugins/check_ups.c:663
 #: plugins/check_users.c:262 plugins/check_ide_smart.c:606 plugins/negate.c:273
@@ -994,8 +994,8 @@ msgstr "FPING %s - %s (perte=%.0f%% )|%s\n"
 #: plugins/check_ntp.c:719 plugins/check_ntp_peer.c:497
 #: plugins/check_ntp_time.c:498 plugins/check_pgsql.c:338
 #: plugins/check_ping.c:301 plugins/check_ping.c:424 plugins/check_radius.c:279
-#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:519
-#: plugins/check_smtp.c:667 plugins/check_ssh.c:162 plugins/check_time.c:240
+#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:525
+#: plugins/check_smtp.c:680 plugins/check_ssh.c:162 plugins/check_time.c:240
 #: plugins/check_time.c:315 plugins/check_ups.c:507 plugins/check_ups.c:576
 msgid "Invalid hostname/address"
 msgstr "Adresse/Nom d'hôte invalide"
@@ -1268,7 +1268,7 @@ msgid "file does not exist or is not readable"
 msgstr ""
 
 #: plugins/check_http.c:324 plugins/check_http.c:329 plugins/check_http.c:335
-#: plugins/check_smtp.c:615 plugins/check_tcp.c:590 plugins/check_tcp.c:595
+#: plugins/check_smtp.c:621 plugins/check_tcp.c:590 plugins/check_tcp.c:595
 #: plugins/check_tcp.c:601
 msgid "Invalid certificate expiration period"
 msgstr "Période d'expiration du certificat invalide"
@@ -1307,7 +1307,7 @@ msgstr "Impossible de compiler l'expression rationnelle: %s"
 
 #: plugins/check_http.c:521 plugins/check_ntp.c:732
 #: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:517
-#: plugins/check_smtp.c:647 plugins/check_ssh.c:151 plugins/check_tcp.c:491
+#: plugins/check_smtp.c:660 plugins/check_ssh.c:151 plugins/check_tcp.c:491
 msgid "IPv6 support not available"
 msgstr "Support IPv6 non disponible"
 
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."
 msgstr ""
 
-#: plugins/check_http.c:1749
+#: plugins/check_http.c:1749 plugins/check_smtp.c:856
 msgid "Enable SSL/TLS hostname extension support (SNI)"
 msgstr ""
 
@@ -4460,7 +4460,7 @@ msgstr "Manque de Mémoire?"
 msgid "Invalid NAS-Identifier\n"
 msgstr "NAS-Identifier invalide"
 
-#: plugins/check_radius.c:199 plugins/check_smtp.c:155
+#: plugins/check_radius.c:199 plugins/check_smtp.c:156
 #, c-format
 msgid "gethostname() failed!\n"
 msgstr "La commande gethostname() à échoué\n"
@@ -4651,7 +4651,7 @@ msgstr ""
 msgid "This plugin will attempt to open an RTSP connection with the host."
 msgstr "Ce plugin va essayer d'ouvrir un connexion RTSP avec l'hôte."
 
-#: plugins/check_real.c:439 plugins/check_smtp.c:862
+#: plugins/check_real.c:439 plugins/check_smtp.c:877
 msgid "Successful connects return STATE_OK, refusals and timeouts return"
 msgstr ""
 
@@ -4669,224 +4669,224 @@ msgstr ""
 msgid "values."
 msgstr ""
 
-#: plugins/check_smtp.c:151 plugins/check_swap.c:283 plugins/check_swap.c:289
+#: plugins/check_smtp.c:152 plugins/check_swap.c:283 plugins/check_swap.c:289
 #, c-format
 msgid "malloc() failed!\n"
 msgstr "l'allocation mémoire à échoué!\n"
 
-#: plugins/check_smtp.c:199 plugins/check_smtp.c:211
+#: plugins/check_smtp.c:200 plugins/check_smtp.c:212
 #, c-format
 msgid "recv() failed\n"
 msgstr "La commande recv() à échoué\n"
 
-#: plugins/check_smtp.c:221
+#: plugins/check_smtp.c:222
 #, c-format
 msgid "WARNING - TLS not supported by server\n"
 msgstr "AVERTISSEMENT: - TLS n'est pas supporté par ce serveur\n"
 
-#: plugins/check_smtp.c:233
+#: plugins/check_smtp.c:234
 #, c-format
 msgid "Server does not support STARTTLS\n"
 msgstr "Le serveur ne supporte pas STARTTLS\n"
 
-#: plugins/check_smtp.c:239
+#: plugins/check_smtp.c:240
 #, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr "CRITIQUE - Impossible de créer le contexte SSL.\n"
 
-#: plugins/check_smtp.c:259
+#: plugins/check_smtp.c:260
 msgid "SMTP UNKNOWN - Cannot send EHLO command via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:264
+#: plugins/check_smtp.c:265
 #, c-format
 msgid "sent %s"
 msgstr "envoyé %s"
 
-#: plugins/check_smtp.c:266
+#: plugins/check_smtp.c:267
 msgid "SMTP UNKNOWN - Cannot read EHLO response via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:296
+#: plugins/check_smtp.c:297
 #, c-format
 msgid "Invalid SMTP response received from host: %s\n"
 msgstr "Réponse SMTP reçue de l'hôte invalide: %s\n"
 
-#: plugins/check_smtp.c:298
+#: plugins/check_smtp.c:299
 #, c-format
 msgid "Invalid SMTP response received from host on port %d: %s\n"
 msgstr "Réponse SMTP reçue de l'hôte sur le port %d invalide: %s\n"
 
-#: plugins/check_smtp.c:321 plugins/check_snmp.c:865
+#: plugins/check_smtp.c:322 plugins/check_snmp.c:865
 #, c-format
 msgid "Could Not Compile Regular Expression"
 msgstr "Impossible de compiler l'expression rationnelle"
 
-#: plugins/check_smtp.c:330
+#: plugins/check_smtp.c:331
 #, c-format
 msgid "SMTP %s - Invalid response '%s' to command '%s'\n"
 msgstr "SMTP %s - réponse invalide de '%s' à la commande '%s'\n"
 
-#: plugins/check_smtp.c:334 plugins/check_snmp.c:540
+#: plugins/check_smtp.c:335 plugins/check_snmp.c:540
 #, c-format
 msgid "Execute Error: %s\n"
 msgstr "Erreur d'exécution: %s\n"
 
-#: plugins/check_smtp.c:348
+#: plugins/check_smtp.c:349
 msgid "no authuser specified, "
 msgstr "Pas d'utilisateur pour l'authentification spécifié, "
 
-#: plugins/check_smtp.c:353
+#: plugins/check_smtp.c:354
 msgid "no authpass specified, "
 msgstr "pas de mot de passe spécifié, "
 
-#: plugins/check_smtp.c:360 plugins/check_smtp.c:381 plugins/check_smtp.c:401
-#: plugins/check_smtp.c:714
+#: plugins/check_smtp.c:361 plugins/check_smtp.c:382 plugins/check_smtp.c:402
+#: plugins/check_smtp.c:727
 #, c-format
 msgid "sent %s\n"
 msgstr "envoyé %s\n"
 
-#: plugins/check_smtp.c:363
+#: plugins/check_smtp.c:364
 msgid "recv() failed after AUTH LOGIN, "
 msgstr "recv() à échoué après AUTH LOGIN, "
 
-#: plugins/check_smtp.c:368 plugins/check_smtp.c:389 plugins/check_smtp.c:409
-#: plugins/check_smtp.c:725
+#: plugins/check_smtp.c:369 plugins/check_smtp.c:390 plugins/check_smtp.c:410
+#: plugins/check_smtp.c:738
 #, c-format
 msgid "received %s\n"
 msgstr "reçu %s\n"
 
-#: plugins/check_smtp.c:372
+#: plugins/check_smtp.c:373
 msgid "invalid response received after AUTH LOGIN, "
 msgstr "Réponse invalide reçue après AUTH LOGIN, "
 
-#: plugins/check_smtp.c:385
+#: plugins/check_smtp.c:386
 msgid "recv() failed after sending authuser, "
 msgstr "La commande recv() a échoué après authuser, "
 
-#: plugins/check_smtp.c:393
+#: plugins/check_smtp.c:394
 msgid "invalid response received after authuser, "
 msgstr "Réponse invalide reçue après authuser, "
 
-#: plugins/check_smtp.c:405
+#: plugins/check_smtp.c:406
 msgid "recv() failed after sending authpass, "
 msgstr "la commande recv() à échoué après authpass, "
 
-#: plugins/check_smtp.c:413
+#: plugins/check_smtp.c:414
 msgid "invalid response received after authpass, "
 msgstr "Réponse invalide reçue après authpass, "
 
-#: plugins/check_smtp.c:420
+#: plugins/check_smtp.c:421
 msgid "only authtype LOGIN is supported, "
 msgstr "seul la méthode d'authentification LOGIN est supportée, "
 
-#: plugins/check_smtp.c:444
+#: plugins/check_smtp.c:445
 #, c-format
 msgid "SMTP %s - %s%.3f sec. response time%s%s|%s\n"
 msgstr "SMTP %s - %s%.3f sec. de temps de réponse%s%s|%s\n"
 
-#: plugins/check_smtp.c:556 plugins/check_smtp.c:568
+#: plugins/check_smtp.c:562 plugins/check_smtp.c:574
 #, c-format
 msgid "Could not realloc() units [%d]\n"
 msgstr "Impossible de réallouer des unités [%d]\n"
 
-#: plugins/check_smtp.c:576
+#: plugins/check_smtp.c:582
 #, fuzzy
 msgid "Critical time must be a positive"
 msgstr "Le seuil critique doit être un entier positif"
 
-#: plugins/check_smtp.c:584
+#: plugins/check_smtp.c:590
 #, fuzzy
 msgid "Warning time must be a positive"
 msgstr "Le seuil d'avertissement doit être un entier positif"
 
-#: plugins/check_smtp.c:627
+#: plugins/check_smtp.c:633 plugins/check_smtp.c:644
 msgid "SSL support not available - install OpenSSL and recompile"
 msgstr "SSL n'est pas disponible - installer OpenSSL et recompilez"
 
-#: plugins/check_smtp.c:705 plugins/check_smtp.c:710
+#: plugins/check_smtp.c:718 plugins/check_smtp.c:723
 #, c-format
 msgid "Connection closed by server before sending QUIT command\n"
 msgstr ""
 
-#: plugins/check_smtp.c:720
+#: plugins/check_smtp.c:733
 #, c-format
 msgid "recv() failed after QUIT."
 msgstr "recv() à échoué après QUIT."
 
-#: plugins/check_smtp.c:722
+#: plugins/check_smtp.c:735
 #, c-format
 msgid "Connection reset by peer."
 msgstr ""
 
-#: plugins/check_smtp.c:812
+#: plugins/check_smtp.c:825
 msgid "This plugin will attempt to open an SMTP connection with the host."
 msgstr "Ce plugin va essayer d'ouvrir un connexion SMTP avec l'hôte."
 
-#: plugins/check_smtp.c:826
+#: plugins/check_smtp.c:839
 #, c-format
 msgid "    String to expect in first line of server response (default: '%s')\n"
 msgstr ""
 "   Texte attendu dans la première ligne de réponse du serveur (défaut: "
 "'%s')\n"
 
-#: plugins/check_smtp.c:828
+#: plugins/check_smtp.c:841
 msgid "SMTP command (may be used repeatedly)"
 msgstr "Commande SMTP (peut être utilisé plusieurs fois)"
 
-#: plugins/check_smtp.c:830
+#: plugins/check_smtp.c:843
 msgid "Expected response to command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:832
+#: plugins/check_smtp.c:845
 msgid "FROM-address to include in MAIL command, required by Exchange 2000"
 msgstr ""
 
-#: plugins/check_smtp.c:834
+#: plugins/check_smtp.c:847
 msgid "FQDN used for HELO"
 msgstr ""
 
-#: plugins/check_smtp.c:836
+#: plugins/check_smtp.c:849
 msgid "Use PROXY protocol prefix for the connection."
 msgstr "Utiliser le préfixe du protocole PROXY pour la connexion."
 
-#: plugins/check_smtp.c:839 plugins/check_tcp.c:689
+#: plugins/check_smtp.c:852 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."
 msgstr "Nombre de jours minimum pour que le certificat soit valide."
 
-#: plugins/check_smtp.c:841
+#: plugins/check_smtp.c:854
 msgid "Use STARTTLS for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:845
+#: plugins/check_smtp.c:860
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"
 msgstr ""
 
-#: plugins/check_smtp.c:847
+#: plugins/check_smtp.c:862
 msgid "SMTP AUTH username"
 msgstr ""
 
-#: plugins/check_smtp.c:849
+#: plugins/check_smtp.c:864
 msgid "SMTP AUTH password"
 msgstr ""
 
-#: plugins/check_smtp.c:851
+#: plugins/check_smtp.c:866
 msgid "Send LHLO instead of HELO/EHLO"
 msgstr ""
 
-#: plugins/check_smtp.c:853
+#: plugins/check_smtp.c:868
 msgid "Ignore failure when sending QUIT command to server"
 msgstr ""
 
-#: plugins/check_smtp.c:863
+#: plugins/check_smtp.c:878
 msgid "STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful"
 msgstr ""
 
-#: plugins/check_smtp.c:864
+#: plugins/check_smtp.c:879
 msgid "connects, but incorrect response messages from the host result in"
 msgstr ""
 
-#: plugins/check_smtp.c:865
+#: plugins/check_smtp.c:880
 msgid "STATE_WARNING return values."
 msgstr ""
 

--- a/po/monitoring-plugins.pot
+++ b/po/monitoring-plugins.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2023-06-12 16:29+0200\n"
+"POT-Creation-Date: 2023-06-12 20:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,7 +27,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:557
 #: plugins/check_nwstat.c:173 plugins/check_overcr.c:102
 #: plugins/check_pgsql.c:174 plugins/check_ping.c:97 plugins/check_procs.c:176
-#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:145
+#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:146
 #: plugins/check_snmp.c:248 plugins/check_ssh.c:74 plugins/check_swap.c:115
 #: plugins/check_tcp.c:222 plugins/check_time.c:78 plugins/check_ups.c:122
 #: plugins/check_users.c:84 plugins/negate.c:210 plugins-root/check_dhcp.c:270
@@ -67,14 +67,14 @@ msgstr ""
 
 #: plugins/check_by_ssh.c:242 plugins/check_disk.c:568 plugins/check_http.c:292
 #: plugins/check_ldap.c:334 plugins/check_pgsql.c:314 plugins/check_procs.c:461
-#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:601
+#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:607
 #: plugins/check_snmp.c:789 plugins/check_ssh.c:140 plugins/check_tcp.c:519
 #: plugins/check_time.c:302 plugins/check_ups.c:559 plugins/negate.c:160
 msgid "Timeout interval must be a positive integer"
 msgstr ""
 
 #: plugins/check_by_ssh.c:254 plugins/check_pgsql.c:344
-#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:526
+#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:532
 #: plugins/check_tcp.c:525 plugins/check_time.c:296 plugins/check_ups.c:521
 msgid "Port must be a positive integer"
 msgstr ""
@@ -243,7 +243,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:753 plugins/check_ntp_time.c:651
 #: plugins/check_nwstat.c:1685 plugins/check_overcr.c:467
 #: plugins/check_pgsql.c:551 plugins/check_ping.c:617 plugins/check_procs.c:829
-#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:875
+#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:890
 #: plugins/check_snmp.c:1346 plugins/check_ssh.c:325 plugins/check_swap.c:607
 #: plugins/check_tcp.c:710 plugins/check_time.c:371 plugins/check_ups.c:663
 #: plugins/check_users.c:262 plugins/check_ide_smart.c:606 plugins/negate.c:273
@@ -933,8 +933,8 @@ msgstr ""
 #: plugins/check_ntp.c:719 plugins/check_ntp_peer.c:497
 #: plugins/check_ntp_time.c:498 plugins/check_pgsql.c:338
 #: plugins/check_ping.c:301 plugins/check_ping.c:424 plugins/check_radius.c:279
-#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:519
-#: plugins/check_smtp.c:667 plugins/check_ssh.c:162 plugins/check_time.c:240
+#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:525
+#: plugins/check_smtp.c:680 plugins/check_ssh.c:162 plugins/check_time.c:240
 #: plugins/check_time.c:315 plugins/check_ups.c:507 plugins/check_ups.c:576
 msgid "Invalid hostname/address"
 msgstr ""
@@ -1187,7 +1187,7 @@ msgid "file does not exist or is not readable"
 msgstr ""
 
 #: plugins/check_http.c:324 plugins/check_http.c:329 plugins/check_http.c:335
-#: plugins/check_smtp.c:615 plugins/check_tcp.c:590 plugins/check_tcp.c:595
+#: plugins/check_smtp.c:621 plugins/check_tcp.c:590 plugins/check_tcp.c:595
 #: plugins/check_tcp.c:601
 msgid "Invalid certificate expiration period"
 msgstr ""
@@ -1226,7 +1226,7 @@ msgstr ""
 
 #: plugins/check_http.c:521 plugins/check_ntp.c:732
 #: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:517
-#: plugins/check_smtp.c:647 plugins/check_ssh.c:151 plugins/check_tcp.c:491
+#: plugins/check_smtp.c:660 plugins/check_ssh.c:151 plugins/check_tcp.c:491
 msgid "IPv6 support not available"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."
 msgstr ""
 
-#: plugins/check_http.c:1749
+#: plugins/check_http.c:1749 plugins/check_smtp.c:856
 msgid "Enable SSL/TLS hostname extension support (SNI)"
 msgstr ""
 
@@ -4271,7 +4271,7 @@ msgstr ""
 msgid "Invalid NAS-Identifier\n"
 msgstr ""
 
-#: plugins/check_radius.c:199 plugins/check_smtp.c:155
+#: plugins/check_radius.c:199 plugins/check_smtp.c:156
 #, c-format
 msgid "gethostname() failed!\n"
 msgstr ""
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "This plugin will attempt to open an RTSP connection with the host."
 msgstr ""
 
-#: plugins/check_real.c:439 plugins/check_smtp.c:862
+#: plugins/check_real.c:439 plugins/check_smtp.c:877
 msgid "Successful connects return STATE_OK, refusals and timeouts return"
 msgstr ""
 
@@ -4471,220 +4471,220 @@ msgstr ""
 msgid "values."
 msgstr ""
 
-#: plugins/check_smtp.c:151 plugins/check_swap.c:283 plugins/check_swap.c:289
+#: plugins/check_smtp.c:152 plugins/check_swap.c:283 plugins/check_swap.c:289
 #, c-format
 msgid "malloc() failed!\n"
 msgstr ""
 
-#: plugins/check_smtp.c:199 plugins/check_smtp.c:211
+#: plugins/check_smtp.c:200 plugins/check_smtp.c:212
 #, c-format
 msgid "recv() failed\n"
 msgstr ""
 
-#: plugins/check_smtp.c:221
+#: plugins/check_smtp.c:222
 #, c-format
 msgid "WARNING - TLS not supported by server\n"
 msgstr ""
 
-#: plugins/check_smtp.c:233
+#: plugins/check_smtp.c:234
 #, c-format
 msgid "Server does not support STARTTLS\n"
 msgstr ""
 
-#: plugins/check_smtp.c:239
+#: plugins/check_smtp.c:240
 #, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr ""
 
-#: plugins/check_smtp.c:259
+#: plugins/check_smtp.c:260
 msgid "SMTP UNKNOWN - Cannot send EHLO command via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:264
+#: plugins/check_smtp.c:265
 #, c-format
 msgid "sent %s"
 msgstr ""
 
-#: plugins/check_smtp.c:266
+#: plugins/check_smtp.c:267
 msgid "SMTP UNKNOWN - Cannot read EHLO response via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:296
+#: plugins/check_smtp.c:297
 #, c-format
 msgid "Invalid SMTP response received from host: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:298
+#: plugins/check_smtp.c:299
 #, c-format
 msgid "Invalid SMTP response received from host on port %d: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:321 plugins/check_snmp.c:865
+#: plugins/check_smtp.c:322 plugins/check_snmp.c:865
 #, c-format
 msgid "Could Not Compile Regular Expression"
 msgstr ""
 
-#: plugins/check_smtp.c:330
+#: plugins/check_smtp.c:331
 #, c-format
 msgid "SMTP %s - Invalid response '%s' to command '%s'\n"
 msgstr ""
 
-#: plugins/check_smtp.c:334 plugins/check_snmp.c:540
+#: plugins/check_smtp.c:335 plugins/check_snmp.c:540
 #, c-format
 msgid "Execute Error: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:348
+#: plugins/check_smtp.c:349
 msgid "no authuser specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:353
+#: plugins/check_smtp.c:354
 msgid "no authpass specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:360 plugins/check_smtp.c:381 plugins/check_smtp.c:401
-#: plugins/check_smtp.c:714
+#: plugins/check_smtp.c:361 plugins/check_smtp.c:382 plugins/check_smtp.c:402
+#: plugins/check_smtp.c:727
 #, c-format
 msgid "sent %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:363
+#: plugins/check_smtp.c:364
 msgid "recv() failed after AUTH LOGIN, "
 msgstr ""
 
-#: plugins/check_smtp.c:368 plugins/check_smtp.c:389 plugins/check_smtp.c:409
-#: plugins/check_smtp.c:725
+#: plugins/check_smtp.c:369 plugins/check_smtp.c:390 plugins/check_smtp.c:410
+#: plugins/check_smtp.c:738
 #, c-format
 msgid "received %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:372
+#: plugins/check_smtp.c:373
 msgid "invalid response received after AUTH LOGIN, "
 msgstr ""
 
-#: plugins/check_smtp.c:385
+#: plugins/check_smtp.c:386
 msgid "recv() failed after sending authuser, "
 msgstr ""
 
-#: plugins/check_smtp.c:393
+#: plugins/check_smtp.c:394
 msgid "invalid response received after authuser, "
 msgstr ""
 
-#: plugins/check_smtp.c:405
+#: plugins/check_smtp.c:406
 msgid "recv() failed after sending authpass, "
 msgstr ""
 
-#: plugins/check_smtp.c:413
+#: plugins/check_smtp.c:414
 msgid "invalid response received after authpass, "
 msgstr ""
 
-#: plugins/check_smtp.c:420
+#: plugins/check_smtp.c:421
 msgid "only authtype LOGIN is supported, "
 msgstr ""
 
-#: plugins/check_smtp.c:444
+#: plugins/check_smtp.c:445
 #, c-format
 msgid "SMTP %s - %s%.3f sec. response time%s%s|%s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:556 plugins/check_smtp.c:568
+#: plugins/check_smtp.c:562 plugins/check_smtp.c:574
 #, c-format
 msgid "Could not realloc() units [%d]\n"
 msgstr ""
 
-#: plugins/check_smtp.c:576
+#: plugins/check_smtp.c:582
 msgid "Critical time must be a positive"
 msgstr ""
 
-#: plugins/check_smtp.c:584
+#: plugins/check_smtp.c:590
 msgid "Warning time must be a positive"
 msgstr ""
 
-#: plugins/check_smtp.c:627
+#: plugins/check_smtp.c:633 plugins/check_smtp.c:644
 msgid "SSL support not available - install OpenSSL and recompile"
 msgstr ""
 
-#: plugins/check_smtp.c:705 plugins/check_smtp.c:710
+#: plugins/check_smtp.c:718 plugins/check_smtp.c:723
 #, c-format
 msgid "Connection closed by server before sending QUIT command\n"
 msgstr ""
 
-#: plugins/check_smtp.c:720
+#: plugins/check_smtp.c:733
 #, c-format
 msgid "recv() failed after QUIT."
 msgstr ""
 
-#: plugins/check_smtp.c:722
+#: plugins/check_smtp.c:735
 #, c-format
 msgid "Connection reset by peer."
 msgstr ""
 
-#: plugins/check_smtp.c:812
+#: plugins/check_smtp.c:825
 msgid "This plugin will attempt to open an SMTP connection with the host."
 msgstr ""
 
-#: plugins/check_smtp.c:826
+#: plugins/check_smtp.c:839
 #, c-format
 msgid "    String to expect in first line of server response (default: '%s')\n"
 msgstr ""
 
-#: plugins/check_smtp.c:828
+#: plugins/check_smtp.c:841
 msgid "SMTP command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:830
+#: plugins/check_smtp.c:843
 msgid "Expected response to command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:832
+#: plugins/check_smtp.c:845
 msgid "FROM-address to include in MAIL command, required by Exchange 2000"
 msgstr ""
 
-#: plugins/check_smtp.c:834
+#: plugins/check_smtp.c:847
 msgid "FQDN used for HELO"
 msgstr ""
 
-#: plugins/check_smtp.c:836
+#: plugins/check_smtp.c:849
 msgid "Use PROXY protocol prefix for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:839 plugins/check_tcp.c:689
+#: plugins/check_smtp.c:852 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."
 msgstr ""
 
-#: plugins/check_smtp.c:841
+#: plugins/check_smtp.c:854
 msgid "Use STARTTLS for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:845
+#: plugins/check_smtp.c:860
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"
 msgstr ""
 
-#: plugins/check_smtp.c:847
+#: plugins/check_smtp.c:862
 msgid "SMTP AUTH username"
 msgstr ""
 
-#: plugins/check_smtp.c:849
+#: plugins/check_smtp.c:864
 msgid "SMTP AUTH password"
 msgstr ""
 
-#: plugins/check_smtp.c:851
+#: plugins/check_smtp.c:866
 msgid "Send LHLO instead of HELO/EHLO"
 msgstr ""
 
-#: plugins/check_smtp.c:853
+#: plugins/check_smtp.c:868
 msgid "Ignore failure when sending QUIT command to server"
 msgstr ""
 
-#: plugins/check_smtp.c:863
+#: plugins/check_smtp.c:878
 msgid "STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful"
 msgstr ""
 
-#: plugins/check_smtp.c:864
+#: plugins/check_smtp.c:879
 msgid "connects, but incorrect response messages from the host result in"
 msgstr ""
 
-#: plugins/check_smtp.c:865
+#: plugins/check_smtp.c:880
 msgid "STATE_WARNING return values."
 msgstr ""
 


### PR DESCRIPTION
Add support for SSL/TLS hostname extension support (SNI) for check_smtp
plugin.

Backported from nagios-plugins:
https://github.com/nagios-plugins/nagios-plugins/commit/9f1628f4b5525335ce1d6e48e8ac8b07d0757f82

Compiled and successfully tested new `--sni` option