### PR TITLE
Include maxfd.h in lib Makefile to fix "make dist"

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -8,7 +8,7 @@ AM_CPPFLAGS = -DNP_STATE_DIR_PREFIX=\"$(localstatedir)\" \
 	-I$(srcdir) -I$(top_srcdir)/gl -I$(top_srcdir)/intl -I$(top_srcdir)/plugins
 
 libmonitoringplug_a_SOURCES = utils_base.c utils_disk.c utils_tcp.c utils_cmd.c maxfd.c
-EXTRA_DIST = utils_base.h utils_disk.h utils_tcp.h utils_cmd.h parse_ini.h extra_opts.h
+EXTRA_DIST = utils_base.h utils_disk.h utils_tcp.h utils_cmd.h parse_ini.h extra_opts.h maxfd.h
 
 if USE_PARSE_INI
 libmonitoringplug_a_SOURCES += parse_ini.c extra_opts.c


### PR DESCRIPTION
This fixes a regression which was introduced with 719e27ddc2f0b48bcd7fe5584b23e3ce83ddf291 It prevents the creation of working release tarballs with the current toolchain.

This commit add the header file maxfd.h to list of needed files.

This should then fix #1943 