### PR TITLE
Add support for SMTP over TLS

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -505,6 +505,7 @@ process_arguments (int argc, char **argv)
 		{"help", no_argument, 0, 'h'},
 		{"lmtp", no_argument, 0, 'L'},
 		{"ssl", no_argument, 0, 's'},
+		{"tls", no_argument, 0, 's'},
 		{"starttls",no_argument,0,'S'},
 		{"sni", no_argument, 0, SNI_OPTION},
 		{"certificate",required_argument,0,'D'},
@@ -715,7 +716,7 @@ process_arguments (int argc, char **argv)
 		from_arg = strdup(" ");
 
 	if (use_starttls && use_ssl) {
-		usage4 (_("Set either -s/--ssl or -S/--starttls"));
+		usage4 (_("Set either -s/--ssl/--tls or -S/--starttls"));
 	}
 
 	return validate_arguments ();
@@ -875,7 +876,7 @@ print_help (void)
 #ifdef HAVE_SSL
   printf (" %s\n", "-D, --certificate=INTEGER[,INTEGER]");
   printf ("    %s\n", _("Minimum number of days a certificate has to be valid."));
-  printf (" %s\n", "-s, --ssl");
+  printf (" %s\n", "-s, --ssl, --tls");
   printf ("    %s\n", _("Use SSL/TLS for the connection."));
   printf (_("    Sets default port to %d.\n"), SMTPS_PORT);
   printf (" %s\n", "-S, --starttls");

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -50,7 +50,8 @@ int days_till_exp_warn, days_till_exp_crit;
 #endif
 
 enum {
-	SMTP_PORT	= 25
+	SMTP_PORT	= 25,
+	SMTPS_PORT	= 465
 };
 #define PROXY_PREFIX "PROXY TCP4 0.0.0.0 0.0.0.0 25 25\r\n"
 #define SMTP_EXPECT "220"
@@ -650,6 +651,7 @@ process_arguments (int argc, char **argv)
 		case 's':
 		/* ssl */
 			use_ssl = TRUE;
+			server_port = SMTPS_PORT;
 			break;
 		case 'S':
 		/* starttls */
@@ -879,6 +881,7 @@ print_help (void)
   printf ("    %s\n", _("Minimum number of days a certificate has to be valid."));
   printf (" %s\n", "-s, --ssl");
   printf ("    %s\n", _("Use SSL/TLS for the connection."));
+  printf (_("    Sets default port to %d.\n"), SMTPS_PORT);
   printf (" %s\n", "-S, --starttls");
   printf ("    %s\n", _("Use STARTTLS for the connection."));
   printf (" %s\n", "--sni");

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -42,8 +42,8 @@ const char *email = "devel@monitoring-plugins.org";
 #ifdef HAVE_SSL
 int check_cert = FALSE;
 int days_till_exp_warn, days_till_exp_crit;
-#  define my_recv(buf, len) ((use_ssl && ssl_established) ? np_net_ssl_read(buf, len) : read(sd, buf, len))
-#  define my_send(buf, len) ((use_ssl && ssl_established) ? np_net_ssl_write(buf, len) : send(sd, buf, len, 0))
+#  define my_recv(buf, len) (((use_starttls || use_ssl) && ssl_established) ? np_net_ssl_read(buf, len) : read(sd, buf, len))
+#  define my_send(buf, len) (((use_starttls || use_ssl) && ssl_established) ? np_net_ssl_write(buf, len) : send(sd, buf, len, 0))
 #else /* ifndef HAVE_SSL */
 #  define my_recv(buf, len) read(sd, buf, len)
 #  define my_send(buf, len) send(sd, buf, len, 0)
@@ -103,6 +103,7 @@ double critical_time = 0;
 int check_critical_time = FALSE;
 int verbose = 0;
 int use_ssl = FALSE;
+int use_starttls = FALSE;
 int use_sni = FALSE;
 short use_proxy_prefix = FALSE;
 short use_ehlo = FALSE;
@@ -186,12 +187,25 @@ main (int argc, char **argv)
 	result = my_tcp_connect (server_address, server_port, &sd);
 
 	if (result == STATE_OK) { /* we connected */
+#ifdef HAVE_SSL
+		if (use_ssl) {
+			result = np_net_ssl_init_with_hostname(sd, (use_sni ? server_address : NULL));
+			if (result != STATE_OK) {
+				printf (_("CRITICAL - Cannot create SSL context.\n"));
+				close(sd);
+				np_net_ssl_cleanup();
+				return STATE_CRITICAL;
+			} else {
+				ssl_established = 1;
+			}
+		}
+#endif
 
 		/* If requested, send PROXY header */
 		if (use_proxy_prefix) {
 			if (verbose)
 				printf ("Sending header %s\n", PROXY_PREFIX);
-			send(sd, PROXY_PREFIX, strlen(PROXY_PREFIX), 0);
+			my_send(PROXY_PREFIX, strlen(PROXY_PREFIX));
 		}
 
 		/* watch for the SMTP connection string and */
@@ -205,7 +219,7 @@ main (int argc, char **argv)
 		xasprintf(&server_response, "%s", buffer);
 
 		/* send the HELO/EHLO command */
-		send(sd, helocmd, strlen(helocmd), 0);
+		my_send(helocmd, strlen(helocmd));
 
 		/* allow for response to helo command to reach us */
 		if (recvlines(buffer, MAX_INPUT_BUFFER) <= 0) {
@@ -218,14 +232,14 @@ main (int argc, char **argv)
 			}
 		}
 
