### PR TITLE
check_smtp: Reimplement proxy protocol

### DIFF
--- a/.github/NPTest.cache
+++ b/.github/NPTest.cache
@@ -28,6 +28,7 @@
   'NP_HOST_TCP_SMTP_NOSTARTTLS' => '',
   'NP_HOST_TCP_SMTP_STARTTLS' => 'localhost',
   'NP_HOST_TCP_SMTP_TLS' => 'localhost',
+  'NP_PORT_TCP_SMTP_PROXY_PROT' => '',
   'NP_HOST_TLS_CERT' => 'localhost',
   'NP_HOST_TLS_HTTP' => 'localhost',
   'NP_HOST_UDP_TIME' => 'none',

--- a/.github/prepare_debian.sh
+++ b/.github/prepare_debian.sh
@@ -92,7 +92,7 @@ service mariadb start || service mysql start
 mysql -e "create database IF NOT EXISTS test;" -uroot
 
 # ldap
-sed -e 's/cn=admin,dc=nodomain/'$(/usr/sbin/slapcat|grep ^dn:|awk '{print $2}')'/' -i .github/NPTest.cache
+sed -e 's/cn=admin,dc=nodomain/'$(/usr/sbin/slapcat|grep ^dn:|awk '{print $2}')'/' -i "${NPTEST_CACHE}"
 service slapd start
 
 # sshd
@@ -125,13 +125,13 @@ ${proxy_protocol_port}      inet  n       -       n       -       -       smtpd
   -o smtpd_upstream_proxy_protocol=haproxy
 EOD
 service postfix start
-sed "/NP_PORT_TCP_SMTP_PROXY_PROT/c\ \ 'NP_PORT_TCP_SMTP_PROXY_PROT' => '${proxy_protocol_port}'," -i /src/.github/NPTest.cache
+sed "/NP_PORT_TCP_SMTP_PROXY_PROT/c\ \ 'NP_PORT_TCP_SMTP_PROXY_PROT' => '${proxy_protocol_port}'," -i "${NPTEST_CACHE}"
 
 # start ftpd
 service vsftpd start
 
 # hostname
-sed "/NP_HOST_TLS_CERT/s/.*/'NP_HOST_TLS_CERT' => '$(hostname)',/" -i /src/.github/NPTest.cache
+sed "/NP_HOST_TLS_CERT/s/.*/'NP_HOST_TLS_CERT' => '$(hostname)',/" -i "${NPTEST_CACHE}"
 
 # create some test files to lower inodes
 for i in $(seq 10); do

--- a/.github/prepare_debian.sh
+++ b/.github/prepare_debian.sh
@@ -117,11 +117,15 @@ service snmpd start
 cron
 
 # postfix
+proxy_protocol_port="2525"
 cat <<EOD >> /etc/postfix/master.cf
 smtps     inet  n       -       n       -       -       smtpd
   -o smtpd_tls_wrappermode=yes
+${proxy_protocol_port}      inet  n       -       n       -       -       smtpd
+  -o smtpd_upstream_proxy_protocol=haproxy
 EOD
 service postfix start
+sed "/NP_PORT_TCP_SMTP_PROXY_PROT/c\ \ 'NP_PORT_TCP_SMTP_PROXY_PROT' => '${proxy_protocol_port}'," -i /src/.github/NPTest.cache
 
 # start ftpd
 service vsftpd start

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -650,6 +650,7 @@ process_arguments (int argc, char **argv)
 #else
 			usage (_("SSL support not available - install OpenSSL and recompile"));
 #endif
+			break;
 		case 's':
 		/* ssl */
 			use_ssl = TRUE;

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -288,16 +288,17 @@ main (int argc, char **argv)
 			printf("%s", buffer);
 		}
 
-#  ifdef USE_OPENSSL
-		  if ( check_cert ) {
+		}
+#endif
+
+#ifdef USE_OPENSSL
+		if ( (use_ssl || use_starttls) && check_cert ) {
                     result = np_net_ssl_check_cert(days_till_exp_warn, days_till_exp_crit);
 		    smtp_quit();
 		    my_close();
 		    return result;
 		  }
