### PR TITLE
use pack_sockaddr_in rather than hand-rolled

### DIFF
--- a/plugins-scripts/check_ircd.pl
+++ b/plugins-scripts/check_ircd.pl
@@ -146,7 +146,6 @@ sub bindRemote ($$)
 {
 	my ($in_remotehost, $in_remoteport) = @_;
 	my $proto = getprotobyname('tcp');
-	my $sockaddr;
 	my $that;
 	my ($name, $aliases,$type,$len,$thataddr) = gethostbyname($in_remotehost);
 
@@ -154,8 +153,7 @@ sub bindRemote ($$)
 	    print "IRCD UNKNOWN: Could not start socket ($!)\n";
 	    exit $ERRORS{"UNKNOWN"};
 	}
-	$sockaddr = 'S n a4 x8';
-	$that = pack($sockaddr, AF_INET, $in_remoteport, $thataddr);
+	$that = pack_sockaddr_in ($in_remoteport, $thataddr);
 	if (!connect(ClientSocket, $that)) { 
 	    print "IRCD UNKNOWN: Could not connect socket ($!)\n";
 	    exit $ERRORS{"UNKNOWN"};


### PR DESCRIPTION
On some OS, sockaddr structs include a length field. Perl's pack_sockaddr_in takes this into account; the hand-rolled "pack('S n a4 x8'..." doesn't do so, resulting in connection failures.

This replaces #1463 since github doesn't let me update the original branch