### PR TITLE
Use codespell-project/actions-codespell@v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Codespell
-        uses: codespell-project/actions-codespell@master
+        uses: codespell-project/actions-codespell@v2
         with:
           skip: "./.git,./.gitignore,./ABOUT-NLS,*.po,./gl,./po,./tools/squid.conf,./build-aux/ltmain.sh"
           ignore_words_list: allright,gord,didi,hda,nd,alis,clen,scrit,ser,fot,te,parm,isnt,consol,oneliners


### PR DESCRIPTION
The current master version seems to introduce an issue, e. g.

codespell
Can't use 'tar -xzf' extract archive file: /home/runner/work/_actions/_temp_301f7ff6-2829-439a-bb1e-e3787b7d0b37/0567173d-ce48-4e72-bccb-2a410baeb2a3.tar.gz. return code: 2.

https://github.com/monitoring-plugins/monitoring-plugins/actions/runs/6074675443