-#  endif /* USE_OPENSSL */
-		}
-#endif
+#endif /* USE_OPENSSL */
 
 		if (verbose)
 			printf ("%s", buffer);

--- a/plugins/netutils.h
+++ b/plugins/netutils.h
@@ -49,6 +49,10 @@
 # define HOST_MAX_BYTES 255
 #endif
 
+#define PROXY_PROTOCOL_V1_HEADER_MAX_SIZE 108
+
+int proxy_protocol_v1_header(char *, size_t, int);
+
 /* process_request and wrapper macros */
 #define process_tcp_request(addr, port, sbuf, rbuf, rsize) \
 	process_request(addr, port, IPPROTO_TCP, sbuf, rbuf, rsize)

--- a/plugins/t/check_smtp.t
+++ b/plugins/t/check_smtp.t
@@ -16,6 +16,10 @@ my $host_tcp_smtp_nostarttls = getTestParameter( "NP_HOST_TCP_SMTP_NOSTARTTLS",
 					   "A host providing SMTP without STARTTLS", "");
 my $host_tcp_smtp_tls        = getTestParameter( "NP_HOST_TCP_SMTP_TLS",
 					   "A host providing SMTP with TLS", $host_tcp_smtp);
+my $host_tcp_smtp_proxy_prot = getTestParameter( "NP_HOST_TCP_SMTP_PROXY_PROT",
+					   "A host providing SMTP with proxy protocol", $host_tcp_smtp);
+my $port_tcp_smtp_proxy_prot = getTestParameter( "NP_PORT_TCP_SMTP_PROXY_PROT",
+					   "A port providing SMTP with proxy protocol", "");
 
 my $host_nonresponsive = getTestParameter( "NP_HOST_NONRESPONSIVE", 
 					   "The hostname of system not responsive to network requests", "10.0.0.1" );
@@ -24,7 +28,7 @@ my $hostname_invalid   = getTestParameter( "NP_HOSTNAME_INVALID",
                                            "An invalid (not known to DNS) hostname", "nosuchhost" );
 my $res;
 