-		if(use_ssl && ! supports_tls){
+		if(use_starttls && ! supports_tls){
 			printf(_("WARNING - TLS not supported by server\n"));
 			smtp_quit();
 			return STATE_WARNING;
 		}
 
 #ifdef HAVE_SSL
-		if(use_ssl) {
+		if(use_starttls) {
 		  /* send the STARTTLS command */
 		  send(sd, SMTP_STARTTLS, strlen(SMTP_STARTTLS), 0);
 
@@ -489,6 +503,7 @@ process_arguments (int argc, char **argv)
 		{"use-ipv6", no_argument, 0, '6'},
 		{"help", no_argument, 0, 'h'},
 		{"lmtp", no_argument, 0, 'L'},
+		{"ssl", no_argument, 0, 's'},
 		{"starttls",no_argument,0,'S'},
 		{"sni", no_argument, 0, SNI_OPTION},
 		{"certificate",required_argument,0,'D'},
@@ -510,7 +525,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	while (1) {
-		c = getopt_long (argc, argv, "+hVv46Lrt:p:f:e:c:w:H:C:R:SD:F:A:U:P:q",
+		c = getopt_long (argc, argv, "+hVv46Lrt:p:f:e:c:w:H:C:R:sSD:F:A:U:P:q",
 		                 longopts, &option);
 
 		if (c == -1 || c == EOF)
@@ -632,10 +647,13 @@ process_arguments (int argc, char **argv)
 #else
 			usage (_("SSL support not available - install OpenSSL and recompile"));
 #endif
-			// fall through
+		case 's':
+		/* ssl */
+			use_ssl = TRUE;
+			break;
 		case 'S':
 		/* starttls */
-			use_ssl = TRUE;
+			use_starttls = TRUE;
 			use_ehlo = TRUE;
 			break;
 		case SNI_OPTION:
@@ -693,6 +711,14 @@ process_arguments (int argc, char **argv)
 
 	if (from_arg==NULL)
 		from_arg = strdup(" ");
+
+	if (use_starttls && use_ssl) {
+		usage4 (_("Set either -s/--ssl or -S/--starttls"));
+	}
+
+	if (use_ssl && use_proxy_prefix) {
+		usage4 (_("PROXY protocol (-r/--proxy) is not implemented with SSL/TLS (-s/--ssl), yet."));
+	}
 
 	return validate_arguments ();
 }
@@ -851,6 +877,8 @@ print_help (void)
 #ifdef HAVE_SSL
   printf (" %s\n", "-D, --certificate=INTEGER[,INTEGER]");
   printf ("    %s\n", _("Minimum number of days a certificate has to be valid."));
+  printf (" %s\n", "-s, --ssl");
+  printf ("    %s\n", _("Use SSL/TLS for the connection."));
   printf (" %s\n", "-S, --starttls");
   printf ("    %s\n", _("Use STARTTLS for the connection."));
   printf (" %s\n", "--sni");

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -84,6 +84,7 @@ int eflags = 0;
 int errcode, excode;
 
 int server_port = SMTP_PORT;
+int server_port_option = 0;
 char *server_address = NULL;
 char *server_expect = NULL;
 char *mail_command = NULL;
@@ -544,7 +545,7 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'p':									/* port */
 			if (is_intpos (optarg))
-				server_port = atoi (optarg);
+				server_port_option = atoi (optarg);
 			else
 				usage4 (_("Port must be a positive integer"));
 			break;
@@ -717,6 +718,10 @@ process_arguments (int argc, char **argv)
 
 	if (use_starttls && use_ssl) {
 		usage4 (_("Set either -s/--ssl/--tls or -S/--starttls"));
+	}
+
+	if (server_port_option != 0) {
+		server_port = server_port_option;
 	}
 
 	return validate_arguments ();

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -188,6 +188,13 @@ main (int argc, char **argv)
 	result = my_tcp_connect (server_address, server_port, &sd);
 
 	if (result == STATE_OK) { /* we connected */
+		/* If requested, send PROXY header */
+		if (use_proxy_prefix) {
+			if (verbose)
+				printf ("Sending header %s\n", PROXY_PREFIX);
+			my_send(PROXY_PREFIX, strlen(PROXY_PREFIX));
+		}
+
 #ifdef HAVE_SSL
 		if (use_ssl) {
 			result = np_net_ssl_init_with_hostname(sd, (use_sni ? server_address : NULL));
@@ -201,13 +208,6 @@ main (int argc, char **argv)
 			}
 		}
 #endif
-
-		/* If requested, send PROXY header */
-		if (use_proxy_prefix) {
-			if (verbose)
-				printf ("Sending header %s\n", PROXY_PREFIX);
-			my_send(PROXY_PREFIX, strlen(PROXY_PREFIX));
-		}
 
 		/* watch for the SMTP connection string and */
 		/* return a WARNING status if we couldn't read any data */
@@ -716,10 +716,6 @@ process_arguments (int argc, char **argv)
 
 	if (use_starttls && use_ssl) {
 		usage4 (_("Set either -s/--ssl or -S/--starttls"));
-	}
-
-	if (use_ssl && use_proxy_prefix) {
-		usage4 (_("PROXY protocol (-r/--proxy) is not implemented with SSL/TLS (-s/--ssl), yet."));
 	}
 
 	return validate_arguments ();

--- a/po/de.po
+++ b/po/de.po
@@ -4727,7 +4727,7 @@ msgstr ""
 
 #: plugins/check_smtp.c:720
 msgid "Set either -s/--ssl/--tls or -S/--starttls"
-msgstr ""
+msgstr "Setze entweder -s/--ssl/--tls oder -S/--starttls"
 
 #: plugins/check_smtp.c:749 plugins/check_smtp.c:754
 #, c-format
@@ -4781,16 +4781,16 @@ msgstr ""
 #: plugins/check_smtp.c:885
 #, fuzzy
 msgid "Use SSL/TLS for the connection."
-msgstr "Benutze PROXY-Protokoll-Präfix für die Verbindung."
+msgstr "Benutze SSL/TLS für die Verbindung."
 
 #: plugins/check_smtp.c:886
 #, c-format
 msgid "    Sets default port to %d.\n"
-msgstr ""
+msgstr "    Setze den Default-Port auf %d.\n"
 
 #: plugins/check_smtp.c:888
 msgid "Use STARTTLS for the connection."
-msgstr ""
+msgstr "Benutze STARTTLS für die Verbindung."
 
 #: plugins/check_smtp.c:894
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nagiosplug\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2023-08-28 14:50+0200\n"
+"POT-Creation-Date: 2023-08-29 09:47+0200\n"
 "PO-Revision-Date: 2004-12-23 17:46+0100\n"
 "Last-Translator:  <>\n"
 "Language-Team: English <en@li.org>\n"
@@ -28,7 +28,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:557
 #: plugins/check_nwstat.c:173 plugins/check_overcr.c:102
 #: plugins/check_pgsql.c:174 plugins/check_ping.c:97 plugins/check_procs.c:176
-#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:146
+#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:149
 #: plugins/check_snmp.c:250 plugins/check_ssh.c:74 plugins/check_swap.c:115
 #: plugins/check_tcp.c:222 plugins/check_time.c:78 plugins/check_ups.c:122
 #: plugins/check_users.c:89 plugins/negate.c:210 plugins-root/check_dhcp.c:270
@@ -68,14 +68,14 @@ msgstr ""
 
 #: plugins/check_by_ssh.c:242 plugins/check_disk.c:568 plugins/check_http.c:292
 #: plugins/check_ldap.c:334 plugins/check_pgsql.c:314 plugins/check_procs.c:461
-#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:607
+#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:625
 #: plugins/check_snmp.c:805 plugins/check_ssh.c:140 plugins/check_tcp.c:519
 #: plugins/check_time.c:302 plugins/check_ups.c:559 plugins/negate.c:160
 msgid "Timeout interval must be a positive integer"
 msgstr "Timeout interval muss ein positiver Integer sein"
 
 #: plugins/check_by_ssh.c:254 plugins/check_pgsql.c:344
-#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:532
+#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:550
 #: plugins/check_tcp.c:525 plugins/check_time.c:296 plugins/check_ups.c:521
 msgid "Port must be a positive integer"
 msgstr "Port muss ein positiver Integer sein"
@@ -252,7 +252,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:753 plugins/check_ntp_time.c:651
 #: plugins/check_nwstat.c:1685 plugins/check_overcr.c:467
 #: plugins/check_pgsql.c:551 plugins/check_ping.c:617 plugins/check_procs.c:829
-#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:891
+#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:924
 #: plugins/check_snmp.c:1368 plugins/check_ssh.c:325 plugins/check_swap.c:607
 #: plugins/check_tcp.c:710 plugins/check_time.c:371 plugins/check_ups.c:663
 #: plugins/check_users.c:275 plugins/check_ide_smart.c:606 plugins/negate.c:273
@@ -957,8 +957,8 @@ msgstr "FPING %s - %s (verloren=%.0f%% )|%s\n"
 #: plugins/check_ntp.c:719 plugins/check_ntp_peer.c:497
 #: plugins/check_ntp_time.c:498 plugins/check_pgsql.c:338
 #: plugins/check_ping.c:301 plugins/check_ping.c:424 plugins/check_radius.c:279
-#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:525
-#: plugins/check_smtp.c:681 plugins/check_ssh.c:162 plugins/check_time.c:240
+#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:543
+#: plugins/check_smtp.c:703 plugins/check_ssh.c:162 plugins/check_time.c:240
 #: plugins/check_time.c:315 plugins/check_ups.c:507 plugins/check_ups.c:576
 msgid "Invalid hostname/address"
 msgstr "Ungültige(r) Hostname/Adresse"
@@ -1227,7 +1227,7 @@ msgid "file does not exist or is not readable"
 msgstr ""
 
 #: plugins/check_http.c:324 plugins/check_http.c:329 plugins/check_http.c:335
-#: plugins/check_smtp.c:621 plugins/check_tcp.c:590 plugins/check_tcp.c:595
+#: plugins/check_smtp.c:639 plugins/check_tcp.c:590 plugins/check_tcp.c:595
 #: plugins/check_tcp.c:601
 msgid "Invalid certificate expiration period"
 msgstr "Ungültiger Zertifikatsablauftermin"
@@ -1267,7 +1267,7 @@ msgstr ""
 
 #: plugins/check_http.c:522 plugins/check_ntp.c:732
 #: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:517
-#: plugins/check_smtp.c:661 plugins/check_ssh.c:151 plugins/check_tcp.c:491
+#: plugins/check_smtp.c:683 plugins/check_ssh.c:151 plugins/check_tcp.c:491
 msgid "IPv6 support not available"
 msgstr "IPv6 Unterstützung nicht vorhanden"
 
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."
 msgstr ""
 
-#: plugins/check_http.c:1750 plugins/check_smtp.c:857
+#: plugins/check_http.c:1750 plugins/check_smtp.c:890
 msgid "Enable SSL/TLS hostname extension support (SNI)"
 msgstr ""
 
@@ -4376,7 +4376,7 @@ msgstr "Kein Papier"
 msgid "Invalid NAS-Identifier\n"
 msgstr "Ungültige(r) Hostname/Adresse"
 
-#: plugins/check_radius.c:199 plugins/check_smtp.c:156
+#: plugins/check_radius.c:199 plugins/check_smtp.c:159
 #, c-format
 msgid "gethostname() failed!\n"
 msgstr ""
@@ -4568,7 +4568,7 @@ msgstr ""
 msgid "This plugin will attempt to open an RTSP connection with the host."
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_real.c:439 plugins/check_smtp.c:878
+#: plugins/check_real.c:439 plugins/check_smtp.c:911
 msgid "Successful connects return STATE_OK, refusals and timeouts return"
 msgstr ""
 
@@ -4586,227 +4586,241 @@ msgstr ""
 msgid "values."
 msgstr ""
 
-#: plugins/check_smtp.c:152 plugins/check_swap.c:283 plugins/check_swap.c:289
+#: plugins/check_smtp.c:155 plugins/check_swap.c:283 plugins/check_swap.c:289
 #, c-format
 msgid "malloc() failed!\n"
 msgstr ""
 
-#: plugins/check_smtp.c:200 plugins/check_smtp.c:212
-#, c-format
-msgid "recv() failed\n"
-msgstr ""
-
-#: plugins/check_smtp.c:222
-#, c-format
-msgid "WARNING - TLS not supported by server\n"
-msgstr ""
-
-#: plugins/check_smtp.c:234
-#, c-format
-msgid "Server does not support STARTTLS\n"
-msgstr ""
-
-#: plugins/check_smtp.c:240
+#: plugins/check_smtp.c:203 plugins/check_smtp.c:256
 #, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr ""
 
-#: plugins/check_smtp.c:260
+#: plugins/check_smtp.c:216 plugins/check_smtp.c:228
+#, c-format
+msgid "recv() failed\n"
+msgstr ""
+
+#: plugins/check_smtp.c:238
+#, c-format
+msgid "WARNING - TLS not supported by server\n"
+msgstr ""
+
+#: plugins/check_smtp.c:250
+#, c-format
+msgid "Server does not support STARTTLS\n"
+msgstr ""
+
+#: plugins/check_smtp.c:276
 msgid "SMTP UNKNOWN - Cannot send EHLO command via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:265
+#: plugins/check_smtp.c:281
 #, c-format
 msgid "sent %s"
 msgstr ""
 
-#: plugins/check_smtp.c:267
+#: plugins/check_smtp.c:283
 msgid "SMTP UNKNOWN - Cannot read EHLO response via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:297
+#: plugins/check_smtp.c:313
 #, fuzzy, c-format
 msgid "Invalid SMTP response received from host: %s\n"
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:299
+#: plugins/check_smtp.c:315
 #, fuzzy, c-format
 msgid "Invalid SMTP response received from host on port %d: %s\n"
 msgstr "Ungültige HTTP Antwort von Host erhalten auf Port %d\n"
 
-#: plugins/check_smtp.c:322 plugins/check_snmp.c:882
+#: plugins/check_smtp.c:338 plugins/check_snmp.c:882
 #, c-format
 msgid "Could Not Compile Regular Expression"
 msgstr ""
 
-#: plugins/check_smtp.c:331
+#: plugins/check_smtp.c:347
 #, c-format
 msgid "SMTP %s - Invalid response '%s' to command '%s'\n"
 msgstr ""
 
-#: plugins/check_smtp.c:335 plugins/check_snmp.c:555
+#: plugins/check_smtp.c:351 plugins/check_snmp.c:555
 #, c-format
 msgid "Execute Error: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:349
+#: plugins/check_smtp.c:365
 msgid "no authuser specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:354
+#: plugins/check_smtp.c:370
 msgid "no authpass specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:361 plugins/check_smtp.c:382 plugins/check_smtp.c:402
-#: plugins/check_smtp.c:728
+#: plugins/check_smtp.c:377 plugins/check_smtp.c:398 plugins/check_smtp.c:418
+#: plugins/check_smtp.c:758
 #, c-format
 msgid "sent %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:364
+#: plugins/check_smtp.c:380
 #, fuzzy
 msgid "recv() failed after AUTH LOGIN, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:369 plugins/check_smtp.c:390 plugins/check_smtp.c:410
-#: plugins/check_smtp.c:739
+#: plugins/check_smtp.c:385 plugins/check_smtp.c:406 plugins/check_smtp.c:426
+#: plugins/check_smtp.c:769
 #, fuzzy, c-format
 msgid "received %s\n"
 msgstr "Keine Daten empfangen %s\n"
 
-#: plugins/check_smtp.c:373
+#: plugins/check_smtp.c:389
 #, fuzzy
 msgid "invalid response received after AUTH LOGIN, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:386
+#: plugins/check_smtp.c:402
 msgid "recv() failed after sending authuser, "
 msgstr ""
 
-#: plugins/check_smtp.c:394
+#: plugins/check_smtp.c:410
 #, fuzzy
 msgid "invalid response received after authuser, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:406
+#: plugins/check_smtp.c:422
 msgid "recv() failed after sending authpass, "
 msgstr ""
 
-#: plugins/check_smtp.c:414
+#: plugins/check_smtp.c:430
 #, fuzzy
 msgid "invalid response received after authpass, "
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:421
+#: plugins/check_smtp.c:437
 msgid "only authtype LOGIN is supported, "
 msgstr ""
 
-#: plugins/check_smtp.c:445
+#: plugins/check_smtp.c:461
 #, fuzzy, c-format
 msgid "SMTP %s - %s%.3f sec. response time%s%s|%s\n"
 msgstr " - %s - %.3f Sekunden Antwortzeit %s%s|%s %s\n"
 
-#: plugins/check_smtp.c:562 plugins/check_smtp.c:574
+#: plugins/check_smtp.c:580 plugins/check_smtp.c:592
 #, c-format
 msgid "Could not realloc() units [%d]\n"
 msgstr ""
 
-#: plugins/check_smtp.c:582
+#: plugins/check_smtp.c:600
 #, fuzzy
 msgid "Critical time must be a positive"
 msgstr "Critical time muss ein positiver Integer sein"
 
-#: plugins/check_smtp.c:590
+#: plugins/check_smtp.c:608
 #, fuzzy
 msgid "Warning time must be a positive"
 msgstr "Warnung time muss ein positiver Integer sein"
 
-#: plugins/check_smtp.c:633 plugins/check_smtp.c:645
+#: plugins/check_smtp.c:651 plugins/check_smtp.c:667
 msgid "SSL support not available - install OpenSSL and recompile"
 msgstr ""
 
-#: plugins/check_smtp.c:719 plugins/check_smtp.c:724
+#: plugins/check_smtp.c:720
+msgid "Set either -s/--ssl/--tls or -S/--starttls"
+msgstr ""
+
+#: plugins/check_smtp.c:749 plugins/check_smtp.c:754
 #, c-format
 msgid "Connection closed by server before sending QUIT command\n"
 msgstr ""
 
-#: plugins/check_smtp.c:734
+#: plugins/check_smtp.c:764
 #, fuzzy, c-format
 msgid "recv() failed after QUIT."
 msgstr "Ungültige HTTP Antwort von Host empfangen\n"
 
-#: plugins/check_smtp.c:736
+#: plugins/check_smtp.c:766
 #, c-format
 msgid "Connection reset by peer."
 msgstr ""
 
-#: plugins/check_smtp.c:826
+#: plugins/check_smtp.c:856
 #, fuzzy
 msgid "This plugin will attempt to open an SMTP connection with the host."
 msgstr "Dieses plugin testet Gameserververbindungen zum angegebenen Host."
 
-#: plugins/check_smtp.c:840
+#: plugins/check_smtp.c:870
 #, c-format
 msgid "    String to expect in first line of server response (default: '%s')\n"
 msgstr ""
 
-#: plugins/check_smtp.c:842
+#: plugins/check_smtp.c:872
 msgid "SMTP command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:844
+#: plugins/check_smtp.c:874
 msgid "Expected response to command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:846
+#: plugins/check_smtp.c:876
 msgid "FROM-address to include in MAIL command, required by Exchange 2000"
 msgstr ""
 
-#: plugins/check_smtp.c:848
+#: plugins/check_smtp.c:878
 msgid "FQDN used for HELO"
 msgstr ""
 
-#: plugins/check_smtp.c:850
+#: plugins/check_smtp.c:880
 msgid "Use PROXY protocol prefix for the connection."
 msgstr "Benutze PROXY-Protokoll-Präfix für die Verbindung."
 
-#: plugins/check_smtp.c:853 plugins/check_tcp.c:689
+#: plugins/check_smtp.c:883 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."
 msgstr ""
 
-#: plugins/check_smtp.c:855
+#: plugins/check_smtp.c:885
+#, fuzzy
+msgid "Use SSL/TLS for the connection."
+msgstr "Benutze PROXY-Protokoll-Präfix für die Verbindung."
+
+#: plugins/check_smtp.c:886
+#, c-format
+msgid "    Sets default port to %d.\n"
+msgstr ""
+
+#: plugins/check_smtp.c:888
 msgid "Use STARTTLS for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:861
+#: plugins/check_smtp.c:894
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"
 msgstr ""
 
-#: plugins/check_smtp.c:863
+#: plugins/check_smtp.c:896
 msgid "SMTP AUTH username"
 msgstr ""
 
-#: plugins/check_smtp.c:865
+#: plugins/check_smtp.c:898
 msgid "SMTP AUTH password"
 msgstr ""
 
-#: plugins/check_smtp.c:867
+#: plugins/check_smtp.c:900
 msgid "Send LHLO instead of HELO/EHLO"
 msgstr ""
 
-#: plugins/check_smtp.c:869
+#: plugins/check_smtp.c:902
 msgid "Ignore failure when sending QUIT command to server"
 msgstr ""
 
-#: plugins/check_smtp.c:879
+#: plugins/check_smtp.c:912
 msgid "STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful"
 msgstr ""
 
-#: plugins/check_smtp.c:880
+#: plugins/check_smtp.c:913
 msgid "connects, but incorrect response messages from the host result in"
 msgstr ""
 
-#: plugins/check_smtp.c:881
+#: plugins/check_smtp.c:914
 msgid "STATE_WARNING return values."
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -4806,7 +4806,7 @@ msgstr "SSL n'est pas disponible - installer OpenSSL et recompilez"
 
 #: plugins/check_smtp.c:720
 msgid "Set either -s/--ssl/--tls or -S/--starttls"
-msgstr ""
+msgstr "Définissez -s/--ssl/--tls ou -S/--starttls"
 
 #: plugins/check_smtp.c:749 plugins/check_smtp.c:754
 #, c-format
@@ -4861,16 +4861,16 @@ msgstr "Nombre de jours minimum pour que le certificat soit valide."
 #: plugins/check_smtp.c:885
 #, fuzzy
 msgid "Use SSL/TLS for the connection."
-msgstr "Utiliser le préfixe du protocole PROXY pour la connexion."
+msgstr "Utiliser SSL/TLS pour la connexion."
 
 #: plugins/check_smtp.c:886
 #, c-format
 msgid "    Sets default port to %d.\n"
-msgstr ""
+msgstr "    Définit le port par défaut à %d.\n"
 
 #: plugins/check_smtp.c:888
 msgid "Use STARTTLS for the connection."
-msgstr ""
+msgstr "Utiliser STARTTLS pour la connexion."
 
 #: plugins/check_smtp.c:894
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2023-08-28 14:50+0200\n"
+"POT-Creation-Date: 2023-08-29 09:47+0200\n"
 "PO-Revision-Date: 2010-04-21 23:38-0400\n"
 "Last-Translator: Thomas Guyot-Sionnest <dermoth@aei.ca>\n"
 "Language-Team: Nagios Plugin Development Mailing List <nagiosplug-"
@@ -31,7 +31,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:557
 #: plugins/check_nwstat.c:173 plugins/check_overcr.c:102
 #: plugins/check_pgsql.c:174 plugins/check_ping.c:97 plugins/check_procs.c:176
-#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:146
+#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:149
 #: plugins/check_snmp.c:250 plugins/check_ssh.c:74 plugins/check_swap.c:115
 #: plugins/check_tcp.c:222 plugins/check_time.c:78 plugins/check_ups.c:122
 #: plugins/check_users.c:89 plugins/negate.c:210 plugins-root/check_dhcp.c:270
@@ -71,14 +71,14 @@ msgstr "%s: Erreur d'analyse du résultat\n"
 
 #: plugins/check_by_ssh.c:242 plugins/check_disk.c:568 plugins/check_http.c:292
 #: plugins/check_ldap.c:334 plugins/check_pgsql.c:314 plugins/check_procs.c:461
-#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:607
+#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:625
 #: plugins/check_snmp.c:805 plugins/check_ssh.c:140 plugins/check_tcp.c:519
 #: plugins/check_time.c:302 plugins/check_ups.c:559 plugins/negate.c:160
 msgid "Timeout interval must be a positive integer"
 msgstr "Le délai d'attente doit être un entier positif"
 
 #: plugins/check_by_ssh.c:254 plugins/check_pgsql.c:344
-#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:532
+#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:550
 #: plugins/check_tcp.c:525 plugins/check_time.c:296 plugins/check_ups.c:521
 msgid "Port must be a positive integer"
 msgstr "Le numéro du port doit être un entier positif"
@@ -258,7 +258,7 @@ msgstr "Exemples:"
 #: plugins/check_ntp_peer.c:753 plugins/check_ntp_time.c:651
 #: plugins/check_nwstat.c:1685 plugins/check_overcr.c:467
 #: plugins/check_pgsql.c:551 plugins/check_ping.c:617 plugins/check_procs.c:829
-#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:891
+#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:924
 #: plugins/check_snmp.c:1368 plugins/check_ssh.c:325 plugins/check_swap.c:607
 #: plugins/check_tcp.c:710 plugins/check_time.c:371 plugins/check_ups.c:663
 #: plugins/check_users.c:275 plugins/check_ide_smart.c:606 plugins/negate.c:273
@@ -994,8 +994,8 @@ msgstr "FPING %s - %s (perte=%.0f%% )|%s\n"
 #: plugins/check_ntp.c:719 plugins/check_ntp_peer.c:497
 #: plugins/check_ntp_time.c:498 plugins/check_pgsql.c:338
 #: plugins/check_ping.c:301 plugins/check_ping.c:424 plugins/check_radius.c:279
-#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:525
-#: plugins/check_smtp.c:681 plugins/check_ssh.c:162 plugins/check_time.c:240
+#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:543
+#: plugins/check_smtp.c:703 plugins/check_ssh.c:162 plugins/check_time.c:240
 #: plugins/check_time.c:315 plugins/check_ups.c:507 plugins/check_ups.c:576
 msgid "Invalid hostname/address"
 msgstr "Adresse/Nom d'hôte invalide"
@@ -1268,7 +1268,7 @@ msgid "file does not exist or is not readable"
 msgstr ""
 
 #: plugins/check_http.c:324 plugins/check_http.c:329 plugins/check_http.c:335
-#: plugins/check_smtp.c:621 plugins/check_tcp.c:590 plugins/check_tcp.c:595
+#: plugins/check_smtp.c:639 plugins/check_tcp.c:590 plugins/check_tcp.c:595
 #: plugins/check_tcp.c:601
 msgid "Invalid certificate expiration period"
 msgstr "Période d'expiration du certificat invalide"
@@ -1307,7 +1307,7 @@ msgstr "Impossible de compiler l'expression rationnelle: %s"
 
 #: plugins/check_http.c:522 plugins/check_ntp.c:732
 #: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:517
-#: plugins/check_smtp.c:661 plugins/check_ssh.c:151 plugins/check_tcp.c:491
+#: plugins/check_smtp.c:683 plugins/check_ssh.c:151 plugins/check_tcp.c:491
 msgid "IPv6 support not available"
 msgstr "Support IPv6 non disponible"
 
@@ -1495,8 +1495,8 @@ msgstr ""
 #, fuzzy, c-format
 msgid "HTTP CRITICAL - redirection creates an infinite loop - %s://%s:%d%s%s\n"
 msgstr ""
-"HTTP AVERTISSEMENT - la redirection crée une boucle infinie - %s://%s:%d%s"
-"%s\n"
+"HTTP AVERTISSEMENT - la redirection crée une boucle infinie - %s://%s:"
+"%d%s%s\n"
 
 #: plugins/check_http.c:1630
 #, c-format
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."
 msgstr ""
 
-#: plugins/check_http.c:1750 plugins/check_smtp.c:857
+#: plugins/check_http.c:1750 plugins/check_smtp.c:890
 msgid "Enable SSL/TLS hostname extension support (SNI)"
 msgstr ""
 
@@ -3084,8 +3084,8 @@ msgstr ""
 #: plugins/check_ntp_peer.c:716
 msgid "Critical threshold for number of usable time sources (\"truechimers\")"
 msgstr ""
-"Seuil critique pour le nombre de sources de temps utilisable (\"truechimers"
-"\")"
+"Seuil critique pour le nombre de sources de temps utilisable "
+"(\"truechimers\")"
 
 #: plugins/check_ntp_peer.c:721
 msgid "This plugin checks an NTP server independent of any commandline"
@@ -4460,7 +4460,7 @@ msgstr "Manque de Mémoire?"
 msgid "Invalid NAS-Identifier\n"
 msgstr "NAS-Identifier invalide"
 
-#: plugins/check_radius.c:199 plugins/check_smtp.c:156
+#: plugins/check_radius.c:199 plugins/check_smtp.c:159
 #, c-format
 msgid "gethostname() failed!\n"
 msgstr "La commande gethostname() à échoué\n"
@@ -4651,7 +4651,7 @@ msgstr ""
 msgid "This plugin will attempt to open an RTSP connection with the host."
 msgstr "Ce plugin va essayer d'ouvrir un connexion RTSP avec l'hôte."
 
-#: plugins/check_real.c:439 plugins/check_smtp.c:878
+#: plugins/check_real.c:439 plugins/check_smtp.c:911
 msgid "Successful connects return STATE_OK, refusals and timeouts return"
 msgstr ""
 
@@ -4669,224 +4669,238 @@ msgstr ""
 msgid "values."
 msgstr ""
 
-#: plugins/check_smtp.c:152 plugins/check_swap.c:283 plugins/check_swap.c:289
+#: plugins/check_smtp.c:155 plugins/check_swap.c:283 plugins/check_swap.c:289
 #, c-format
 msgid "malloc() failed!\n"
 msgstr "l'allocation mémoire à échoué!\n"
 
-#: plugins/check_smtp.c:200 plugins/check_smtp.c:212
-#, c-format
-msgid "recv() failed\n"
-msgstr "La commande recv() à échoué\n"
-
-#: plugins/check_smtp.c:222
-#, c-format
-msgid "WARNING - TLS not supported by server\n"
-msgstr "AVERTISSEMENT: - TLS n'est pas supporté par ce serveur\n"
-
-#: plugins/check_smtp.c:234
-#, c-format
-msgid "Server does not support STARTTLS\n"
-msgstr "Le serveur ne supporte pas STARTTLS\n"
-
-#: plugins/check_smtp.c:240
+#: plugins/check_smtp.c:203 plugins/check_smtp.c:256
 #, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr "CRITIQUE - Impossible de créer le contexte SSL.\n"
 
-#: plugins/check_smtp.c:260
+#: plugins/check_smtp.c:216 plugins/check_smtp.c:228
+#, c-format
+msgid "recv() failed\n"
+msgstr "La commande recv() à échoué\n"
+
+#: plugins/check_smtp.c:238
+#, c-format
+msgid "WARNING - TLS not supported by server\n"
+msgstr "AVERTISSEMENT: - TLS n'est pas supporté par ce serveur\n"
+
+#: plugins/check_smtp.c:250
+#, c-format
+msgid "Server does not support STARTTLS\n"
+msgstr "Le serveur ne supporte pas STARTTLS\n"
+
+#: plugins/check_smtp.c:276
 msgid "SMTP UNKNOWN - Cannot send EHLO command via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:265
+#: plugins/check_smtp.c:281
 #, c-format
 msgid "sent %s"
 msgstr "envoyé %s"
 
-#: plugins/check_smtp.c:267
+#: plugins/check_smtp.c:283
 msgid "SMTP UNKNOWN - Cannot read EHLO response via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:297
+#: plugins/check_smtp.c:313
 #, c-format
 msgid "Invalid SMTP response received from host: %s\n"
 msgstr "Réponse SMTP reçue de l'hôte invalide: %s\n"
 
-#: plugins/check_smtp.c:299
+#: plugins/check_smtp.c:315
 #, c-format
 msgid "Invalid SMTP response received from host on port %d: %s\n"
 msgstr "Réponse SMTP reçue de l'hôte sur le port %d invalide: %s\n"
 
-#: plugins/check_smtp.c:322 plugins/check_snmp.c:882
+#: plugins/check_smtp.c:338 plugins/check_snmp.c:882
 #, c-format
 msgid "Could Not Compile Regular Expression"
 msgstr "Impossible de compiler l'expression rationnelle"
 
-#: plugins/check_smtp.c:331
+#: plugins/check_smtp.c:347
 #, c-format
 msgid "SMTP %s - Invalid response '%s' to command '%s'\n"
 msgstr "SMTP %s - réponse invalide de '%s' à la commande '%s'\n"
 
-#: plugins/check_smtp.c:335 plugins/check_snmp.c:555
+#: plugins/check_smtp.c:351 plugins/check_snmp.c:555
 #, c-format
 msgid "Execute Error: %s\n"
 msgstr "Erreur d'exécution: %s\n"
 
-#: plugins/check_smtp.c:349
+#: plugins/check_smtp.c:365
 msgid "no authuser specified, "
 msgstr "Pas d'utilisateur pour l'authentification spécifié, "
 
-#: plugins/check_smtp.c:354
+#: plugins/check_smtp.c:370
 msgid "no authpass specified, "
 msgstr "pas de mot de passe spécifié, "
 
-#: plugins/check_smtp.c:361 plugins/check_smtp.c:382 plugins/check_smtp.c:402
-#: plugins/check_smtp.c:728
+#: plugins/check_smtp.c:377 plugins/check_smtp.c:398 plugins/check_smtp.c:418
+#: plugins/check_smtp.c:758
 #, c-format
 msgid "sent %s\n"
 msgstr "envoyé %s\n"
 
-#: plugins/check_smtp.c:364
+#: plugins/check_smtp.c:380
 msgid "recv() failed after AUTH LOGIN, "
 msgstr "recv() à échoué après AUTH LOGIN, "
 
-#: plugins/check_smtp.c:369 plugins/check_smtp.c:390 plugins/check_smtp.c:410
-#: plugins/check_smtp.c:739
+#: plugins/check_smtp.c:385 plugins/check_smtp.c:406 plugins/check_smtp.c:426
+#: plugins/check_smtp.c:769
 #, c-format
 msgid "received %s\n"
 msgstr "reçu %s\n"
 
-#: plugins/check_smtp.c:373
+#: plugins/check_smtp.c:389
 msgid "invalid response received after AUTH LOGIN, "
 msgstr "Réponse invalide reçue après AUTH LOGIN, "
 
-#: plugins/check_smtp.c:386
+#: plugins/check_smtp.c:402
 msgid "recv() failed after sending authuser, "
 msgstr "La commande recv() a échoué après authuser, "
 
-#: plugins/check_smtp.c:394
+#: plugins/check_smtp.c:410
 msgid "invalid response received after authuser, "
 msgstr "Réponse invalide reçue après authuser, "
 
-#: plugins/check_smtp.c:406
+#: plugins/check_smtp.c:422
 msgid "recv() failed after sending authpass, "
 msgstr "la commande recv() à échoué après authpass, "
 
-#: plugins/check_smtp.c:414
+#: plugins/check_smtp.c:430
 msgid "invalid response received after authpass, "
 msgstr "Réponse invalide reçue après authpass, "
 
-#: plugins/check_smtp.c:421
+#: plugins/check_smtp.c:437
 msgid "only authtype LOGIN is supported, "
 msgstr "seul la méthode d'authentification LOGIN est supportée, "
 
-#: plugins/check_smtp.c:445
+#: plugins/check_smtp.c:461
 #, c-format
 msgid "SMTP %s - %s%.3f sec. response time%s%s|%s\n"
 msgstr "SMTP %s - %s%.3f sec. de temps de réponse%s%s|%s\n"
 
-#: plugins/check_smtp.c:562 plugins/check_smtp.c:574
+#: plugins/check_smtp.c:580 plugins/check_smtp.c:592
 #, c-format
 msgid "Could not realloc() units [%d]\n"
 msgstr "Impossible de réallouer des unités [%d]\n"
 
-#: plugins/check_smtp.c:582
+#: plugins/check_smtp.c:600
 #, fuzzy
 msgid "Critical time must be a positive"
 msgstr "Le seuil critique doit être un entier positif"
 
-#: plugins/check_smtp.c:590
+#: plugins/check_smtp.c:608
 #, fuzzy
 msgid "Warning time must be a positive"
 msgstr "Le seuil d'avertissement doit être un entier positif"
 
-#: plugins/check_smtp.c:633 plugins/check_smtp.c:645
+#: plugins/check_smtp.c:651 plugins/check_smtp.c:667
 msgid "SSL support not available - install OpenSSL and recompile"
 msgstr "SSL n'est pas disponible - installer OpenSSL et recompilez"
 
-#: plugins/check_smtp.c:719 plugins/check_smtp.c:724
+#: plugins/check_smtp.c:720
+msgid "Set either -s/--ssl/--tls or -S/--starttls"
+msgstr ""
+
+#: plugins/check_smtp.c:749 plugins/check_smtp.c:754
 #, c-format
 msgid "Connection closed by server before sending QUIT command\n"
 msgstr ""
 
-#: plugins/check_smtp.c:734
+#: plugins/check_smtp.c:764
 #, c-format
 msgid "recv() failed after QUIT."
 msgstr "recv() à échoué après QUIT."
 
-#: plugins/check_smtp.c:736
+#: plugins/check_smtp.c:766
 #, c-format
 msgid "Connection reset by peer."
 msgstr ""
 
-#: plugins/check_smtp.c:826
+#: plugins/check_smtp.c:856
 msgid "This plugin will attempt to open an SMTP connection with the host."
 msgstr "Ce plugin va essayer d'ouvrir un connexion SMTP avec l'hôte."
 
-#: plugins/check_smtp.c:840
+#: plugins/check_smtp.c:870
 #, c-format
 msgid "    String to expect in first line of server response (default: '%s')\n"
 msgstr ""
 "   Texte attendu dans la première ligne de réponse du serveur (défaut: "
 "'%s')\n"
 
-#: plugins/check_smtp.c:842
+#: plugins/check_smtp.c:872
 msgid "SMTP command (may be used repeatedly)"
 msgstr "Commande SMTP (peut être utilisé plusieurs fois)"
 
-#: plugins/check_smtp.c:844
+#: plugins/check_smtp.c:874
 msgid "Expected response to command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:846
+#: plugins/check_smtp.c:876
 msgid "FROM-address to include in MAIL command, required by Exchange 2000"
 msgstr ""
 
-#: plugins/check_smtp.c:848
+#: plugins/check_smtp.c:878
 msgid "FQDN used for HELO"
 msgstr ""
 
-#: plugins/check_smtp.c:850
+#: plugins/check_smtp.c:880
 msgid "Use PROXY protocol prefix for the connection."
 msgstr "Utiliser le préfixe du protocole PROXY pour la connexion."
 
-#: plugins/check_smtp.c:853 plugins/check_tcp.c:689
+#: plugins/check_smtp.c:883 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."
 msgstr "Nombre de jours minimum pour que le certificat soit valide."
 
-#: plugins/check_smtp.c:855
+#: plugins/check_smtp.c:885
+#, fuzzy
+msgid "Use SSL/TLS for the connection."
+msgstr "Utiliser le préfixe du protocole PROXY pour la connexion."
+
+#: plugins/check_smtp.c:886
+#, c-format
+msgid "    Sets default port to %d.\n"
+msgstr ""
+
+#: plugins/check_smtp.c:888
 msgid "Use STARTTLS for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:861
+#: plugins/check_smtp.c:894
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"
 msgstr ""
 
-#: plugins/check_smtp.c:863
+#: plugins/check_smtp.c:896
 msgid "SMTP AUTH username"
 msgstr ""
 
-#: plugins/check_smtp.c:865
+#: plugins/check_smtp.c:898
 msgid "SMTP AUTH password"
 msgstr ""
 
-#: plugins/check_smtp.c:867
+#: plugins/check_smtp.c:900
 msgid "Send LHLO instead of HELO/EHLO"
 msgstr ""
 
-#: plugins/check_smtp.c:869
+#: plugins/check_smtp.c:902
 msgid "Ignore failure when sending QUIT command to server"
 msgstr ""
 
-#: plugins/check_smtp.c:879
+#: plugins/check_smtp.c:912
 msgid "STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful"
 msgstr ""
 
-#: plugins/check_smtp.c:880
+#: plugins/check_smtp.c:913
 msgid "connects, but incorrect response messages from the host result in"
 msgstr ""
 
-#: plugins/check_smtp.c:881
+#: plugins/check_smtp.c:914
 msgid "STATE_WARNING return values."
 msgstr ""
 

--- a/po/monitoring-plugins.pot
+++ b/po/monitoring-plugins.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2023-08-28 14:50+0200\n"
+"POT-Creation-Date: 2023-08-29 09:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,7 +27,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:575 plugins/check_ntp_time.c:557
 #: plugins/check_nwstat.c:173 plugins/check_overcr.c:102
 #: plugins/check_pgsql.c:174 plugins/check_ping.c:97 plugins/check_procs.c:176
-#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:146
+#: plugins/check_radius.c:176 plugins/check_real.c:80 plugins/check_smtp.c:149
 #: plugins/check_snmp.c:250 plugins/check_ssh.c:74 plugins/check_swap.c:115
 #: plugins/check_tcp.c:222 plugins/check_time.c:78 plugins/check_ups.c:122
 #: plugins/check_users.c:89 plugins/negate.c:210 plugins-root/check_dhcp.c:270
@@ -67,14 +67,14 @@ msgstr ""
 
 #: plugins/check_by_ssh.c:242 plugins/check_disk.c:568 plugins/check_http.c:292
 #: plugins/check_ldap.c:334 plugins/check_pgsql.c:314 plugins/check_procs.c:461
-#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:607
+#: plugins/check_radius.c:323 plugins/check_real.c:357 plugins/check_smtp.c:625
 #: plugins/check_snmp.c:805 plugins/check_ssh.c:140 plugins/check_tcp.c:519
 #: plugins/check_time.c:302 plugins/check_ups.c:559 plugins/negate.c:160
 msgid "Timeout interval must be a positive integer"
 msgstr ""
 
 #: plugins/check_by_ssh.c:254 plugins/check_pgsql.c:344
-#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:532
+#: plugins/check_radius.c:287 plugins/check_real.c:328 plugins/check_smtp.c:550
 #: plugins/check_tcp.c:525 plugins/check_time.c:296 plugins/check_ups.c:521
 msgid "Port must be a positive integer"
 msgstr ""
@@ -243,7 +243,7 @@ msgstr ""
 #: plugins/check_ntp_peer.c:753 plugins/check_ntp_time.c:651
 #: plugins/check_nwstat.c:1685 plugins/check_overcr.c:467
 #: plugins/check_pgsql.c:551 plugins/check_ping.c:617 plugins/check_procs.c:829
-#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:891
+#: plugins/check_radius.c:400 plugins/check_real.c:452 plugins/check_smtp.c:924
 #: plugins/check_snmp.c:1368 plugins/check_ssh.c:325 plugins/check_swap.c:607
 #: plugins/check_tcp.c:710 plugins/check_time.c:371 plugins/check_ups.c:663
 #: plugins/check_users.c:275 plugins/check_ide_smart.c:606 plugins/negate.c:273
@@ -933,8 +933,8 @@ msgstr ""
 #: plugins/check_ntp.c:719 plugins/check_ntp_peer.c:497
 #: plugins/check_ntp_time.c:498 plugins/check_pgsql.c:338
 #: plugins/check_ping.c:301 plugins/check_ping.c:424 plugins/check_radius.c:279
-#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:525
-#: plugins/check_smtp.c:681 plugins/check_ssh.c:162 plugins/check_time.c:240
+#: plugins/check_real.c:315 plugins/check_real.c:377 plugins/check_smtp.c:543
+#: plugins/check_smtp.c:703 plugins/check_ssh.c:162 plugins/check_time.c:240
 #: plugins/check_time.c:315 plugins/check_ups.c:507 plugins/check_ups.c:576
 msgid "Invalid hostname/address"
 msgstr ""
@@ -1187,7 +1187,7 @@ msgid "file does not exist or is not readable"
 msgstr ""
 
 #: plugins/check_http.c:324 plugins/check_http.c:329 plugins/check_http.c:335
-#: plugins/check_smtp.c:621 plugins/check_tcp.c:590 plugins/check_tcp.c:595
+#: plugins/check_smtp.c:639 plugins/check_tcp.c:590 plugins/check_tcp.c:595
 #: plugins/check_tcp.c:601
 msgid "Invalid certificate expiration period"
 msgstr ""
@@ -1226,7 +1226,7 @@ msgstr ""
 
 #: plugins/check_http.c:522 plugins/check_ntp.c:732
 #: plugins/check_ntp_peer.c:513 plugins/check_ntp_time.c:517
-#: plugins/check_smtp.c:661 plugins/check_ssh.c:151 plugins/check_tcp.c:491
+#: plugins/check_smtp.c:683 plugins/check_ssh.c:151 plugins/check_tcp.c:491
 msgid "IPv6 support not available"
 msgstr ""
 
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "1.2 = TLSv1.2). With a '+' suffix, newer versions are also accepted."
 msgstr ""
 
-#: plugins/check_http.c:1750 plugins/check_smtp.c:857
+#: plugins/check_http.c:1750 plugins/check_smtp.c:890
 msgid "Enable SSL/TLS hostname extension support (SNI)"
 msgstr ""
 
@@ -4271,7 +4271,7 @@ msgstr ""
 msgid "Invalid NAS-Identifier\n"
 msgstr ""
 
-#: plugins/check_radius.c:199 plugins/check_smtp.c:156
+#: plugins/check_radius.c:199 plugins/check_smtp.c:159
 #, c-format
 msgid "gethostname() failed!\n"
 msgstr ""
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "This plugin will attempt to open an RTSP connection with the host."
 msgstr ""
 
-#: plugins/check_real.c:439 plugins/check_smtp.c:878
+#: plugins/check_real.c:439 plugins/check_smtp.c:911
 msgid "Successful connects return STATE_OK, refusals and timeouts return"
 msgstr ""
 
@@ -4471,220 +4471,233 @@ msgstr ""
 msgid "values."
 msgstr ""
 
-#: plugins/check_smtp.c:152 plugins/check_swap.c:283 plugins/check_swap.c:289
+#: plugins/check_smtp.c:155 plugins/check_swap.c:283 plugins/check_swap.c:289
 #, c-format
 msgid "malloc() failed!\n"
 msgstr ""
 
-#: plugins/check_smtp.c:200 plugins/check_smtp.c:212
-#, c-format
-msgid "recv() failed\n"
-msgstr ""
-
-#: plugins/check_smtp.c:222
-#, c-format
-msgid "WARNING - TLS not supported by server\n"
-msgstr ""
-
-#: plugins/check_smtp.c:234
-#, c-format
-msgid "Server does not support STARTTLS\n"
-msgstr ""
-
-#: plugins/check_smtp.c:240
+#: plugins/check_smtp.c:203 plugins/check_smtp.c:256
 #, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr ""
 
-#: plugins/check_smtp.c:260
+#: plugins/check_smtp.c:216 plugins/check_smtp.c:228
+#, c-format
+msgid "recv() failed\n"
+msgstr ""
+
+#: plugins/check_smtp.c:238
+#, c-format
+msgid "WARNING - TLS not supported by server\n"
+msgstr ""
+
+#: plugins/check_smtp.c:250
+#, c-format
+msgid "Server does not support STARTTLS\n"
+msgstr ""
+
+#: plugins/check_smtp.c:276
 msgid "SMTP UNKNOWN - Cannot send EHLO command via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:265
+#: plugins/check_smtp.c:281
 #, c-format
 msgid "sent %s"
 msgstr ""
 
-#: plugins/check_smtp.c:267
+#: plugins/check_smtp.c:283
 msgid "SMTP UNKNOWN - Cannot read EHLO response via TLS."
 msgstr ""
 
-#: plugins/check_smtp.c:297
+#: plugins/check_smtp.c:313
 #, c-format
 msgid "Invalid SMTP response received from host: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:299
+#: plugins/check_smtp.c:315
 #, c-format
 msgid "Invalid SMTP response received from host on port %d: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:322 plugins/check_snmp.c:882
+#: plugins/check_smtp.c:338 plugins/check_snmp.c:882
 #, c-format
 msgid "Could Not Compile Regular Expression"
 msgstr ""
 
-#: plugins/check_smtp.c:331
+#: plugins/check_smtp.c:347
 #, c-format
 msgid "SMTP %s - Invalid response '%s' to command '%s'\n"
 msgstr ""
 
-#: plugins/check_smtp.c:335 plugins/check_snmp.c:555
+#: plugins/check_smtp.c:351 plugins/check_snmp.c:555
 #, c-format
 msgid "Execute Error: %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:349
+#: plugins/check_smtp.c:365
 msgid "no authuser specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:354
+#: plugins/check_smtp.c:370
 msgid "no authpass specified, "
 msgstr ""
 
-#: plugins/check_smtp.c:361 plugins/check_smtp.c:382 plugins/check_smtp.c:402
-#: plugins/check_smtp.c:728
+#: plugins/check_smtp.c:377 plugins/check_smtp.c:398 plugins/check_smtp.c:418
+#: plugins/check_smtp.c:758
 #, c-format
 msgid "sent %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:364
+#: plugins/check_smtp.c:380
 msgid "recv() failed after AUTH LOGIN, "
 msgstr ""
 
-#: plugins/check_smtp.c:369 plugins/check_smtp.c:390 plugins/check_smtp.c:410
-#: plugins/check_smtp.c:739
+#: plugins/check_smtp.c:385 plugins/check_smtp.c:406 plugins/check_smtp.c:426
+#: plugins/check_smtp.c:769
 #, c-format
 msgid "received %s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:373
+#: plugins/check_smtp.c:389
 msgid "invalid response received after AUTH LOGIN, "
 msgstr ""
 
-#: plugins/check_smtp.c:386
+#: plugins/check_smtp.c:402
 msgid "recv() failed after sending authuser, "
 msgstr ""
 
-#: plugins/check_smtp.c:394
+#: plugins/check_smtp.c:410
 msgid "invalid response received after authuser, "
 msgstr ""
 
-#: plugins/check_smtp.c:406
+#: plugins/check_smtp.c:422
 msgid "recv() failed after sending authpass, "
 msgstr ""
 
-#: plugins/check_smtp.c:414
+#: plugins/check_smtp.c:430
 msgid "invalid response received after authpass, "
 msgstr ""
 
-#: plugins/check_smtp.c:421
+#: plugins/check_smtp.c:437
 msgid "only authtype LOGIN is supported, "
 msgstr ""
 
-#: plugins/check_smtp.c:445
+#: plugins/check_smtp.c:461
 #, c-format
 msgid "SMTP %s - %s%.3f sec. response time%s%s|%s\n"
 msgstr ""
 
-#: plugins/check_smtp.c:562 plugins/check_smtp.c:574
+#: plugins/check_smtp.c:580 plugins/check_smtp.c:592
 #, c-format
 msgid "Could not realloc() units [%d]\n"
 msgstr ""
 
-#: plugins/check_smtp.c:582
+#: plugins/check_smtp.c:600
 msgid "Critical time must be a positive"
 msgstr ""
 
-#: plugins/check_smtp.c:590
+#: plugins/check_smtp.c:608
 msgid "Warning time must be a positive"
 msgstr ""
 
-#: plugins/check_smtp.c:633 plugins/check_smtp.c:645
+#: plugins/check_smtp.c:651 plugins/check_smtp.c:667
 msgid "SSL support not available - install OpenSSL and recompile"
 msgstr ""
 
-#: plugins/check_smtp.c:719 plugins/check_smtp.c:724
+#: plugins/check_smtp.c:720
+msgid "Set either -s/--ssl/--tls or -S/--starttls"
+msgstr ""
+
+#: plugins/check_smtp.c:749 plugins/check_smtp.c:754
 #, c-format
 msgid "Connection closed by server before sending QUIT command\n"
 msgstr ""
 
-#: plugins/check_smtp.c:734
+#: plugins/check_smtp.c:764
 #, c-format
 msgid "recv() failed after QUIT."
 msgstr ""
 
-#: plugins/check_smtp.c:736
+#: plugins/check_smtp.c:766
 #, c-format
 msgid "Connection reset by peer."
 msgstr ""
 
-#: plugins/check_smtp.c:826
+#: plugins/check_smtp.c:856
 msgid "This plugin will attempt to open an SMTP connection with the host."
 msgstr ""
 
-#: plugins/check_smtp.c:840
+#: plugins/check_smtp.c:870
 #, c-format
 msgid "    String to expect in first line of server response (default: '%s')\n"
 msgstr ""
 
-#: plugins/check_smtp.c:842
+#: plugins/check_smtp.c:872
 msgid "SMTP command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:844
+#: plugins/check_smtp.c:874
 msgid "Expected response to command (may be used repeatedly)"
 msgstr ""
 
-#: plugins/check_smtp.c:846
+#: plugins/check_smtp.c:876
 msgid "FROM-address to include in MAIL command, required by Exchange 2000"
 msgstr ""
 
-#: plugins/check_smtp.c:848
+#: plugins/check_smtp.c:878
 msgid "FQDN used for HELO"
 msgstr ""
 
-#: plugins/check_smtp.c:850
+#: plugins/check_smtp.c:880
 msgid "Use PROXY protocol prefix for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:853 plugins/check_tcp.c:689
+#: plugins/check_smtp.c:883 plugins/check_tcp.c:689
 msgid "Minimum number of days a certificate has to be valid."
 msgstr ""
 
-#: plugins/check_smtp.c:855
+#: plugins/check_smtp.c:885
+msgid "Use SSL/TLS for the connection."
+msgstr ""
+
+#: plugins/check_smtp.c:886
+#, c-format
+msgid "    Sets default port to %d.\n"
+msgstr ""
+
+#: plugins/check_smtp.c:888
 msgid "Use STARTTLS for the connection."
 msgstr ""
 
-#: plugins/check_smtp.c:861
+#: plugins/check_smtp.c:894
 msgid "SMTP AUTH type to check (default none, only LOGIN supported)"
 msgstr ""
 
-#: plugins/check_smtp.c:863
+#: plugins/check_smtp.c:896
 msgid "SMTP AUTH username"
 msgstr ""
 
-#: plugins/check_smtp.c:865
+#: plugins/check_smtp.c:898
 msgid "SMTP AUTH password"
 msgstr ""
 
-#: plugins/check_smtp.c:867
+#: plugins/check_smtp.c:900
 msgid "Send LHLO instead of HELO/EHLO"
 msgstr ""
 
-#: plugins/check_smtp.c:869
+#: plugins/check_smtp.c:902
 msgid "Ignore failure when sending QUIT command to server"
 msgstr ""
 
-#: plugins/check_smtp.c:879
+#: plugins/check_smtp.c:912
 msgid "STATE_CRITICAL, other errors return STATE_UNKNOWN.  Successful"
 msgstr ""
 
-#: plugins/check_smtp.c:880
+#: plugins/check_smtp.c:913
 msgid "connects, but incorrect response messages from the host result in"
 msgstr ""
 
-#: plugins/check_smtp.c:881
+#: plugins/check_smtp.c:914
 msgid "STATE_WARNING return values."
 msgstr ""
 


### PR DESCRIPTION
This PR adds new flags `-s/--ssl/--tls` to use SMTP over TLS (smtps). Per default port 465 is used if one of these new flags is set.

By changing the order of code -r/--proxy can be used with -s/--ssl/--tls, too.

These combination of options were tested successfully:

```
./plugins/check_smtp -H backend-smtp.example.com --tls --proxy
./plugins/check_smtp -H backend-smtp.example.com --tls --proxy -p 587  (fails as expected)
./plugins/check_smtp -H backend-smtp.example.com --starttls -p 587 --proxy
./plugins/check_smtp -H frontend-smtp.example.com --tls
./plugins/check_smtp -H frontend-smtp.example.com --tls -p 587 (fails as expected)
./plugins/check_smtp -H frontend-smtp.example.com --starttls -p 587
```