-plan tests => 16;
+plan tests => 17;
 
 SKIP: {
 	skip "No SMTP server defined", 4 unless $host_tcp_smtp;
@@ -74,6 +78,12 @@ SKIP: {
 	$res = NPTest->testCmd( "./check_smtp -H $host_tcp_smtp_tls -p $unused_port --ssl" );
 	is ($res->return_code, 2, "Check rc of connecting to $host_tcp_smtp_tls with TLS on unused port $unused_port" );
 	like ($res->output, qr/^connect to address $host_tcp_smtp_tls and port $unused_port: Connection refused/, "Check output of connecting to $host_tcp_smtp_tls with TLS on unused port $unused_port");
+}
+
+SKIP: {
+	skip "No parameters for proxy protocol defined", 1 unless $host_tcp_smtp_proxy_prot or $port_tcp_smtp_proxy_prot;
+	$res = NPTest->testCmd( "./check_smtp -H $host_tcp_smtp_proxy_prot --proxy -p $port_tcp_smtp_proxy_prot" );
+	is ($res->return_code, 0, "Check rc of connecting to $host_tcp_smtp_proxy_prot port $port_tcp_smtp_proxy_prot with proxy protocol" );
 }
 
 $res = NPTest->testCmd( "./check_smtp $host_nonresponsive" );

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nagiosplug\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2023-09-05 00:31+0200\n"
+"POT-Creation-Date: 2023-09-05 23:54+0200\n"
 "PO-Revision-Date: 2004-12-23 17:46+0100\n"
 "Last-Translator:  <>\n"
 "Language-Team: English <en@li.org>\n"
@@ -3503,6 +3503,10 @@ msgid "malloc() failed!\n"
 msgstr ""
 
 #, c-format
+msgid "Sending header %s\n"
+msgstr "Sende Kopfzeile %s\n"
+
+#, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr ""
 
@@ -4611,6 +4615,18 @@ msgid "Invalid hostname/address - %s"
 msgstr ""
 "Ungültige(r) Name/Adresse: %s\n"
 "\n"
+
+#, c-format
+msgid "CRITICAL - proxy_protocol_header()/getsockname(): %s\n"
+msgstr "CRITICAL - proxy_protocol_header()/getsockname(): %s\n"
+
+#, c-format
+msgid "CRITICAL - proxy_protocol_header()/getpeername(): %s\n"
+msgstr "CRITICAL - proxy_protocol_header()/getpeername(): %s\n"
+
+#, c-format
+msgid "CRITICAL - proxy_protocol_header(): Unhandled address family: %d\n"
+msgstr "CRITICAL - proxy_protocol_header(): Unbehandelte Adressfamilie: %d\n"
 
 #, fuzzy
 msgid "Could not malloc argv array in popen()"

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2023-09-05 00:31+0200\n"
+"POT-Creation-Date: 2023-09-05 23:54+0200\n"
 "PO-Revision-Date: 2010-04-21 23:38-0400\n"
 "Last-Translator: Thomas Guyot-Sionnest <dermoth@aei.ca>\n"
 "Language-Team: Nagios Plugin Development Mailing List <nagiosplug-"
@@ -3586,6 +3586,10 @@ msgid "malloc() failed!\n"
 msgstr "l'allocation mémoire à échoué!\n"
 
 #, c-format
+msgid "Sending header %s\n"
+msgstr "En-tête d'envoi %s\n"
+
+#, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr "CRITIQUE - Impossible de créer le contexte SSL.\n"
 
@@ -4745,6 +4749,19 @@ msgstr "La réception à échoué"
 #, c-format
 msgid "Invalid hostname/address - %s"
 msgstr "Adresse/Nom invalide - %s"
+
+#, c-format
+msgid "CRITICAL - proxy_protocol_header()/getsockname(): %s\n"
+msgstr "CRITICAL - proxy_protocol_header()/getsockname(): %s\n"
+
+#, c-format
+msgid "CRITICAL - proxy_protocol_header()/getpeername(): %s\n"
+msgstr "CRITICAL - proxy_protocol_header()/getpeername(): %s\n"
+
+#, c-format
+msgid "CRITICAL - proxy_protocol_header(): Unhandled address family: %d\n"
+msgstr ""
+"CRITICAL - proxy_protocol_header(): Famille d'adresses non traitées: %d\n"
 
 msgid "Could not malloc argv array in popen()"
 msgstr "Impossible de réallouer un tableau pour les paramètres dans popen()"

--- a/po/monitoring-plugins.pot
+++ b/po/monitoring-plugins.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: devel@monitoring-plugins.org\n"
-"POT-Creation-Date: 2023-09-05 15:21+0200\n"
+"POT-Creation-Date: 2023-09-05 23:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3388,6 +3388,10 @@ msgid "malloc() failed!\n"
 msgstr ""
 
 #, c-format
+msgid "Sending header %s\n"
+msgstr ""
+
+#, c-format
 msgid "CRITICAL - Cannot create SSL context.\n"
 msgstr ""
 
@@ -4445,6 +4449,18 @@ msgstr ""
 
 #, c-format
 msgid "Invalid hostname/address - %s"
+msgstr ""
+
+#, c-format
+msgid "CRITICAL - proxy_protocol_header()/getsockname(): %s\n"
+msgstr ""
+
+#, c-format
+msgid "CRITICAL - proxy_protocol_header()/getpeername(): %s\n"
+msgstr ""
+
+#, c-format
+msgid "CRITICAL - proxy_protocol_header(): Unhandled address family: %d\n"
 msgstr ""
 
 msgid "Could not malloc argv array in popen()"

--- a/test.pl.in
+++ b/test.pl.in
@@ -49,4 +49,6 @@ if ( ! scalar( @tests ) )
 
 use Test::Harness;
 
+$Test::Harness::verbose = 1;
+
 runtests( @tests );


### PR DESCRIPTION
    Add and use new function proxy_protocol_v1_header()
    
    check_smtp uses a dummy header for the proxy protocol without real IP
    addresses and a fixed port 25. Since check_smtp is able to use different
    ports with various options we add a new function to synthesize the header
    properly with real addresses and port numbers.
    
    As a side effect using a function other plugins can implement an option
    for proxy protocol quite easy, too.
