### PR TITLE
Replace most of the boolean variables declared as "int" with "bool"

### DIFF
--- a/plugins/check_by_ssh.c
+++ b/plugins/check_by_ssh.c
@@ -50,7 +50,7 @@ unsigned int services = 0;
 int skip_stdout = 0;
 int skip_stderr = 0;
 int warn_on_stderr = 0;
-bool unknown_timeout = FALSE;
+bool unknown_timeout = false;
 char *remotecmd = NULL;
 char **commargv = NULL;
 int commargc = 0;
@@ -58,8 +58,8 @@ char *hostname = NULL;
 char *outputfile = NULL;
 char *host_shortname = NULL;
 char **service;
-int passive = FALSE;
-int verbose = FALSE;
+bool passive = false;
+bool verbose = false;
 
 int
 main (int argc, char **argv)
@@ -235,7 +235,7 @@ process_arguments (int argc, char **argv)
 			print_help ();
 			exit (STATE_UNKNOWN);
 		case 'v':									/* help */
-			verbose = TRUE;
+			verbose = true;
 			break;
 		case 't':									/* timeout period */
 			if (!is_integer (optarg))
@@ -244,7 +244,7 @@ process_arguments (int argc, char **argv)
 				timeout_interval = atoi (optarg);
 			break;
 		case 'U':
-			unknown_timeout = TRUE;
+			unknown_timeout = true;
 			break;
 		case 'H':									/* host */
 			hostname = optarg;
@@ -257,7 +257,7 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'O':									/* output file */
 			outputfile = optarg;
-			passive = TRUE;
+			passive = true;
 			break;
 		case 's':									/* description of service to check */
 			p1 = optarg;

--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -56,7 +56,7 @@ char *expected_address = NULL;
 char *dns_server = NULL;
 char *dig_args = "";
 char *query_transport = "";
-int verbose = FALSE;
+bool verbose = false;
 int server_port = DEFAULT_PORT;
 int number_tries = DEFAULT_TRIES;
 double warning_interval = UNDEFINED;
@@ -176,11 +176,11 @@ main (int argc, char **argv)
           state_text (result), elapsed_time,
           msg ? msg : _("Probably a non-existent host/domain"),
           fperfdata("time", elapsed_time, "s",
-                    (warning_interval>UNDEFINED?TRUE:FALSE),
+                    (warning_interval>UNDEFINED ? true:false),
                     warning_interval,
-                    (critical_interval>UNDEFINED?TRUE:FALSE),
+                    (critical_interval>UNDEFINED ? true:false),
             critical_interval,
-            TRUE, 0, FALSE, 0));
+            true, 0, false, 0));
   return result;
 }
 
@@ -270,7 +270,7 @@ process_arguments (int argc, char **argv)
       dig_args = strdup(optarg);
       break;
     case 'v':                 /* verbose */
-      verbose = TRUE;
+      verbose = true;
       break;
     case 'T':
       record_type = optarg;

--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -135,12 +135,12 @@ char *exclude_device;
 char *units;
 uintmax_t mult = 1024 * 1024;
 int verbose = 0;
-int erronly = FALSE;
-int display_mntp = FALSE;
-int exact_match = FALSE;
+bool erronly = false;
+bool display_mntp = false;
+bool exact_match = false;
 bool ignore_missing = false;
-int freespace_ignore_reserved = FALSE;
-int display_inodes_perfdata = FALSE;
+bool freespace_ignore_reserved = false;
+bool display_inodes_perfdata = false;
 char *warn_freespace_units = NULL;
 char *crit_freespace_units = NULL;
 char *warn_freespace_percent = NULL;
@@ -153,7 +153,7 @@ char *warn_usedinodes_percent = NULL;
 char *crit_usedinodes_percent = NULL;
 char *warn_freeinodes_percent = NULL;
 char *crit_freeinodes_percent = NULL;
-int path_selected = FALSE;
+bool path_selected = false;
 bool path_ignored = false;
 char *group = NULL;
 struct stat *stat_buf;
@@ -205,7 +205,7 @@ main (int argc, char **argv)
   /* If a list of paths has not been selected, find entire
      mount list and create list of paths
    */
-  if (path_selected == FALSE && path_ignored == false) {
+  if (path_selected == false && path_ignored == false) {
     for (me = mount_list; me; me = me->me_next) {
       if (! (path = np_find_parameter(path_select_list, me->me_mountdir))) {
         path = np_add_parameter(&path_select_list, me->me_mountdir);
@@ -396,10 +396,10 @@ main (int argc, char **argv)
               perfdata_uint64 (
                   (!strcmp(me->me_mountdir, "none") || display_mntp) ? me->me_devname : me->me_mountdir,
                   path->dused_units * mult, "B",
-                  (warning_high_tide == UINT64_MAX ? FALSE : TRUE), warning_high_tide,
-                  (critical_high_tide == UINT64_MAX ? FALSE : TRUE), critical_high_tide,
-                  TRUE, 0,
-                  TRUE, path->dtotal_units * mult));
+                  (warning_high_tide == UINT64_MAX ? false : true), warning_high_tide,
+                  (critical_high_tide == UINT64_MAX ? false : true), critical_high_tide,
+                  true, 0,
+                  true, path->dtotal_units * mult));
 
       if (display_inodes_perfdata) {
         /* *_high_tide must be reinitialized at each run */
@@ -418,10 +418,10 @@ main (int argc, char **argv)
         xasprintf (&perf, "%s %s", perf,
                 perfdata_uint64 (perf_ilabel,
                     path->inodes_used, "",
-                    (warning_high_tide != UINT64_MAX ? TRUE : FALSE), warning_high_tide,
-                    (critical_high_tide != UINT64_MAX ? TRUE : FALSE), critical_high_tide,
-                    TRUE, 0,
-                    TRUE, path->inodes_total));
+                    (warning_high_tide != UINT64_MAX ? true : false), warning_high_tide,
+                    (critical_high_tide != UINT64_MAX ? true : false), critical_high_tide,
+                    true, 0,
+                    true, path->inodes_total));
       }
 
       if (disk_result==STATE_OK && erronly && !verbose)
@@ -710,7 +710,7 @@ process_arguments (int argc, char **argv)
       mount_list = read_file_system_list (0);
       np_set_best_match(se, mount_list, exact_match);
 
-      path_selected = TRUE;
+      path_selected = true;
       break;
     case 'x':                 /* exclude path or partition */
       np_add_name(&dp_exclude_list, optarg);
@@ -734,18 +734,18 @@ process_arguments (int argc, char **argv)
       break;
     case 'q':                 /* TODO: this function should eventually go away (removed 2007-09-20) */
       /* verbose--; **replaced by line below**. -q was only a broken way of implementing -e */
-      erronly = TRUE;
+      erronly = true;
       break;
     case 'e':
-      erronly = TRUE;
+      erronly = true;
       break;
     case 'E':
       if (path_selected)
         die (STATE_UNKNOWN, "DISK %s: %s", _("UNKNOWN"), _("Must set -E before selecting paths\n"));
-      exact_match = TRUE;
+      exact_match = true;
       break;
     case 'f':
-      freespace_ignore_reserved = TRUE;
+      freespace_ignore_reserved = true;
       break;
     case 'g':
       if (path_selected)
@@ -817,7 +817,7 @@ process_arguments (int argc, char **argv)
 
       for (me = mount_list; me; me = me->me_next) {
         if (np_regex_match_mount_entry(me, &re)) {
-          fnd = TRUE;
+          fnd = true;
           if (verbose >= 3)
             printf("%s %s matching expression %s\n", me->me_devname, me->me_mountdir, optarg);
 
@@ -832,24 +832,24 @@ process_arguments (int argc, char **argv)
 
       if (!fnd && ignore_missing == true) {
         path_ignored = true;
-        /* path_selected = TRUE;*/
+        /* path_selected = true;*/
         break;
       } else if (!fnd)
         die (STATE_UNKNOWN, "DISK %s: %s - %s\n",_("UNKNOWN"),
             _("Regular expression did not match any path or disk"), optarg);
 
-      fnd = FALSE;
-      path_selected = TRUE;
+      fnd = false;
+      path_selected = true;
       np_set_best_match(path_select_list, mount_list, exact_match);
       cflags = default_cflags;
 
       break;
     case 'M': /* display mountpoint */
-      display_mntp = TRUE;
+      display_mntp = true;
       break;
     case 'C':
        /* add all mount entries to path_select list if no partitions have been explicitly defined using -p */
-       if (path_selected == FALSE) {
+       if (path_selected == false) {
          struct parameter_list *path;
          for (me = mount_list; me; me = me->me_next) {
            if (! (path = np_find_parameter(path_select_list, me->me_mountdir)))
@@ -872,7 +872,7 @@ process_arguments (int argc, char **argv)
       warn_freeinodes_percent = NULL;
       crit_freeinodes_percent = NULL;
 
-      path_selected = FALSE;
+      path_selected = false;
       group = NULL;
       break;
     case 'V':                 /* version */
@@ -896,7 +896,7 @@ process_arguments (int argc, char **argv)
 
   if (argc > c) {
     se = np_add_parameter(&path_select_list, strdup(argv[c++]));
-    path_selected = TRUE;
+    path_selected = true;
     set_all_thresholds(se);
   }
 
@@ -905,7 +905,7 @@ process_arguments (int argc, char **argv)
     mult = (uintmax_t)1024 * 1024;
   }
 
-  return TRUE;
+  return true;
 }
 
 

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -41,8 +41,8 @@ const char *email = "devel@monitoring-plugins.org";
 
 int process_arguments (int, char **);
 int validate_arguments (void);
-int error_scan (char *, int *);
-int ip_match_cidr(const char *, const char *);
+int error_scan (char *, bool *);
+bool ip_match_cidr(const char *, const char *);
 unsigned long ip2long(const char *);
 void print_help (void);
 void print_usage (void);
@@ -51,13 +51,13 @@ void print_usage (void);
 char query_address[ADDRESS_LENGTH] = "";
 char dns_server[ADDRESS_LENGTH] = "";
 char ptr_server[ADDRESS_LENGTH] = "";
-int verbose = FALSE;
+bool verbose = false;
 char **expected_address = NULL;
 int expected_address_cnt = 0;
-int expect_nxdomain = FALSE;
+bool expect_nxdomain = false;
 
-int expect_authority = FALSE;
-int all_match = FALSE;
+bool expect_authority = false;
+bool all_match = false;
 thresholds *time_thresholds = NULL;
 
 static int
@@ -80,15 +80,15 @@ main (int argc, char **argv)
   int n_addresses = 0;
   char *msg = NULL;
   char *temp_buffer = NULL;
-  int non_authoritative = FALSE;
+  bool non_authoritative = false;
   int result = STATE_UNKNOWN;
   double elapsed_time;
   long microsec;
   struct timeval tv;
-  int parse_address = FALSE; /* This flag scans for Address: but only after Name: */
+  bool parse_address = false; /* This flag scans for Address: but only after Name: */
   output chld_out, chld_err;
   size_t i;
-  int is_nxdomain = FALSE;
+  int is_nxdomain = false;
 
   setlocale (LC_ALL, "");
   bindtextdomain (PACKAGE, LOCALEDIR);
@@ -164,8 +164,8 @@ main (int argc, char **argv)
 
     /* the server is responding, we just got the host name... */
     if (strstr (chld_out.line[i], "Name:"))
-      parse_address = TRUE;
-    else if (parse_address == TRUE && (strstr (chld_out.line[i], "Address:") ||
+      parse_address = true;
+    else if (parse_address && (strstr (chld_out.line[i], "Address:") ||
              strstr (chld_out.line[i], "Addresses:"))) {
       temp_buffer = index (chld_out.line[i], ':');
       temp_buffer++;
@@ -184,7 +184,7 @@ main (int argc, char **argv)
       addresses[n_addresses++] = strdup(temp_buffer);
     }
     else if (strstr (chld_out.line[i], _("Non-authoritative answer:"))) {
-      non_authoritative = TRUE;
+      non_authoritative = true;
     }
 
 
@@ -298,21 +298,21 @@ main (int argc, char **argv)
     printf (_(". %s returns %s"), query_address, address);
     if ((time_thresholds->warning != NULL) && (time_thresholds->critical != NULL)) {
       printf ("|%s\n", fperfdata ("time", elapsed_time, "s",
-                                  TRUE, time_thresholds->warning->end,
-                                  TRUE, time_thresholds->critical->end,
-                                  TRUE, 0, FALSE, 0));
+                                  true, time_thresholds->warning->end,
+                                  true, time_thresholds->critical->end,
+                                  true, 0, false, 0));
     } else if ((time_thresholds->warning == NULL) && (time_thresholds->critical != NULL)) {
       printf ("|%s\n", fperfdata ("time", elapsed_time, "s",
-                                  FALSE, 0,
-                                  TRUE, time_thresholds->critical->end,
-                                  TRUE, 0, FALSE, 0));
+                                  false, 0,
+                                  true, time_thresholds->critical->end,
+                                  true, 0, false, 0));
     } else if ((time_thresholds->warning != NULL) && (time_thresholds->critical == NULL)) {
       printf ("|%s\n", fperfdata ("time", elapsed_time, "s",
-                                  TRUE, time_thresholds->warning->end,
-                                  FALSE, 0,
-                                  TRUE, 0, FALSE, 0));
+                                  true, time_thresholds->warning->end,
+                                  false, 0,
+                                  true, 0, false, 0));
     } else
-      printf ("|%s\n", fperfdata ("time", elapsed_time, "s", FALSE, 0, FALSE, 0, TRUE, 0, FALSE, 0));
+      printf ("|%s\n", fperfdata ("time", elapsed_time, "s", false, 0, false, 0, true, 0, false, 0));
   }
   else if (result == STATE_WARNING)
     printf (_("DNS WARNING - %s\n"),
@@ -327,15 +327,14 @@ main (int argc, char **argv)
   return result;
 }
 
-int
-ip_match_cidr(const char *addr, const char *cidr_ro)
-{
+bool ip_match_cidr(const char *addr, const char *cidr_ro) {
   char *subnet, *mask_c, *cidr = strdup(cidr_ro);
   int mask;
   subnet = strtok(cidr, "/");
   mask_c = strtok(NULL, "\0");
-  if (!subnet || !mask_c)
-    return FALSE;
+  if (!subnet || !mask_c) {
+    return false;
+	}
   mask = atoi(mask_c);
 
   /* https://www.cryptobells.com/verifying-ips-in-a-subnet-in-php/ */
@@ -355,14 +354,14 @@ ip2long(const char* src) {
 }
 
 int
-error_scan (char *input_buffer, int *is_nxdomain)
+error_scan (char *input_buffer, bool *is_nxdomain)
 {
 
   const int nxdomain = strstr (input_buffer, "Non-existent") ||
                        strstr (input_buffer, "** server can't find") ||
                        strstr (input_buffer, "** Can't find") ||
                        strstr (input_buffer, "NXDOMAIN");
-  if (nxdomain) *is_nxdomain = TRUE;
+  if (nxdomain) *is_nxdomain = true;
 
   /* the DNS lookup timed out */
   if (strstr (input_buffer, _("Note: nslookup is deprecated and may be removed from future releases.")) ||
@@ -461,7 +460,7 @@ process_arguments (int argc, char **argv)
       print_revision (progname, NP_VERSION);
       exit (STATE_UNKNOWN);
     case 'v': /* version */
-      verbose = TRUE;
+      verbose = true;
       break;
     case 't': /* timeout period */
       timeout_interval = atoi (optarg);
@@ -508,13 +507,13 @@ process_arguments (int argc, char **argv)
       }
       break;
     case 'n': /* expect NXDOMAIN */
-      expect_nxdomain = TRUE;
+      expect_nxdomain = true;
       break;
     case 'A': /* expect authority */
-      expect_authority = TRUE;
+      expect_authority = true;
       break;
     case 'L': /* all must match */
-      all_match = TRUE;
+      all_match = true;
       break;
     case 'w':
       warning = optarg;

--- a/plugins/check_dns.c
+++ b/plugins/check_dns.c
@@ -88,7 +88,7 @@ main (int argc, char **argv)
   bool parse_address = false; /* This flag scans for Address: but only after Name: */
   output chld_out, chld_err;
   size_t i;
-  int is_nxdomain = false;
+  bool is_nxdomain = false;
 
   setlocale (LC_ALL, "");
   bindtextdomain (PACKAGE, LOCALEDIR);

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -59,16 +59,16 @@ int packet_size = PACKET_SIZE;
 int packet_count = PACKET_COUNT;
 int target_timeout = 0;
 int packet_interval = 0;
-int verbose = FALSE;
+bool verbose = false;
 int cpl;
 int wpl;
 double crta;
 double wrta;
-int cpl_p = FALSE;
-int wpl_p = FALSE;
-bool alive_p = FALSE;
-int crta_p = FALSE;
-int wrta_p = FALSE;
+bool cpl_p = false;
+bool wpl_p = false;
+bool alive_p = false;
+bool crta_p = false;
+bool wrta_p = false;
 
 int
 main (int argc, char **argv)
@@ -194,8 +194,8 @@ int textscan (char *buf) {
          _("FPING %s - %s (rta=%f ms)|%s\n"),
          state_text (STATE_OK), server_name,rta,
 		 /* No loss since we only waited for the first reply
-         perfdata ("loss", (long int)loss, "%", wpl_p, wpl, cpl_p, cpl, TRUE, 0, TRUE, 100), */
-         fperfdata ("rta", rta/1.0e3, "s", wrta_p, wrta/1.0e3, crta_p, crta/1.0e3, TRUE, 0, FALSE, 0));
+         perfdata ("loss", (long int)loss, "%", wpl_p, wpl, cpl_p, cpl, true, 0, true, 100), */
+         fperfdata ("rta", rta/1.0e3, "s", wrta_p, wrta/1.0e3, crta_p, crta/1.0e3, true, 0, false, 0));
   }
 
   if (strstr (buf, "not found")) {
@@ -228,21 +228,21 @@ int textscan (char *buf) {
     rtastr = 1 + index (rtastr, '/');
     loss = strtod (losstr, NULL);
     rta = strtod (rtastr, NULL);
-    if (cpl_p == TRUE && loss > cpl)
+    if (cpl_p && loss > cpl)
       status = STATE_CRITICAL;
-    else if (crta_p == TRUE  && rta > crta)
+    else if (crta_p && rta > crta)
       status = STATE_CRITICAL;
-    else if (wpl_p == TRUE && loss > wpl)
+    else if (wpl_p && loss > wpl)
       status = STATE_WARNING;
-    else if (wrta_p == TRUE && rta > wrta)
+    else if (wrta_p && rta > wrta)
       status = STATE_WARNING;
     else
       status = STATE_OK;
     die (status,
           _("FPING %s - %s (loss=%.0f%%, rta=%f ms)|%s %s\n"),
          state_text (status), server_name, loss, rta,
-         perfdata ("loss", (long int)loss, "%", wpl_p, wpl, cpl_p, cpl, TRUE, 0, TRUE, 100),
-         fperfdata ("rta", rta/1.0e3, "s", wrta_p, wrta/1.0e3, crta_p, crta/1.0e3, TRUE, 0, FALSE, 0));
+         perfdata ("loss", (long int)loss, "%", wpl_p, wpl, cpl_p, cpl, true, 0, true, 100),
+         fperfdata ("rta", rta/1.0e3, "s", wrta_p, wrta/1.0e3, crta_p, crta/1.0e3, true, 0, false, 0));
 
   }
   else if(strstr (buf, "xmt/rcv/%loss") ) {
@@ -258,16 +258,16 @@ int textscan (char *buf) {
     loss = strtod (losstr, NULL);
     if (atoi(losstr) == 100)
       status = STATE_CRITICAL;
-    else if (cpl_p == TRUE && loss > cpl)
+    else if (cpl_p && loss > cpl)
       status = STATE_CRITICAL;
-    else if (wpl_p == TRUE && loss > wpl)
+    else if (wpl_p && loss > wpl)
       status = STATE_WARNING;
     else
       status = STATE_OK;
     /* loss=%.0f%%;%d;%d;0;100 */
     die (status, _("FPING %s - %s (loss=%.0f%% )|%s\n"),
          state_text (status), server_name, loss ,
-         perfdata ("loss", (long int)loss, "%", wpl_p, wpl, cpl_p, cpl, TRUE, 0, TRUE, 100));
+         perfdata ("loss", (long int)loss, "%", wpl_p, wpl, cpl_p, cpl, true, 0, true, 100));
 
   }
   else {
@@ -329,7 +329,7 @@ process_arguments (int argc, char **argv)
     case '?':                 /* print short usage statement if args not parsable */
       usage5 ();
     case 'a':                 /* host alive mode */
-      alive_p = TRUE;
+      alive_p = true;
       break;
     case 'h':                 /* help */
       print_help ();
@@ -338,16 +338,16 @@ process_arguments (int argc, char **argv)
       print_revision (progname, NP_VERSION);
       exit (STATE_UNKNOWN);
     case 'v':                 /* verbose mode */
-      verbose = TRUE;
+      verbose = true;
       break;
     case 'H':                 /* hostname */
-      if (is_host (optarg) == FALSE) {
+      if (is_host (optarg) == false) {
         usage2 (_("Invalid hostname/address"), optarg);
       }
       server_name = strscpy (server_name, optarg);
       break;
     case 'S':                 /* sourceip */
-      if (is_host (optarg) == FALSE) {
+      if (is_host (optarg) == false) {
         usage2 (_("Invalid hostname/address"), optarg);
       }
       sourceip = strscpy (sourceip, optarg);
@@ -369,12 +369,12 @@ process_arguments (int argc, char **argv)
       get_threshold (optarg, rv);
       if (rv[RTA]) {
         crta = strtod (rv[RTA], NULL);
-        crta_p = TRUE;
+        crta_p = true;
         rv[RTA] = NULL;
       }
       if (rv[PL]) {
         cpl = atoi (rv[PL]);
-        cpl_p = TRUE;
+        cpl_p = true;
         rv[PL] = NULL;
       }
       break;
@@ -382,12 +382,12 @@ process_arguments (int argc, char **argv)
       get_threshold (optarg, rv);
       if (rv[RTA]) {
         wrta = strtod (rv[RTA], NULL);
-        wrta_p = TRUE;
+        wrta_p = true;
         rv[RTA] = NULL;
       }
       if (rv[PL]) {
         wpl = atoi (rv[PL]);
-        wpl_p = TRUE;
+        wpl_p = true;
         rv[PL] = NULL;
       }
       break;

--- a/plugins/check_game.c
+++ b/plugins/check_game.c
@@ -53,7 +53,7 @@ char *server_ip;
 char *game_type;
 int port = 0;
 
-int verbose;
+bool verbose = false;
 
 int qstat_game_players_max = -1;
 int qstat_game_players = -1;
@@ -90,7 +90,7 @@ main (int argc, char **argv)
   if (port)
     xasprintf (&command_line, "%s:%-d", command_line, port);
 
-  if (verbose > 0)
+  if (verbose)
     printf ("%s\n", command_line);
 
   /* run the command. historically, this plugin ignores output on stderr,
@@ -142,11 +142,11 @@ main (int argc, char **argv)
             ret[qstat_map_field],
             ret[qstat_ping_field],
             perfdata ("players", atol(ret[qstat_game_players]), "",
-                      FALSE, 0, FALSE, 0,
-                      TRUE, 0, TRUE, atol(ret[qstat_game_players_max])),
+                      false, 0, false, 0,
+                      true, 0, true, atol(ret[qstat_game_players_max])),
             fperfdata ("ping", strtod(ret[qstat_ping_field], NULL), "",
-                      FALSE, 0, FALSE, 0,
-                      TRUE, 0, FALSE, 0));
+                      false, 0, false, 0,
+                      true, 0, false, 0));
   }
 
   return result;
@@ -201,7 +201,7 @@ process_arguments (int argc, char **argv)
       print_revision (progname, NP_VERSION);
       exit (STATE_UNKNOWN);
     case 'v': /* version */
-      verbose = TRUE;
+      verbose = true;
       break;
     case 't': /* timeout period */
       timeout_interval = atoi (optarg);

--- a/plugins/check_ide_smart.c
+++ b/plugins/check_ide_smart.c
@@ -73,10 +73,6 @@ void print_usage (void);
 	
 #define NR_ATTRIBUTES	30
 	
-#ifndef TRUE
-#define TRUE 1
-#endif	/*  */
-	
 #define PREFAILURE 2
 #define ADVISORY 1
 #define OPERATIONAL 0
@@ -169,9 +165,9 @@ int smart_read_values (int, values_t *);
 int nagios (values_t *, thresholds_t *);
 void print_value (value_t *, threshold_t *);
 void print_values (values_t *, thresholds_t *);
-int smart_cmd_simple (int, enum SmartCommand, __u8, char);
+int smart_cmd_simple (int, enum SmartCommand, __u8, bool);
 int smart_read_thresholds (int, thresholds_t *);
-int verbose = FALSE;
+bool verbose = false;
 
 int
 main (int argc, char *argv[]) 
@@ -203,7 +199,7 @@ main (int argc, char *argv[])
 	bindtextdomain (PACKAGE, LOCALEDIR);
 	textdomain (PACKAGE);
 
-	while (1) {
+	while (true) {
 		
 		o = getopt_long (argc, argv, "+d:iq10nhVv", longopts, &longindex);
 
@@ -229,7 +225,7 @@ main (int argc, char *argv[])
 			fprintf (stderr, "%s\n", _("default and will be removed from future releases."));
 			break;
 		case 'v': /* verbose */
-			verbose = TRUE;
+			verbose = true;
 			break;
 		case 'h':
 			print_help ();
@@ -258,7 +254,7 @@ main (int argc, char *argv[])
 		return STATE_CRITICAL;
 	}
 
-	if (smart_cmd_simple (fd, SMART_CMD_ENABLE, 0, FALSE)) {
+	if (smart_cmd_simple (fd, SMART_CMD_ENABLE, 0, false)) {
 		printf (_("CRITICAL - SMART_CMD_ENABLE\n"));
 		return STATE_CRITICAL;
 	}
@@ -447,9 +443,7 @@ print_values (values_t * p, thresholds_t * t)
 }
 
 
-int
-smart_cmd_simple (int fd, enum SmartCommand command, __u8 val0, char show_error) 
-{
+int smart_cmd_simple (int fd, enum SmartCommand command, __u8 val0, bool show_error) {
 	int e = STATE_UNKNOWN;
 #ifdef __linux__
 	__u8 args[4];

--- a/plugins/check_ldap.c
+++ b/plugins/check_ldap.c
@@ -71,9 +71,9 @@ thresholds *entries_thresholds = NULL;
 struct timeval tv;
 char* warn_entries = NULL;
 char* crit_entries = NULL;
-int starttls = FALSE;
-int ssl_on_connect = FALSE;
-int verbose = 0;
+bool starttls = false;
+bool ssl_on_connect = false;
+bool verbose = false;
 
 /* for ldap tls */
 
@@ -115,7 +115,7 @@ main (int argc, char *argv[])
 		usage4 (_("Could not parse arguments"));
 
 	if (strstr(argv[0],"check_ldaps") && ! starttls && ! ssl_on_connect)
-		starttls = TRUE;
+		starttls = true;
 
 	/* initialize alarm signal handling */
 	signal (SIGALRM, socket_timeout_alarm_handler);
@@ -253,11 +253,11 @@ main (int argc, char *argv[])
 			fperfdata ("time", elapsed_time, "s",
 				(int)warn_time, warn_time,
 				(int)crit_time, crit_time,
-				TRUE, 0, FALSE, 0),
+				true, 0, false, 0),
 			sperfdata ("entries", (double)num_entries, "",
 				warn_entries,
 				crit_entries,
-				TRUE, 0.0, FALSE, 0.0));
+				true, 0.0, false, 0.0));
 	} else {
 		printf (_("LDAP %s - %.3f seconds response time|%s\n"),
 			state_text (status),
@@ -265,7 +265,7 @@ main (int argc, char *argv[])
 			fperfdata ("time", elapsed_time, "s",
 				(int)warn_time, warn_time,
 				(int)crit_time, crit_time,
-				TRUE, 0, FALSE, 0));
+				true, 0, false, 0));
 	}
 
 	return status;
@@ -313,7 +313,7 @@ process_arguments (int argc, char **argv)
 			strcpy (argv[c], "-t");
 	}
 
-	while (1) {
+	while (true) {
 		c = getopt_long (argc, argv, "hvV234TS6t:c:w:H:b:p:a:D:P:C:W:", longopts, &option);
 
 		if (c == -1 || c == EOF)
@@ -374,17 +374,17 @@ process_arguments (int argc, char **argv)
 			address_family = AF_INET;
 			break;
 		case 'v':
-			verbose++;
+			verbose = true;
 			break;
 		case 'T':
 			if (! ssl_on_connect)
-				starttls = TRUE;
+				starttls = true;
 			else
 				usage_va(_("%s cannot be combined with %s"), "-T/--starttls", "-S/--ssl");
 			break;
 		case 'S':
 			if (! starttls) {
-				ssl_on_connect = TRUE;
+				ssl_on_connect = true;
 				if (ld_port == -1)
 					ld_port = LDAPS_PORT;
 			} else

--- a/plugins/check_mrtg.c
+++ b/plugins/check_mrtg.c
@@ -43,7 +43,7 @@ void print_usage (void);
 
 char *log_file = NULL;
 int expire_minutes = 0;
-int use_average = TRUE;
+bool use_average = true;
 int variable_number = -1;
 unsigned long value_warning_threshold = 0L;
 unsigned long value_critical_threshold = 0L;
@@ -138,7 +138,7 @@ main (int argc, char **argv)
 	}
 
 	/* else check the incoming/outgoing rates */
-	if (use_average == TRUE)
+	if (use_average)
 		rate = average_value_rate;
 	else
 		rate = maximum_value_rate;
@@ -149,7 +149,7 @@ main (int argc, char **argv)
 		result = STATE_WARNING;
 
 	printf("%s. %s = %lu %s|%s\n",
-	       (use_average == TRUE) ? _("Avg") : _("Max"),
+	       (use_average) ? _("Avg") : _("Max"),
 	       label, rate, units,
 	       perfdata(label, (long) rate, units,
 		        (int) value_warning_threshold, (long) value_warning_threshold,
@@ -211,9 +211,9 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'a':									/* port */
 			if (!strcmp (optarg, "MAX"))
-				use_average = FALSE;
+				use_average = false;
 			else
-				use_average = TRUE;
+				use_average = true;
 			break;
 		case 'v':
 			variable_number = atoi (optarg);
@@ -258,11 +258,11 @@ process_arguments (int argc, char **argv)
 	}
 
 	if (argc > c && strcmp (argv[c], "MAX") == 0) {
-		use_average = FALSE;
+		use_average = false;
 		c++;
 	}
 	else if (argc > c && strcmp (argv[c], "AVG") == 0) {
-		use_average = TRUE;
+		use_average = true;
 		c++;
 	}
 

--- a/plugins/check_mrtgtraf.c
+++ b/plugins/check_mrtgtraf.c
@@ -43,7 +43,7 @@ void print_usage(void);
 
 char *log_file = NULL;
 int expire_minutes = -1;
-int use_average = TRUE;
+bool use_average = true;
 unsigned long incoming_warning_threshold = 0L;
 unsigned long incoming_critical_threshold = 0L;
 unsigned long outgoing_warning_threshold = 0L;
@@ -137,7 +137,7 @@ main (int argc, char **argv)
 		     (int) ((current_time - timestamp) / 60));
 
 	/* else check the incoming/outgoing rates */
-	if (use_average == TRUE) {
+	if (use_average) {
 		incoming_rate = average_incoming_rate;
 		outgoing_rate = average_outgoing_rate;
 	}
@@ -192,17 +192,17 @@ main (int argc, char **argv)
 	}
 
 	xasprintf (&error_message, _("%s. In = %0.1f %s/s, %s. Out = %0.1f %s/s|%s %s\n"),
-	          (use_average == TRUE) ? _("Avg") : _("Max"), adjusted_incoming_rate,
-	          incoming_speed_rating, (use_average == TRUE) ? _("Avg") : _("Max"),
+	          (use_average) ? _("Avg") : _("Max"), adjusted_incoming_rate,
+	          incoming_speed_rating, (use_average) ? _("Avg") : _("Max"),
 	          adjusted_outgoing_rate, outgoing_speed_rating,
 	          fperfdata("in", adjusted_incoming_rate, incoming_speed_rating,
 	                   (int)incoming_warning_threshold, incoming_warning_threshold,
 	                   (int)incoming_critical_threshold, incoming_critical_threshold,
-	                   TRUE, 0, FALSE, 0),
+	                   true, 0, false, 0),
 	          fperfdata("out", adjusted_outgoing_rate, outgoing_speed_rating,
 	                   (int)outgoing_warning_threshold, outgoing_warning_threshold,
 	                   (int)outgoing_critical_threshold, outgoing_critical_threshold,
-	                   TRUE, 0, FALSE, 0));
+	                   true, 0, false, 0));
 
 	printf (_("Traffic %s - %s\n"), state_text(result), error_message);
 
@@ -256,9 +256,9 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'a':									/* aggregation (AVE or MAX) */
 			if (!strcmp (optarg, "MAX"))
-				use_average = FALSE;
+				use_average = false;
 			else
-				use_average = TRUE;
+				use_average = true;
 			break;
 		case 'c':									/* warning threshold */
 			sscanf (optarg, "%lu,%lu", &incoming_critical_threshold,
@@ -289,11 +289,11 @@ process_arguments (int argc, char **argv)
 	}
 
 	if (argc > c && strcmp (argv[c], "MAX") == 0) {
-		use_average = FALSE;
+		use_average = false;
 		c++;
 	}
 	else if (argc > c && strcmp (argv[c], "AVG") == 0) {
-		use_average = TRUE;
+		use_average = true;
 		c++;
 	}
 

--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -113,7 +113,7 @@ main (int argc, char **argv)
 	char slaveresult[SLAVERESULTSIZE] = { 0 };
 	char* perf;
 
-        perf = strdup ("");
+	perf = strdup ("");
 
 	setlocale (LC_ALL, "");
 	bindtextdomain (PACKAGE, LOCALEDIR);
@@ -193,14 +193,14 @@ main (int argc, char **argv)
 			for(i = 0; i < LENGTH_METRIC_UNIT; i++) {
 				if (strcmp(row[0], metric_unit[i]) == 0) {
 					xasprintf(&perf, "%s%s ", perf, perfdata(metric_unit[i],
-						atol(row[1]), "", FALSE, 0, FALSE, 0, FALSE, 0, FALSE, 0));
+						atol(row[1]), "", false, 0, false, 0, false, 0, false, 0));
 					continue;
 				}
 			}
 			for(i = 0; i < LENGTH_METRIC_COUNTER; i++) {
 				if (strcmp(row[0], metric_counter[i]) == 0) {
 					xasprintf(&perf, "%s%s ", perf, perfdata(metric_counter[i],
-						atol(row[1]), "c", FALSE, 0, FALSE, 0, FALSE, 0, FALSE, 0));
+						atol(row[1]), "c", false, 0, false, 0, false, 0, false, 0));
 					continue;
 				}
 			}
@@ -322,10 +322,10 @@ main (int argc, char **argv)
 				status = get_status(value, my_threshold);
 
 				xasprintf (&perf, "%s %s", perf, fperfdata ("seconds behind master", value, "s",
-        	                        TRUE, (double) warning_time,
-                	                TRUE, (double) critical_time,
-                        	        FALSE, 0,
-                                	FALSE, 0));
+							true, (double) warning_time,
+							true, (double) critical_time,
+							false, 0,
+							false, 0));
 
 				if (status == STATE_WARNING) {
 					printf("SLOW_SLAVE %s: %s|%s\n", _("WARNING"), slaveresult, perf);

--- a/plugins/check_mysql_query.c
+++ b/plugins/check_mysql_query.c
@@ -162,10 +162,10 @@ main (int argc, char **argv)
 	}
 	printf(_("'%s' returned %f | %s"), sql_query, value,
 		fperfdata("result", value, "",
-		my_thresholds->warning?TRUE:FALSE, my_thresholds->warning?my_thresholds->warning->end:0,
-		my_thresholds->critical?TRUE:FALSE, my_thresholds->critical?my_thresholds->critical->end:0,
-		FALSE, 0, 
-		FALSE, 0)
+		my_thresholds->warning?true:false, my_thresholds->warning?my_thresholds->warning->end:0,
+		my_thresholds->critical?true:false, my_thresholds->critical?my_thresholds->critical->end:0,
+		false, 0,
+		false, 0)
 	);
 	printf("\n");
 

--- a/plugins/check_nt.c
+++ b/plugins/check_nt.c
@@ -67,17 +67,17 @@ char *req_password=NULL;
 unsigned long lvalue_list[MAX_VALUE_LIST];
 unsigned long warning_value=0L;
 unsigned long critical_value=0L;
-int check_warning_value=FALSE;
-int check_critical_value=FALSE;
+bool check_warning_value=false;
+bool check_critical_value=false;
 enum checkvars vars_to_check = CHECK_NONE;
-int show_all=FALSE;
+bool show_all = false;
 
 char recv_buffer[MAX_INPUT_BUFFER];
 
 void fetch_data (const char* address, int port, const char* sendb);
 int process_arguments(int, char **);
 void preparelist(char *string);
-int strtoularray(unsigned long *array, char *string, const char *delim);
+bool strtoularray(unsigned long *array, char *string, const char *delim);
 void print_help(void);
 void print_usage(void);
 
@@ -113,8 +113,8 @@ int main(int argc, char **argv){
 	int uphours=0;
 	int upminutes=0;
 
-	int isPercent = FALSE;
-	int allRight = FALSE;
+	bool isPercent = false;
+	bool allRight = false;
 
 	setlocale (LC_ALL, "");
 	bindtextdomain (PACKAGE, LOCALEDIR);
@@ -151,7 +151,7 @@ int main(int argc, char **argv){
 
 		if (value_list==NULL)
 			output_message = strdup (_("missing -l parameters"));
-		else if (strtoularray(lvalue_list,value_list,",")==FALSE)
+		else if (! strtoularray(lvalue_list,value_list,","))
 			output_message = strdup (_("wrong -l parameter."));
 		else {
 			/* -l parameters is present with only integers */
@@ -224,9 +224,9 @@ int main(int argc, char **argv){
 
 			xasprintf(&output_message,_("System Uptime - %u day(s) %u hour(s) %u minute(s) |uptime=%lu"),updays, uphours, upminutes, uptime);
 
-			if (check_critical_value==TRUE && uptime <= critical_value)
+			if (check_critical_value && uptime <= critical_value)
 				return_code=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && uptime <= warning_value)
+			else if (check_warning_value && uptime <= warning_value)
 				return_code=STATE_WARNING;
 			else
 				return_code=STATE_OK;
@@ -261,9 +261,9 @@ int main(int argc, char **argv){
 				  (total_disk_space - free_disk_space) / 1073741824, warning_used_space / 1073741824,
 				  critical_used_space / 1073741824, total_disk_space / 1073741824);
 
-				if(check_critical_value==TRUE && percent_used_space >= critical_value)
+				if(check_critical_value && percent_used_space >= critical_value)
 					return_code=STATE_CRITICAL;
-				else if (check_warning_value==TRUE && percent_used_space >= warning_value)
+				else if (check_warning_value && percent_used_space >= warning_value)
 					return_code=STATE_WARNING;
 				else
 					return_code=STATE_OK;
@@ -285,7 +285,7 @@ int main(int argc, char **argv){
 		else {
 			preparelist(value_list);		/* replace , between services with & to send the request */
 			xasprintf(&send_buffer,"%s&%u&%s&%s", req_password,(vars_to_check==CHECK_SERVICESTATE)?5:6,
-							 (show_all==TRUE) ? "ShowAll" : "ShowFail",value_list);
+							 (show_all) ? "ShowAll" : "ShowFail",value_list);
 			fetch_data (server_address, server_port, send_buffer);
 			numstr = strtok(recv_buffer,"&");
 			if (numstr == NULL)
@@ -321,9 +321,9 @@ int main(int argc, char **argv){
 		  warning_used_space / 1048567, critical_used_space / 1048567, mem_commitLimit / 1048567);
 
 		return_code=STATE_OK;
-		if(check_critical_value==TRUE && percent_used_space >= critical_value)
+		if(check_critical_value && percent_used_space >= critical_value)
 			return_code=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && percent_used_space >= warning_value)
+		else if (check_warning_value && percent_used_space >= warning_value)
 			return_code=STATE_WARNING;
 
 		break;
@@ -371,7 +371,7 @@ int main(int argc, char **argv){
 			else if (isPercent)
 			{
 				counter_unit = strdup ("%");
-				allRight = TRUE;
+				allRight = true;
 			}
 
 			if ((counter_unit != NULL) && (!allRight))
@@ -391,7 +391,7 @@ int main(int argc, char **argv){
 					if ((fmaxval == 0) && (maxval == errcvt))
 						output_message = strdup (_("Maximum value contains non-numbers"));
 					else
-						allRight = TRUE;	/* Everything is OK. */
+						allRight = true;	/* Everything is OK. */
 
 				}
 			}
@@ -418,9 +418,9 @@ int main(int argc, char **argv){
 
 		if (critical_value > warning_value)
 		{			/* Normal thresholds */
-			if (check_critical_value == TRUE && counter_value >= critical_value)
+			if (check_critical_value && counter_value >= critical_value)
 				return_code = STATE_CRITICAL;
-			else if (check_warning_value == TRUE && counter_value >= warning_value)
+			else if (check_warning_value  && counter_value >= warning_value)
 				return_code = STATE_WARNING;
 			else
 				return_code = STATE_OK;
@@ -428,9 +428,9 @@ int main(int argc, char **argv){
 		else
 		{			/* inverse thresholds */
 			return_code = STATE_OK;
-			if (check_critical_value == TRUE && counter_value <= critical_value)
+			if (check_critical_value && counter_value <= critical_value)
 				return_code = STATE_CRITICAL;
-			else if (check_warning_value == TRUE && counter_value <= warning_value)
+			else if (check_warning_value && counter_value <= warning_value)
 				return_code = STATE_WARNING;
 		}
 	break;
@@ -448,17 +448,17 @@ int main(int argc, char **argv){
 			output_message = strdup (description);
 
 			if (critical_value > warning_value) {        /* Normal thresholds */
-				if(check_critical_value==TRUE && age_in_minutes >= critical_value)
+				if(check_critical_value && age_in_minutes >= critical_value)
 					return_code=STATE_CRITICAL;
-				else if (check_warning_value==TRUE && age_in_minutes >= warning_value)
+				else if (check_warning_value && age_in_minutes >= warning_value)
 					return_code=STATE_WARNING;
 				else
 					return_code=STATE_OK;
 			}
 			else {                                       /* inverse thresholds */
-				if(check_critical_value==TRUE && age_in_minutes <= critical_value)
+				if(check_critical_value && age_in_minutes <= critical_value)
 					return_code=STATE_CRITICAL;
-				else if (check_warning_value==TRUE && age_in_minutes <= warning_value)
+				else if (check_warning_value && age_in_minutes <= warning_value)
 					return_code=STATE_WARNING;
 				else
 					return_code=STATE_OK;
@@ -600,15 +600,15 @@ int process_arguments(int argc, char **argv){
 				break;
 			case 'w': /* warning threshold */
 				warning_value=strtoul(optarg,NULL,10);
-				check_warning_value=TRUE;
+				check_warning_value=true;
 				break;
 			case 'c': /* critical threshold */
 				critical_value=strtoul(optarg,NULL,10);
-				check_critical_value=TRUE;
+				check_critical_value=true;
 				break;
 			case 'd': /* Display select for services */
 				if (!strcmp(optarg,"SHOWALL"))
-					show_all = TRUE;
+					show_all = true;
 				break;
 			case 'u':
 				socket_timeout_state=STATE_UNKNOWN;
@@ -646,7 +646,7 @@ void fetch_data (const char *address, int port, const char *sendb) {
 		die (STATE_UNKNOWN, "NSClient - %s\n",recv_buffer);
 }
 
-int strtoularray(unsigned long *array, char *string, const char *delim) {
+bool strtoularray(unsigned long *array, char *string, const char *delim) {
 	/* split a <delim> delimited string into a long array */
 	int idx=0;
 	char *t1;
@@ -660,9 +660,9 @@ int strtoularray(unsigned long *array, char *string, const char *delim) {
 			array[idx]=strtoul(t1,NULL,10);
 			idx++;
 		} else
-			return FALSE;
+			return false;
 	}
-	return TRUE;
+	return true;
 }
 
 void preparelist(char *string) {

--- a/plugins/check_ntp.c
+++ b/plugins/check_ntp.c
@@ -40,10 +40,10 @@ const char *email = "devel@monitoring-plugins.org";
 
 static char *server_address=NULL;
 static int verbose=0;
-static short do_offset=0;
+static bool do_offset = false;
 static char *owarn="60";
 static char *ocrit="120";
-static short do_jitter=0;
+static bool do_jitter = false;
 static char *jwarn="5000";
 static char *jcrit="10000";
 
@@ -513,7 +513,8 @@ setup_control_request(ntp_control_message *p, uint8_t opcode, uint16_t seq){
 
 /* XXX handle responses with the error bit set */
 double jitter_request(int *status){
-	int conn=-1, i, npeers=0, num_candidates=0, syncsource_found=0;
+	int conn=-1, i, npeers=0, num_candidates=0;
+	bool syncsource_found = false;
 	int run=0, min_peer_sel=PEER_INCLUDED, num_selected=0, num_valid=0;
 	int peers_size=0, peer_offset=0;
 	ntp_assoc_status_pair *peers=NULL;
@@ -570,7 +571,7 @@ double jitter_request(int *status){
 		if (PEER_SEL(peers[i].status) >= PEER_INCLUDED){
 			num_candidates++;
 			if(PEER_SEL(peers[i].status) >= PEER_SYNCSOURCE){
-				syncsource_found=1;
+				syncsource_found = true;
 				min_peer_sel=PEER_SYNCSOURCE;
 			}
 		}
@@ -699,23 +700,23 @@ int process_arguments(int argc, char **argv){
 			verbose++;
 			break;
 		case 'w':
-			do_offset=1;
+			do_offset = true;
 			owarn = optarg;
 			break;
 		case 'c':
-			do_offset=1;
+			do_offset = true;
 			ocrit = optarg;
 			break;
 		case 'j':
-			do_jitter=1;
+			do_jitter = true;
 			jwarn = optarg;
 			break;
 		case 'k':
-			do_jitter=1;
+			do_jitter = true;
 			jcrit = optarg;
 			break;
 		case 'H':
-			if(is_host(optarg) == FALSE)
+			if(!is_host(optarg))
 				usage2(_("Invalid hostname/address"), optarg);
 			server_address = strdup(optarg);
 			break;
@@ -749,9 +750,9 @@ int process_arguments(int argc, char **argv){
 char *perfd_offset (double offset)
 {
 	return fperfdata ("offset", offset, "s",
-		TRUE, offset_thresholds->warning->end,
-		TRUE, offset_thresholds->critical->end,
-		FALSE, 0, FALSE, 0);
+		true, offset_thresholds->warning->end,
+		true, offset_thresholds->critical->end,
+		false, 0, false, 0);
 }
 
 char *perfd_jitter (double jitter)
@@ -759,7 +760,7 @@ char *perfd_jitter (double jitter)
 	return fperfdata ("jitter", jitter, "s",
 		do_jitter, jitter_thresholds->warning->end,
 		do_jitter, jitter_thresholds->critical->end,
-		TRUE, 0, FALSE, 0);
+		true, 0, false, 0);
 }
 
 int main(int argc, char *argv[]){

--- a/plugins/check_ntp.c
+++ b/plugins/check_ntp.c
@@ -39,11 +39,11 @@ const char *email = "devel@monitoring-plugins.org";
 #include "utils.h"
 
 static char *server_address=NULL;
-static bool verbose = false;
-static bool do_offset = false;
+static int verbose=0;
+static short do_offset=0;
 static char *owarn="60";
 static char *ocrit="120";
-static bool do_jitter = false;
+static short do_jitter=0;
 static char *jwarn="5000";
 static char *jcrit="10000";
 
@@ -696,26 +696,26 @@ int process_arguments(int argc, char **argv){
 			exit(STATE_UNKNOWN);
 			break;
 		case 'v':
-			verbose = true;
+			verbose++;
 			break;
 		case 'w':
-			do_offset = true;
+			do_offset=1;
 			owarn = optarg;
 			break;
 		case 'c':
-			do_offset = true;
+			do_offset=1;
 			ocrit = optarg;
 			break;
 		case 'j':
-			do_jitter = true;
+			do_jitter=1;
 			jwarn = optarg;
 			break;
 		case 'k':
-			do_jitter = true;
+			do_jitter=1;
 			jcrit = optarg;
 			break;
 		case 'H':
-			if(is_host(optarg) == false)
+			if(is_host(optarg) == FALSE)
 				usage2(_("Invalid hostname/address"), optarg);
 			server_address = strdup(optarg);
 			break;
@@ -749,9 +749,9 @@ int process_arguments(int argc, char **argv){
 char *perfd_offset (double offset)
 {
 	return fperfdata ("offset", offset, "s",
-		true, offset_thresholds->warning->end,
-		true, offset_thresholds->critical->end,
-		false, 0, false, 0);
+		TRUE, offset_thresholds->warning->end,
+		TRUE, offset_thresholds->critical->end,
+		FALSE, 0, FALSE, 0);
 }
 
 char *perfd_jitter (double jitter)
@@ -759,7 +759,7 @@ char *perfd_jitter (double jitter)
 	return fperfdata ("jitter", jitter, "s",
 		do_jitter, jitter_thresholds->warning->end,
 		do_jitter, jitter_thresholds->critical->end,
-		true, 0, false, 0);
+		TRUE, 0, FALSE, 0);
 }
 
 int main(int argc, char *argv[]){

--- a/plugins/check_ntp.c
+++ b/plugins/check_ntp.c
@@ -39,11 +39,11 @@ const char *email = "devel@monitoring-plugins.org";
 #include "utils.h"
 
 static char *server_address=NULL;
-static int verbose=0;
-static short do_offset=0;
+static bool verbose = false;
+static bool do_offset = false;
 static char *owarn="60";
 static char *ocrit="120";
-static short do_jitter=0;
+static bool do_jitter = false;
 static char *jwarn="5000";
 static char *jcrit="10000";
 
@@ -696,26 +696,26 @@ int process_arguments(int argc, char **argv){
 			exit(STATE_UNKNOWN);
 			break;
 		case 'v':
-			verbose++;
+			verbose = true;
 			break;
 		case 'w':
-			do_offset=1;
+			do_offset = true;
 			owarn = optarg;
 			break;
 		case 'c':
-			do_offset=1;
+			do_offset = true;
 			ocrit = optarg;
 			break;
 		case 'j':
-			do_jitter=1;
+			do_jitter = true;
 			jwarn = optarg;
 			break;
 		case 'k':
-			do_jitter=1;
+			do_jitter = true;
 			jcrit = optarg;
 			break;
 		case 'H':
-			if(is_host(optarg) == FALSE)
+			if(is_host(optarg) == false)
 				usage2(_("Invalid hostname/address"), optarg);
 			server_address = strdup(optarg);
 			break;
@@ -749,9 +749,9 @@ int process_arguments(int argc, char **argv){
 char *perfd_offset (double offset)
 {
 	return fperfdata ("offset", offset, "s",
-		TRUE, offset_thresholds->warning->end,
-		TRUE, offset_thresholds->critical->end,
-		FALSE, 0, FALSE, 0);
+		true, offset_thresholds->warning->end,
+		true, offset_thresholds->critical->end,
+		false, 0, false, 0);
 }
 
 char *perfd_jitter (double jitter)
@@ -759,7 +759,7 @@ char *perfd_jitter (double jitter)
 	return fperfdata ("jitter", jitter, "s",
 		do_jitter, jitter_thresholds->warning->end,
 		do_jitter, jitter_thresholds->critical->end,
-		TRUE, 0, FALSE, 0);
+		true, 0, false, 0);
 }
 
 int main(int argc, char *argv[]){

--- a/plugins/check_ntp_peer.c
+++ b/plugins/check_ntp_peer.c
@@ -46,21 +46,20 @@ const char *email = "devel@monitoring-plugins.org";
 static char *server_address=NULL;
 static int port=123;
 static int verbose=0;
-static int quiet=0;
-static short do_offset=0;
+static bool quiet = false;
 static char *owarn="60";
 static char *ocrit="120";
-static short do_stratum=0;
+static bool do_stratum = false;
 static char *swarn="-1:16";
 static char *scrit="-1:16";
-static short do_jitter=0;
+static bool do_jitter = false;
 static char *jwarn="-1:5000";
 static char *jcrit="-1:10000";
-static short do_truechimers=0;
+static bool do_truechimers = false;
 static char *twarn="0:";
 static char *tcrit="0:";
-static int syncsource_found=0;
-static int li_alarm=0;
+static bool syncsource_found = false;
+static bool li_alarm = false;
 
 int process_arguments (int, char **);
 thresholds *offset_thresholds = NULL;
@@ -254,7 +253,7 @@ int ntp_request(double *offset, int *offset_result, double *jitter, int *stratum
 				die(STATE_CRITICAL, "NTP CRITICAL: Invalid packet received from NTP server\n");
 		} while (!(req.op&OP_READSTAT && ntohs(req.seq) == 1));
 
-		if (LI(req.flags) == LI_ALARM) li_alarm = 1;
+		if (LI(req.flags) == LI_ALARM) li_alarm = true;
 		/* Each peer identifier is 4 bytes in the data section, which
 	 	 * we represent as a ntp_assoc_status_pair datatype.
 	 	 */
@@ -276,7 +275,7 @@ int ntp_request(double *offset, int *offset_result, double *jitter, int *stratum
 			if(PEER_SEL(peers[i].status) >= PEER_INCLUDED){
 				num_candidates++;
 				if(PEER_SEL(peers[i].status) >= PEER_SYNCSOURCE){
-					syncsource_found=1;
+					syncsource_found = true;
 					min_peer_sel=PEER_SYNCSOURCE;
 				}
 			}
@@ -440,7 +439,7 @@ int process_arguments(int argc, char **argv){
 	if (argc < 2)
 		usage ("\n");
 
-	while (1) {
+	while (true) {
 		c = getopt_long (argc, argv, "Vhv46qw:c:W:C:j:k:m:n:t:H:p:", longopts, &option);
 		if (c == -1 || c == EOF || c == 1)
 			break;
@@ -458,42 +457,40 @@ int process_arguments(int argc, char **argv){
 			verbose++;
 			break;
 		case 'q':
-			quiet = 1;
+			quiet = true;
 			break;
 		case 'w':
-			do_offset=1;
 			owarn = optarg;
 			break;
 		case 'c':
-			do_offset=1;
 			ocrit = optarg;
 			break;
 		case 'W':
-			do_stratum=1;
+			do_stratum = true;
 			swarn = optarg;
 			break;
 		case 'C':
-			do_stratum=1;
+			do_stratum = true;
 			scrit = optarg;
 			break;
 		case 'j':
-			do_jitter=1;
+			do_jitter = true;
 			jwarn = optarg;
 			break;
 		case 'k':
-			do_jitter=1;
+			do_jitter = true;
 			jcrit = optarg;
 			break;
 		case 'm':
-			do_truechimers=1;
+			do_truechimers = true;
 			twarn = optarg;
 			break;
 		case 'n':
-			do_truechimers=1;
+			do_truechimers = true;
 			tcrit = optarg;
 			break;
 		case 'H':
-			if(is_host(optarg) == FALSE)
+			if(!is_host(optarg))
 				usage2(_("Invalid hostname/address"), optarg);
 			server_address = strdup(optarg);
 			break;
@@ -530,9 +527,9 @@ int process_arguments(int argc, char **argv){
 char *perfd_offset (double offset)
 {
 	return fperfdata ("offset", offset, "s",
-		TRUE, offset_thresholds->warning->end,
-		TRUE, offset_thresholds->critical->end,
-		FALSE, 0, FALSE, 0);
+		true, offset_thresholds->warning->end,
+		true, offset_thresholds->critical->end,
+		false, 0, false, 0);
 }
 
 char *perfd_jitter (double jitter)
@@ -540,7 +537,7 @@ char *perfd_jitter (double jitter)
 	return fperfdata ("jitter", jitter, "",
 		do_jitter, jitter_thresholds->warning->end,
 		do_jitter, jitter_thresholds->critical->end,
-		TRUE, 0, FALSE, 0);
+		true, 0, false, 0);
 }
 
 char *perfd_stratum (int stratum)
@@ -548,7 +545,7 @@ char *perfd_stratum (int stratum)
 	return perfdata ("stratum", stratum, "",
 		do_stratum, (int)stratum_thresholds->warning->end,
 		do_stratum, (int)stratum_thresholds->critical->end,
-		TRUE, 0, TRUE, 16);
+		true, 0, true, 16);
 }
 
 char *perfd_truechimers (int num_truechimers)
@@ -556,7 +553,7 @@ char *perfd_truechimers (int num_truechimers)
 	return perfdata ("truechimers", num_truechimers, "",
 		do_truechimers, (int)truechimer_thresholds->warning->end,
 		do_truechimers, (int)truechimer_thresholds->critical->end,
-		TRUE, 0, FALSE, 0);
+		true, 0, false, 0);
 }
 
 int main(int argc, char *argv[]){
@@ -590,10 +587,10 @@ int main(int argc, char *argv[]){
 
 	if(offset_result == STATE_UNKNOWN) {
 		/* if there's no sync peer (this overrides ntp_request output): */
-		result = (quiet == 1 ? STATE_UNKNOWN : STATE_CRITICAL);
+		result = (quiet ? STATE_UNKNOWN : STATE_CRITICAL);
 	} else {
 		/* Be quiet if there's no candidates either */
-		if (quiet == 1 && result == STATE_WARNING)
+		if (quiet && result == STATE_WARNING)
 			result = STATE_UNKNOWN;
 		result = max_state_alt(result, get_status(fabs(offset), offset_thresholds));
 	}

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -45,7 +45,7 @@ const char *email = "devel@monitoring-plugins.org";
 static char *server_address=NULL;
 static char *port="123";
 static int verbose=0;
-static int quiet=0;
+static bool quiet = false;
 static char *owarn="60";
 static char *ocrit="120";
 static int time_offset=0;
@@ -485,7 +485,7 @@ int process_arguments(int argc, char **argv){
 			verbose++;
 			break;
 		case 'q':
-			quiet = 1;
+			quiet = true;
 			break;
 		case 'w':
 			owarn = optarg;
@@ -494,7 +494,7 @@ int process_arguments(int argc, char **argv){
 			ocrit = optarg;
 			break;
 		case 'H':
-			if(is_host(optarg) == FALSE)
+			if(!is_host(optarg))
 				usage2(_("Invalid hostname/address"), optarg);
 			server_address = strdup(optarg);
 			break;
@@ -531,12 +531,11 @@ int process_arguments(int argc, char **argv){
 	return 0;
 }
 
-char *perfd_offset (double offset)
-{
+char *perfd_offset (double offset) {
 	return fperfdata ("offset", offset, "s",
-		TRUE, offset_thresholds->warning->end,
-		TRUE, offset_thresholds->critical->end,
-		FALSE, 0, FALSE, 0);
+		true, offset_thresholds->warning->end,
+		true, offset_thresholds->critical->end,
+		false, 0, false, 0);
 }
 
 int main(int argc, char *argv[]){
@@ -566,7 +565,7 @@ int main(int argc, char *argv[]){
 
 	offset = offset_request(server_address, &offset_result);
 	if (offset_result == STATE_UNKNOWN) {
-		result = (quiet == 1 ? STATE_UNKNOWN : STATE_CRITICAL);
+		result = ( (!quiet) ? STATE_UNKNOWN : STATE_CRITICAL);
 	} else {
 		result = get_status(fabs(offset), offset_thresholds);
 	}

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -44,8 +44,8 @@ const char *email = "devel@monitoring-plugins.org";
 
 static char *server_address=NULL;
 static char *port="123";
-static bool verbose = false;
-static bool quiet = false;
+static int verbose=0;
+static int quiet=0;
 static char *owarn="60";
 static char *ocrit="120";
 static int time_offset=0;
@@ -485,7 +485,7 @@ int process_arguments(int argc, char **argv){
 			verbose++;
 			break;
 		case 'q':
-			quiet = true;
+			quiet = 1;
 			break;
 		case 'w':
 			owarn = optarg;
@@ -494,7 +494,7 @@ int process_arguments(int argc, char **argv){
 			ocrit = optarg;
 			break;
 		case 'H':
-			if(!is_host(optarg))
+			if(is_host(optarg) == FALSE)
 				usage2(_("Invalid hostname/address"), optarg);
 			server_address = strdup(optarg);
 			break;
@@ -506,7 +506,7 @@ int process_arguments(int argc, char **argv){
 			break;
 		case 'o':
 			time_offset=atoi(optarg);
-			break;
+                        break;
 		case '4':
 			address_family = AF_INET;
 			break;
@@ -534,9 +534,9 @@ int process_arguments(int argc, char **argv){
 char *perfd_offset (double offset)
 {
 	return fperfdata ("offset", offset, "s",
-		true, offset_thresholds->warning->end,
-		true, offset_thresholds->critical->end,
-		false, 0, false, 0);
+		TRUE, offset_thresholds->warning->end,
+		TRUE, offset_thresholds->critical->end,
+		FALSE, 0, FALSE, 0);
 }
 
 int main(int argc, char *argv[]){
@@ -566,7 +566,7 @@ int main(int argc, char *argv[]){
 
 	offset = offset_request(server_address, &offset_result);
 	if (offset_result == STATE_UNKNOWN) {
-		result = (quiet ? STATE_UNKNOWN : STATE_CRITICAL);
+		result = (quiet == 1 ? STATE_UNKNOWN : STATE_CRITICAL);
 	} else {
 		result = get_status(fabs(offset), offset_thresholds);
 	}
@@ -651,3 +651,4 @@ print_usage(void)
 	printf ("%s\n", _("Usage:"));
 	printf(" %s -H <host> [-4|-6] [-w <warn>] [-c <crit>] [-v verbose] [-o <time offset>]\n", progname);
 }
+

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -44,8 +44,8 @@ const char *email = "devel@monitoring-plugins.org";
 
 static char *server_address=NULL;
 static char *port="123";
-static int verbose=0;
-static int quiet=0;
+static bool verbose = false;
+static bool quiet = false;
 static char *owarn="60";
 static char *ocrit="120";
 static int time_offset=0;
@@ -485,7 +485,7 @@ int process_arguments(int argc, char **argv){
 			verbose++;
 			break;
 		case 'q':
-			quiet = 1;
+			quiet = true;
 			break;
 		case 'w':
 			owarn = optarg;
@@ -494,7 +494,7 @@ int process_arguments(int argc, char **argv){
 			ocrit = optarg;
 			break;
 		case 'H':
-			if(is_host(optarg) == FALSE)
+			if(!is_host(optarg))
 				usage2(_("Invalid hostname/address"), optarg);
 			server_address = strdup(optarg);
 			break;
@@ -506,7 +506,7 @@ int process_arguments(int argc, char **argv){
 			break;
 		case 'o':
 			time_offset=atoi(optarg);
-                        break;
+			break;
 		case '4':
 			address_family = AF_INET;
 			break;
@@ -534,9 +534,9 @@ int process_arguments(int argc, char **argv){
 char *perfd_offset (double offset)
 {
 	return fperfdata ("offset", offset, "s",
-		TRUE, offset_thresholds->warning->end,
-		TRUE, offset_thresholds->critical->end,
-		FALSE, 0, FALSE, 0);
+		true, offset_thresholds->warning->end,
+		true, offset_thresholds->critical->end,
+		false, 0, false, 0);
 }
 
 int main(int argc, char *argv[]){
@@ -566,7 +566,7 @@ int main(int argc, char *argv[]){
 
 	offset = offset_request(server_address, &offset_result);
 	if (offset_result == STATE_UNKNOWN) {
-		result = (quiet == 1 ? STATE_UNKNOWN : STATE_CRITICAL);
+		result = (quiet ? STATE_UNKNOWN : STATE_CRITICAL);
 	} else {
 		result = get_status(fabs(offset), offset_thresholds);
 	}
@@ -651,4 +651,3 @@ print_usage(void)
 	printf ("%s\n", _("Usage:"));
 	printf(" %s -H <host> [-4|-6] [-w <warn>] [-c <crit>] [-v verbose] [-o <time offset>]\n", progname);
 }
-

--- a/plugins/check_nwstat.c
+++ b/plugins/check_nwstat.c
@@ -104,9 +104,9 @@ char *nss7_name=NULL;
 int server_port=PORT;
 unsigned long warning_value=0L;
 unsigned long critical_value=0L;
-int check_warning_value=FALSE;
-int check_critical_value=FALSE;
-int check_netware_version=FALSE;
+bool check_warning_value = false;
+bool check_critical_value = false;
+bool check_netware_version = false;
 enum checkvar vars_to_check = NONE;
 int sap_number=-1;
 
@@ -182,7 +182,7 @@ main(int argc, char **argv) {
 	my_tcp_connect (server_address, server_port, &sd);
 
 	/* get OS version string */
-	if (check_netware_version==TRUE) {
+	if (check_netware_version) {
 		send_buffer = strdup ("S19\r\n");
 		result=send_tcp_request(sd,send_buffer,recv_buffer,sizeof(recv_buffer));
 		if (result!=STATE_OK)
@@ -231,9 +231,9 @@ main(int argc, char **argv) {
 		recv_buffer[strlen(recv_buffer)-1]=0;
 		sprintf(uptime,_("Up %s,"),recv_buffer);
 
-		if (check_critical_value==TRUE && utilization >= critical_value)
+		if (check_critical_value && utilization >= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && utilization >= warning_value)
+		else if (check_warning_value && utilization >= warning_value)
 			result=STATE_WARNING;
 
 		xasprintf (&output_message,
@@ -259,9 +259,9 @@ main(int argc, char **argv) {
 			return result;
 		current_connections=strtoul(recv_buffer,NULL,10);
 
-		if (check_critical_value==TRUE && current_connections >= critical_value)
+		if (check_critical_value && current_connections >= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && current_connections >= warning_value)
+		else if (check_warning_value && current_connections >= warning_value)
 			result=STATE_WARNING;
 
 		xasprintf (&output_message,
@@ -284,9 +284,9 @@ main(int argc, char **argv) {
 			return result;
 		cache_hits=atoi(recv_buffer);
 
-		if (check_critical_value==TRUE && cache_hits <= critical_value)
+		if (check_critical_value && cache_hits <= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && cache_hits <= warning_value)
+		else if (check_warning_value && cache_hits <= warning_value)
 			result=STATE_WARNING;
 
 		xasprintf (&output_message,
@@ -306,9 +306,9 @@ main(int argc, char **argv) {
 			return result;
 		cache_buffers=strtoul(recv_buffer,NULL,10);
 
-		if (check_critical_value==TRUE && cache_buffers <= critical_value)
+		if (check_critical_value && cache_buffers <= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && cache_buffers <= warning_value)
+		else if (check_warning_value && cache_buffers <= warning_value)
 			result=STATE_WARNING;
 
 		xasprintf (&output_message,
@@ -331,9 +331,9 @@ main(int argc, char **argv) {
 			return result;
 		cache_buffers=strtoul(recv_buffer,NULL,10);
 
-		if (check_critical_value==TRUE && cache_buffers >= critical_value)
+		if (check_critical_value && cache_buffers >= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && cache_buffers >= warning_value)
+		else if (check_warning_value && cache_buffers >= warning_value)
 			result=STATE_WARNING;
 
 		xasprintf (&output_message,
@@ -356,9 +356,9 @@ main(int argc, char **argv) {
 			return result;
 		lru_time=strtoul(recv_buffer,NULL,10);
 
-		if (check_critical_value==TRUE && lru_time <= critical_value)
+		if (check_critical_value && lru_time <= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && lru_time <= warning_value)
+		else if (check_warning_value && lru_time <= warning_value)
 			result=STATE_WARNING;
 
 		xasprintf (&output_message,
@@ -383,9 +383,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			free_disk_space=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && free_disk_space <= critical_value)
+			if (check_critical_value && free_disk_space <= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && free_disk_space <= warning_value)
+			else if (check_warning_value && free_disk_space <= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s%lu KB free on volume %s|KBFree%s=%lu;%lu;%lu;;"),
@@ -411,9 +411,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			free_disk_space=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && free_disk_space <= critical_value)
+			if (check_critical_value && free_disk_space <= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && free_disk_space <= warning_value)
+			else if (check_warning_value && free_disk_space <= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s%lu MB free on volume %s|MBFree%s=%lu;%lu;%lu;;"),
@@ -438,9 +438,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			free_disk_space=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && free_disk_space <= critical_value)
+			if (check_critical_value && free_disk_space <= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && free_disk_space <= warning_value)
+			else if (check_warning_value && free_disk_space <= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s%lu MB used on volume %s|MBUsed%s=%lu;%lu;%lu;;"),
@@ -485,9 +485,9 @@ main(int argc, char **argv) {
 
 			percent_free_space=(unsigned long)(((double)free_disk_space/(double)total_disk_space)*100.0);
 
-			if (check_critical_value==TRUE && percent_free_space <= critical_value)
+			if (check_critical_value && percent_free_space <= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && percent_free_space <= warning_value)
+			else if (check_warning_value && percent_free_space <= warning_value)
 				result=STATE_WARNING;
 			free_disk_space/=1024;
 			total_disk_space/=1024;
@@ -596,14 +596,14 @@ main(int argc, char **argv) {
 		percent_used_packet_receive_buffers=(unsigned long)(((double)used_packet_receive_buffers/(double)max_packet_receive_buffers)*100.0);
 
 		if (vars_to_check==UPRB) {
-			if (check_critical_value==TRUE && used_packet_receive_buffers >= critical_value)
+			if (check_critical_value && used_packet_receive_buffers >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && used_packet_receive_buffers >= warning_value)
+			else if (check_warning_value && used_packet_receive_buffers >= warning_value)
 				result=STATE_WARNING;
 		} else {
-			if (check_critical_value==TRUE && percent_used_packet_receive_buffers >= critical_value)
+			if (check_critical_value && percent_used_packet_receive_buffers >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && percent_used_packet_receive_buffers >= warning_value)
+			else if (check_warning_value && percent_used_packet_receive_buffers >= warning_value)
 				result=STATE_WARNING;
 		}
 
@@ -625,9 +625,9 @@ main(int argc, char **argv) {
 
 		sap_entries=atoi(recv_buffer);
 
-		if (check_critical_value==TRUE && sap_entries >= critical_value)
+		if (check_critical_value && sap_entries >= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && sap_entries >= warning_value)
+		else if (check_warning_value && sap_entries >= warning_value)
 			result=STATE_WARNING;
 
 		if (sap_number==-1)
@@ -651,9 +651,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		} else {
 			purgeable_disk_space=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && purgeable_disk_space >= critical_value)
+			if (check_critical_value && purgeable_disk_space >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && purgeable_disk_space >= warning_value)
+			else if (check_warning_value && purgeable_disk_space >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,_("%s%lu KB purgeable on volume %s|Purge%s=%lu;%lu;%lu;;"),
 				 (result==STATE_OK)?"":_("Only "),
@@ -677,9 +677,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		} else {
 			purgeable_disk_space=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && purgeable_disk_space >= critical_value)
+			if (check_critical_value && purgeable_disk_space >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && purgeable_disk_space >= warning_value)
+			else if (check_warning_value && purgeable_disk_space >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,_("%s%lu MB purgeable on volume %s|Purge%s=%lu;%lu;%lu;;"),
 				 (result==STATE_OK)?"":_("Only "),
@@ -722,9 +722,9 @@ main(int argc, char **argv) {
 
 			percent_purgeable_space=(unsigned long)(((double)purgeable_disk_space/(double)total_disk_space)*100.0);
 
-			if (check_critical_value==TRUE && percent_purgeable_space >= critical_value)
+			if (check_critical_value && percent_purgeable_space >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && percent_purgeable_space >= warning_value)
+			else if (check_warning_value && percent_purgeable_space >= warning_value)
 				result=STATE_WARNING;
 			purgeable_disk_space/=1024;
 			xasprintf (&output_message,_("%lu MB (%lu%%) purgeable on volume %s|Purgeable%s=%lu;%lu;%lu;0;100"),
@@ -754,9 +754,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		} else {
 			non_purgeable_disk_space=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && non_purgeable_disk_space >= critical_value)
+			if (check_critical_value && non_purgeable_disk_space >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && non_purgeable_disk_space >= warning_value)
+			else if (check_warning_value && non_purgeable_disk_space >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,_("%s%lu KB not yet purgeable on volume %s"),(result==STATE_OK)?"":_("Only "),non_purgeable_disk_space,volume_name);
 		}
@@ -792,9 +792,9 @@ main(int argc, char **argv) {
 
 			percent_non_purgeable_space=(unsigned long)(((double)non_purgeable_disk_space/(double)total_disk_space)*100.0);
 
-			if (check_critical_value==TRUE && percent_non_purgeable_space >= critical_value)
+			if (check_critical_value && percent_non_purgeable_space >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && percent_non_purgeable_space >= warning_value)
+			else if (check_warning_value && percent_non_purgeable_space >= warning_value)
 				result=STATE_WARNING;
 			purgeable_disk_space/=1024;
 			xasprintf (&output_message,_("%lu MB (%lu%%) not yet purgeable on volume %s"),non_purgeable_disk_space,percent_non_purgeable_space,volume_name);
@@ -813,9 +813,9 @@ main(int argc, char **argv) {
 
 		open_files=atoi(recv_buffer);
 
-		if (check_critical_value==TRUE && open_files >= critical_value)
+		if (check_critical_value && open_files >= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && open_files >= warning_value)
+		else if (check_warning_value && open_files >= warning_value)
 			result=STATE_WARNING;
 
 		xasprintf (&output_message,_("%lu open files|Openfiles=%lu;%lu;%lu;0,0"),
@@ -838,9 +838,9 @@ main(int argc, char **argv) {
 
 		abended_threads=atoi(recv_buffer);
 
-		if (check_critical_value==TRUE && abended_threads >= critical_value)
+		if (check_critical_value && abended_threads >= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && abended_threads >= warning_value)
+		else if (check_warning_value && abended_threads >= warning_value)
 			result=STATE_WARNING;
 
 		xasprintf (&output_message,_("%lu abended threads|Abends=%lu;%lu;%lu;;"),
@@ -872,9 +872,9 @@ main(int argc, char **argv) {
 
 		current_service_processes=atoi(recv_buffer);
 
-		if (check_critical_value==TRUE && current_service_processes >= critical_value)
+		if (check_critical_value && current_service_processes >= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && current_service_processes >= warning_value)
+		else if (check_warning_value && current_service_processes >= warning_value)
 			result=STATE_WARNING;
 
 		xasprintf (&output_message,
@@ -923,9 +923,9 @@ main(int argc, char **argv) {
 			return result;
 		lru_time=strtoul(recv_buffer,NULL,10);
 
-		if (check_critical_value==TRUE && lru_time <= critical_value)
+		if (check_critical_value && lru_time <= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && lru_time <= warning_value)
+		else if (check_warning_value && lru_time <= warning_value)
 			result=STATE_WARNING;
 		xasprintf (&output_message,_("LRU sitting time = %lu seconds"),lru_time);
 
@@ -942,9 +942,9 @@ main(int argc, char **argv) {
 			return result;
 		dirty_cache_buffers=atoi(recv_buffer);
 
-		if (check_critical_value==TRUE && dirty_cache_buffers <= critical_value)
+		if (check_critical_value && dirty_cache_buffers <= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && dirty_cache_buffers <= warning_value)
+		else if (check_warning_value && dirty_cache_buffers <= warning_value)
 			result=STATE_WARNING;
 		xasprintf (&output_message,_("Dirty cache buffers = %lu%% of the total|DCB=%lu;%lu;%lu;0;100"),
 				dirty_cache_buffers,
@@ -964,9 +964,9 @@ main(int argc, char **argv) {
 			return result;
 		total_cache_buffers=atoi(recv_buffer);
 
-		if (check_critical_value==TRUE && total_cache_buffers <= critical_value)
+		if (check_critical_value && total_cache_buffers <= critical_value)
 			result=STATE_CRITICAL;
-		else if (check_warning_value==TRUE && total_cache_buffers <= warning_value)
+		else if (check_warning_value && total_cache_buffers <= warning_value)
 			result=STATE_WARNING;
 		xasprintf (&output_message,_("Total cache buffers = %lu%% of the original|TCB=%lu;%lu;%lu;0;100"),
 				total_cache_buffers,
@@ -1034,9 +1034,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nrmp_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nrmp_value <= critical_value)
+			if (check_critical_value && nrmp_value <= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nrmp_value <= warning_value)
+			else if (check_warning_value && nrmp_value <= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1060,9 +1060,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nrmm_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nrmm_value <= critical_value)
+			if (check_critical_value && nrmm_value <= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nrmm_value <= warning_value)
+			else if (check_warning_value && nrmm_value <= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1086,9 +1086,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nrms_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nrms_value >= critical_value)
+			if (check_critical_value && nrms_value >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nrms_value >= warning_value)
+			else if (check_warning_value && nrms_value >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1112,9 +1112,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nss1_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nss1_value >= critical_value)
+			if (check_critical_value && nss1_value >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nss1_value >= warning_value)
+			else if (check_warning_value && nss1_value >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1138,9 +1138,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nss2_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nss2_value >= critical_value)
+			if (check_critical_value && nss2_value >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nss2_value >= warning_value)
+			else if (check_warning_value && nss2_value >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1164,9 +1164,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nss3_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nss3_value >= critical_value)
+			if (check_critical_value && nss3_value >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nss3_value >= warning_value)
+			else if (check_warning_value && nss3_value >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1190,9 +1190,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nss4_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nss4_value >= critical_value)
+			if (check_critical_value && nss4_value >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nss4_value >= warning_value)
+			else if (check_warning_value && nss4_value >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1216,9 +1216,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nss5_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nss5_value >= critical_value)
+			if (check_critical_value && nss5_value >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nss5_value >= warning_value)
+			else if (check_warning_value && nss5_value >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1242,9 +1242,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nss6_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nss6_value >= critical_value)
+			if (check_critical_value && nss6_value >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nss6_value >= warning_value)
+			else if (check_warning_value && nss6_value >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1268,9 +1268,9 @@ main(int argc, char **argv) {
 			result=STATE_CRITICAL;
 		}	else {
 			nss7_value=strtoul(recv_buffer,NULL,10);
-			if (check_critical_value==TRUE && nss7_value >= critical_value)
+			if (check_critical_value && nss7_value >= critical_value)
 				result=STATE_CRITICAL;
-			else if (check_warning_value==TRUE && nss7_value >= warning_value)
+			else if (check_warning_value && nss7_value >= warning_value)
 				result=STATE_WARNING;
 			xasprintf (&output_message,
 			          _("%s is  %lu|%s=%lu;%lu;%lu;;"),
@@ -1362,7 +1362,7 @@ int process_arguments(int argc, char **argv) {
 				server_address=optarg;
 				break;
 			case 'o': /* display nos version */
-				check_netware_version=TRUE;
+				check_netware_version = true;
 				break;
 			case 'p': /* port */
 				if (is_intnonneg(optarg))
@@ -1569,11 +1569,11 @@ int process_arguments(int argc, char **argv) {
 				break;
 			case 'w': /* warning threshold */
 				warning_value=strtoul(optarg,NULL,10);
-				check_warning_value=TRUE;
+				check_warning_value = true;
 				break;
 			case 'c': /* critical threshold */
 				critical_value=strtoul(optarg,NULL,10);
-				check_critical_value=TRUE;
+				check_critical_value = true;
 				break;
 			case 't': /* timeout */
 				socket_timeout=atoi(optarg);

--- a/plugins/check_overcr.c
+++ b/plugins/check_overcr.c
@@ -56,15 +56,15 @@ char *server_address = NULL;
 int server_port = PORT;
 double warning_value = 0L;
 double critical_value = 0L;
-int check_warning_value = FALSE;
-int check_critical_value = FALSE;
+bool check_warning_value = false;
+bool check_critical_value = false;
 enum checkvar vars_to_check = NONE;
 int cmd_timeout = 1;
 
 int netstat_port = 0;
 char *disk_name = NULL;
 char *process_name = NULL;
-	char send_buffer[MAX_INPUT_BUFFER];
+char send_buffer[MAX_INPUT_BUFFER];
 
 int process_arguments (int, char **);
 void print_usage (void);
@@ -77,7 +77,7 @@ main (int argc, char **argv)
 	char recv_buffer[MAX_INPUT_BUFFER];
 	char temp_buffer[MAX_INPUT_BUFFER];
 	char *temp_ptr = NULL;
-	int found_disk = FALSE;
+	bool found_disk = false;
 	unsigned long percent_used_disk_space = 100;
 	double load;
 	double load_1min;
@@ -155,9 +155,9 @@ main (int argc, char **argv)
 			break;
 		}
 
-		if (check_critical_value == TRUE && (load >= critical_value))
+		if (check_critical_value && (load >= critical_value))
 			result = STATE_CRITICAL;
-		else if (check_warning_value == TRUE && (load >= warning_value))
+		else if (check_warning_value && (load >= warning_value))
 			result = STATE_WARNING;
 
 		die (result,
@@ -178,7 +178,7 @@ main (int argc, char **argv)
 		     temp_ptr = (char *) strtok (NULL, " ")) {
 
 			if (!strcmp (temp_ptr, disk_name)) {
-				found_disk = TRUE;
+				found_disk = true;
 				temp_ptr = (char *) strtok (NULL, "%");
 				if (temp_ptr == NULL)
 					die (STATE_CRITICAL, _("Invalid response from server\n"));
@@ -191,14 +191,14 @@ main (int argc, char **argv)
 		}
 
 		/* error if we couldn't find the info for the disk */
-		if (found_disk == FALSE)
+		if (!found_disk)
 			die (STATE_CRITICAL,
 			           "CRITICAL - Disk '%s' non-existent or not mounted",
 			           disk_name);
 
-		if (check_critical_value == TRUE && (percent_used_disk_space >= critical_value))
+		if (check_critical_value && (percent_used_disk_space >= critical_value))
 			result = STATE_CRITICAL;
-		else if (check_warning_value == TRUE && (percent_used_disk_space >= warning_value))
+		else if (check_warning_value && (percent_used_disk_space >= warning_value))
 			result = STATE_WARNING;
 
 		die (result, "Disk %s - %lu%% used on %s", state_text(result), percent_used_disk_space, disk_name);
@@ -212,9 +212,9 @@ main (int argc, char **argv)
 		else
 			port_connections = strtod (recv_buffer, NULL);
 
-		if (check_critical_value == TRUE && (port_connections >= critical_value))
+		if (check_critical_value && (port_connections >= critical_value))
 			result = STATE_CRITICAL;
-		else if (check_warning_value == TRUE && (port_connections >= warning_value))
+		else if (check_warning_value && (port_connections >= warning_value))
 			result = STATE_WARNING;
 
 		die (result,
@@ -241,9 +241,9 @@ main (int argc, char **argv)
 		else
 			processes = strtod (temp_ptr, NULL);
 
-		if (check_critical_value == TRUE && (processes >= critical_value))
+		if (check_critical_value && (processes >= critical_value))
 			result = STATE_CRITICAL;
-		else if (check_warning_value == TRUE && (processes >= warning_value))
+		else if (check_warning_value && (processes >= warning_value))
 			result = STATE_WARNING;
 
 		die (result,
@@ -262,9 +262,9 @@ main (int argc, char **argv)
 		uptime_raw_hours = strtod (recv_buffer, NULL);
 		uptime_raw_minutes = (unsigned long) (uptime_raw_hours * 60.0);
 
-		if (check_critical_value == TRUE && (uptime_raw_minutes <= critical_value))
+		if (check_critical_value && (uptime_raw_minutes <= critical_value))
 			result = STATE_CRITICAL;
-		else if (check_warning_value == TRUE && (uptime_raw_minutes <= warning_value))
+		else if (check_warning_value && (uptime_raw_minutes <= warning_value))
 			result = STATE_WARNING;
 
 		uptime_days = uptime_raw_minutes / 1440;
@@ -388,11 +388,11 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'w':									/* warning threshold */
 			warning_value = strtoul (optarg, NULL, 10);
-			check_warning_value = TRUE;
+			check_warning_value = true;
 			break;
 		case 'c':									/* critical threshold */
 			critical_value = strtoul (optarg, NULL, 10);
-			check_critical_value = TRUE;
+			check_critical_value = true;
 			break;
 		case 't':									/* timeout */
 			socket_timeout = atoi (optarg);

--- a/plugins/check_pgsql.c
+++ b/plugins/check_pgsql.c
@@ -69,7 +69,7 @@ int process_arguments (int, char **);
 int validate_arguments (void);
 void print_usage (void);
 void print_help (void);
-int is_pg_logname (char *);
+bool is_pg_logname (char *);
 int do_query (PGconn *, char *);
 
 char *pghost = NULL;						/* host name of the backend server */
@@ -252,7 +252,7 @@ main (int argc, char **argv)
 	printf (_(" %s - database %s (%f sec.)|%s\n"),
 	        state_text(status), dbName, elapsed_time,
 	        fperfdata("time", elapsed_time, "s",
-	                 !!(twarn > 0.0), twarn, !!(tcrit > 0.0), tcrit, TRUE, 0, FALSE,0));
+	                 !!(twarn > 0.0), twarn, !!(tcrit > 0.0), tcrit, true, 0, false,0));
 
 	if (pgquery)
 		query_status = do_query (conn, pgquery);
@@ -393,7 +393,7 @@ process_arguments (int argc, char **argv)
 
 <para>&PROTO_validate_arguments;</para>
 
-<para>Given a database name, this function returns TRUE if the string
+<para>Given a database name, this function returns true if the string
 is a valid PostgreSQL database name, and returns false if it is
 not.</para>
 
@@ -424,7 +424,7 @@ function prototype
 
 <para>&PROTO_is_pg_logname;</para>
 
-<para>Given a username, this function returns TRUE if the string is a
+<para>Given a username, this function returns true if the string is a
 valid PostgreSQL username, and returns false if it is not. Valid PostgreSQL
 usernames are less than &NAMEDATALEN; characters long and consist of
 letters, numbers, dashes, and underscores, plus possibly some other
@@ -439,12 +439,10 @@ should be added.</para>
 
 
 
-int
-is_pg_logname (char *username)
-{
+bool is_pg_logname (char *username) {
 	if (strlen (username) > NAMEDATALEN - 1)
-		return (FALSE);
-	return (TRUE);
+		return (false);
+	return (true);
 }
 
 /******************************************************************************

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -55,7 +55,7 @@ int error_scan (char buf[MAX_INPUT_BUFFER], const char *addr);
 void print_usage (void);
 void print_help (void);
 
-int display_html = FALSE;
+bool display_html = false;
 int wpl = UNKNOWN_PACKET_LOSS;
 int cpl = UNKNOWN_PACKET_LOSS;
 float wrta = UNKNOWN_TRIP_TIME;
@@ -153,7 +153,7 @@ main (int argc, char **argv)
 		if (n_addresses > 1 && this_result != STATE_UNKNOWN)
 			die (STATE_OK, "%s is alive\n", addresses[i]);
 
-		if (display_html == TRUE)
+		if (display_html == true)
 			printf ("<A HREF='%s/traceroute.cgi?%s'>", CGIURL, addresses[i]);
 		if (pl == 100)
 			printf (_("PING %s - %sPacket loss = %d%%"), state_text (this_result), warn_text,
@@ -161,22 +161,22 @@ main (int argc, char **argv)
 		else
 			printf (_("PING %s - %sPacket loss = %d%%, RTA = %2.2f ms"),
 							state_text (this_result), warn_text, pl, rta);
-		if (display_html == TRUE)
+		if (display_html == true)
 			printf ("</A>");
 
 		/* Print performance data */
 		if (pl != 100) {
 			printf("|%s", fperfdata ("rta", (double) rta, "ms",
-									  wrta>0?TRUE:FALSE, wrta,
-									  crta>0?TRUE:FALSE, crta,
-									  TRUE, 0, FALSE, 0));
+									  wrta>0?true:false, wrta,
+									  crta>0?true:false, crta,
+									  true, 0, false, 0));
 		} else {
 			printf("| rta=U;%f;%f;;", wrta, crta);
 		}
 		printf(" %s\n", perfdata ("pl", (long) pl, "%",
-		                          wpl>0?TRUE:FALSE, wpl,
-		                          cpl>0?TRUE:FALSE, cpl,
-		                          TRUE, 0, FALSE, 0));
+		                          wpl>0?true:false, wpl,
+		                          cpl>0?true:false, cpl,
+		                          true, 0, false, 0));
 
 		if (verbose >= 2)
 			printf ("%f:%d%% %f:%d%%\n", wrta, wpl, crta, cpl);
@@ -278,10 +278,10 @@ process_arguments (int argc, char **argv)
 				usage2 (_("<max_packets> (%s) must be a non-negative number\n"), optarg);
 			break;
 		case 'n':	/* no HTML */
-			display_html = FALSE;
+			display_html = false;
 			break;
 		case 'L':	/* show HTML */
-			display_html = TRUE;
+			display_html = true;
 			break;
 		case 'c':
 			get_threshold (optarg, &crta, &cpl);
@@ -297,7 +297,7 @@ process_arguments (int argc, char **argv)
 		return validate_arguments ();
 
 	if (addresses[0] == NULL) {
-		if (is_host (argv[c]) == FALSE) {
+		if (!is_host (argv[c])) {
 			usage2 (_("Invalid hostname/address"), argv[c]);
 		} else {
 			addresses[0] = argv[c++];
@@ -308,7 +308,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	if (wpl == UNKNOWN_PACKET_LOSS) {
-		if (is_intpercent (argv[c]) == FALSE) {
+		if (!is_intpercent (argv[c])) {
 			printf (_("<wpl> (%s) must be an integer percentage\n"), argv[c]);
 			return ERROR;
 		} else {
@@ -319,7 +319,7 @@ process_arguments (int argc, char **argv)
 	}
 
 	if (cpl == UNKNOWN_PACKET_LOSS) {
-		if (is_intpercent (argv[c]) == FALSE) {
+		if (!is_intpercent (argv[c])) {
 			printf (_("<cpl> (%s) must be an integer percentage\n"), argv[c]);
 			return ERROR;
 		} else {
@@ -420,7 +420,7 @@ validate_arguments ()
 		timeout_interval = (int)max_seconds;
 
 	for (i=0; i<n_addresses; i++) {
-		if (is_host(addresses[i]) == FALSE)
+		if (!is_host(addresses[i]))
 			usage2 (_("Invalid hostname/address"), addresses[i]);
 	}
 

--- a/plugins/check_radius.c
+++ b/plugins/check_radius.c
@@ -93,7 +93,7 @@ char *expect = NULL;
 char *config_file = NULL;
 unsigned short port = PW_AUTH_UDP_PORT;
 int retries = 1;
-int verbose = FALSE;
+bool verbose = false;
 
 /******************************************************************************
 
@@ -272,10 +272,10 @@ process_arguments (int argc, char **argv)
 			print_revision (progname, NP_VERSION);
 			exit (STATE_UNKNOWN);
 		case 'v':									/* verbose mode */
-			verbose = TRUE;
+			verbose = true;
 			break;
 		case 'H':									/* hostname */
-			if (is_host (optarg) == FALSE) {
+			if (!is_host (optarg)) {
 				usage2 (_("Invalid hostname/address"), optarg);
 			}
 			server = optarg;

--- a/plugins/check_real.c
+++ b/plugins/check_real.c
@@ -54,10 +54,10 @@ char *host_name;
 char *server_url = NULL;
 char *server_expect;
 int warning_time = 0;
-int check_warning_time = FALSE;
+bool check_warning_time = false;
 int critical_time = 0;
-int check_critical_time = FALSE;
-int verbose = FALSE;
+bool check_critical_time = false;
+bool verbose = false;
 
 
 
@@ -238,9 +238,9 @@ main (int argc, char **argv)
 	/* Return results */
 	if (result == STATE_OK) {
 
-		if (check_critical_time == TRUE
+		if (check_critical_time
 				&& (end_time - start_time) > critical_time) result = STATE_CRITICAL;
-		else if (check_warning_time == TRUE
+		else if (check_warning_time
 						 && (end_time - start_time) > warning_time) result =
 				STATE_WARNING;
 
@@ -331,7 +331,7 @@ process_arguments (int argc, char **argv)
 		case 'w':									/* warning time threshold */
 			if (is_intnonneg (optarg)) {
 				warning_time = atoi (optarg);
-				check_warning_time = TRUE;
+				check_warning_time = true;
 			}
 			else {
 				usage4 (_("Warning time must be a positive integer"));
@@ -340,14 +340,14 @@ process_arguments (int argc, char **argv)
 		case 'c':									/* critical time threshold */
 			if (is_intnonneg (optarg)) {
 				critical_time = atoi (optarg);
-				check_critical_time = TRUE;
+				check_critical_time = true;
 			}
 			else {
 				usage4 (_("Critical time must be a positive integer"));
 			}
 			break;
 		case 'v':									/* verbose */
-			verbose = TRUE;
+			verbose = true;
 			break;
 		case 't':									/* timeout */
 			if (is_intnonneg (optarg)) {

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -615,7 +615,7 @@ process_arguments (int argc, char **argv)
 			verbose++;
 			break;
 		case 'q':
-			ignore_send_quit_failure++;             /* ignore problem sending QUIT */
+			ignore_send_quit_failure = true;             /* ignore problem sending QUIT */
 			break;
 		case 't':									/* timeout */
 			if (is_intnonneg (optarg)) {

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -40,7 +40,7 @@ const char *email = "devel@monitoring-plugins.org";
 #include <ctype.h>
 
 #ifdef HAVE_SSL
-int check_cert = FALSE;
+bool check_cert = false;
 int days_till_exp_warn, days_till_exp_crit;
 #  define my_recv(buf, len) (((use_starttls || use_ssl) && ssl_established) ? np_net_ssl_read(buf, len) : read(sd, buf, len))
 #  define my_send(buf, len) (((use_starttls || use_ssl) && ssl_established) ? np_net_ssl_write(buf, len) : send(sd, buf, len, 0))
@@ -100,17 +100,17 @@ char *authtype = NULL;
 char *authuser = NULL;
 char *authpass = NULL;
 double warning_time = 0;
-int check_warning_time = FALSE;
+bool check_warning_time = false;
 double critical_time = 0;
-int check_critical_time = FALSE;
+bool check_critical_time = false;
 int verbose = 0;
-int use_ssl = FALSE;
-int use_starttls = FALSE;
-int use_sni = FALSE;
-short use_proxy_prefix = FALSE;
-short use_ehlo = FALSE;
-short use_lhlo = FALSE;
-short ssl_established = 0;
+bool use_ssl = false;
+bool use_starttls = false;
+bool use_sni = false;
+bool use_proxy_prefix = false;
+bool use_ehlo = false;
+bool use_lhlo = false;
+bool ssl_established = false;
 char *localhostname = NULL;
 int sd;
 char buffer[MAX_INPUT_BUFFER];
@@ -118,13 +118,13 @@ enum {
   TCP_PROTOCOL = 1,
   UDP_PROTOCOL = 2,
 };
-int ignore_send_quit_failure = FALSE;
+bool ignore_send_quit_failure = false;
 
 
 int
 main (int argc, char **argv)
 {
-	short supports_tls=FALSE;
+	bool supports_tls = false;
 	int n = 0;
 	double elapsed_time;
 	long microsec;
@@ -230,7 +230,7 @@ main (int argc, char **argv)
 		} else if(use_ehlo || use_lhlo){
 			if(strstr(buffer, "250 STARTTLS") != NULL ||
 			   strstr(buffer, "250-STARTTLS") != NULL){
-				supports_tls=TRUE;
+				supports_tls=true;
 			}
 		}
 
@@ -466,7 +466,7 @@ main (int argc, char **argv)
 			fperfdata ("time", elapsed_time, "s",
 				(int)check_warning_time, warning_time,
 				(int)check_critical_time, critical_time,
-				TRUE, 0, FALSE, 0));
+				true, 0, false, 0));
 
 	return result;
 }
@@ -560,7 +560,7 @@ process_arguments (int argc, char **argv)
 			break;
 		case 'A':
 			authtype = optarg;
-			use_ehlo = TRUE;
+			use_ehlo = true;
 			break;
 		case 'U':
 			authuser = optarg;
@@ -600,7 +600,7 @@ process_arguments (int argc, char **argv)
 				usage4 (_("Critical time must be a positive"));
 			else {
 				critical_time = strtod (optarg, NULL);
-				check_critical_time = TRUE;
+				check_critical_time = true;
 			}
 			break;
 		case 'w':									/* warning time threshold */
@@ -608,7 +608,7 @@ process_arguments (int argc, char **argv)
 				usage4 (_("Warning time must be a positive"));
 			else {
 				warning_time = strtod (optarg, NULL);
-				check_warning_time = TRUE;
+				check_warning_time = true;
 			}
 			break;
 		case 'v':									/* verbose */
@@ -645,33 +645,33 @@ process_arguments (int argc, char **argv)
                                 usage2 ("Invalid certificate expiration period", optarg);
                             days_till_exp_warn = atoi (optarg);
                         }
-			check_cert = TRUE;
-			ignore_send_quit_failure = TRUE;
+			check_cert = true;
+			ignore_send_quit_failure = true;
 #else
 			usage (_("SSL support not available - install OpenSSL and recompile"));
 #endif
 		case 's':
 		/* ssl */
-			use_ssl = TRUE;
+			use_ssl = true;
 			server_port = SMTPS_PORT;
 			break;
 		case 'S':
 		/* starttls */
-			use_starttls = TRUE;
-			use_ehlo = TRUE;
+			use_starttls = true;
+			use_ehlo = true;
 			break;
 		case SNI_OPTION:
 #ifdef HAVE_SSL
-			use_sni = TRUE;
+			use_sni = true;
 #else
 			usage (_("SSL support not available - install OpenSSL and recompile"));
 #endif
 			break;
 		case 'r':
-			use_proxy_prefix = TRUE;
+			use_proxy_prefix = true;
 			break;
 		case 'L':
-			use_lhlo = TRUE;
+			use_lhlo = true;
 			break;
 		case '4':
 			address_family = AF_INET;

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -135,7 +135,7 @@ int numoids = 0;
 int numauthpriv = 0;
 int numcontext = 0;
 int verbose = 0;
-int usesnmpgetnext = FALSE;
+bool usesnmpgetnext = false;
 char *warning_thresholds = NULL;
 char *critical_thresholds = NULL;
 thresholds **thlds;
@@ -148,7 +148,7 @@ size_t eval_size = OID_COUNT_STEP;
 char *delimiter;
 char *output_delim;
 char *miblist = NULL;
-int needmibs = FALSE;
+bool needmibs = false;
 int calculate_rate = 0;
 double offset = 0.0;
 int rate_multiplier = 1;
@@ -302,7 +302,7 @@ main (int argc, char **argv)
 	}
 
 	/* Create the command array to execute */
-	if(usesnmpgetnext == TRUE) {
+	if(usesnmpgetnext) {
 		snmpcmd = strdup (PATH_TO_SNMPGETNEXT);
 	}else{
 		snmpcmd = strdup (PATH_TO_SNMPGET);
@@ -777,7 +777,7 @@ process_arguments (int argc, char **argv)
 			miblist = optarg;
 			break;
 		case 'n':	/* usesnmpgetnext */
-			usesnmpgetnext = TRUE;
+			usesnmpgetnext = true;
 			break;
 		case 'P':	/* SNMP protocol version */
 			proto = optarg;
@@ -831,7 +831,7 @@ process_arguments (int argc, char **argv)
 					 * so we have a mib variable, rather than just an SNMP OID,
 					 * so we have to actually read the mib files
 					 */
-					needmibs = TRUE;
+					needmibs = true;
 			}
 			for (ptr = strtok(optarg, ", "); ptr != NULL; ptr = strtok(NULL, ", "), j++) {
 				while (j >= oids_size) {
@@ -1034,7 +1034,7 @@ validate_arguments ()
 {
 	/* check whether to load locally installed MIBS (CPU/disk intensive) */
 	if (miblist == NULL) {
-		if ( needmibs == TRUE ) {
+		if (needmibs) {
 			miblist = strdup (DEFAULT_MIBLIST);
 		}else{
 			miblist = "";			/* don't read any mib files for numeric oids */

--- a/plugins/check_ssh.c
+++ b/plugins/check_ssh.c
@@ -47,7 +47,7 @@ int port = -1;
 char *server_name = NULL;
 char *remote_version = NULL;
 char *remote_protocol = NULL;
-int verbose = FALSE;
+bool verbose = false;
 
 int process_arguments (int, char **);
 int validate_arguments (void);
@@ -55,7 +55,6 @@ void print_help (void);
 void print_usage (void);
 
 int ssh_connect (char *haddr, int hport, char *remote_version, char *remote_protocol);
-
 
 
 int
@@ -133,7 +132,7 @@ process_arguments (int argc, char **argv)
 			print_help ();
 			exit (STATE_UNKNOWN);
 		case 'v':									/* verbose */
-			verbose = TRUE;
+			verbose = true;
 			break;
 		case 't':									/* timeout period */
 			if (!is_integer (optarg))
@@ -158,7 +157,7 @@ process_arguments (int argc, char **argv)
 			remote_protocol = optarg;
 			break;
 		case 'H':									/* host */
-			if (is_host (optarg) == FALSE)
+			if (!is_host (optarg))
 				usage2 (_("Invalid hostname/address"), optarg);
 			server_name = optarg;
 			break;
@@ -272,7 +271,7 @@ ssh_connect (char *haddr, int hport, char *remote_version, char *remote_protocol
 		printf
 			(_("SSH OK - %s (protocol %s) | %s\n"),
 			 ssh_server, ssh_proto, fperfdata("time", elapsed_time, "s",
-			 FALSE, 0, FALSE, 0, TRUE, 0, TRUE, (int)socket_timeout));
+			 false, 0, false, 0, true, 0, true, (int)socket_timeout));
 		close(sd);
 		exit (STATE_OK);
 	}

--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -65,7 +65,7 @@ void print_help (void);
 threshold_t warn;
 threshold_t crit;
 int verbose;
-int allswaps;
+bool allswaps = false;
 int no_swap_state = STATE_CRITICAL;
 
 int
@@ -383,10 +383,10 @@ main (int argc, char **argv)
 	if (crit.is_percentage) crit_print = crit.value * (total_swap_mb *1024 *1024/100);
 
 	puts (perfdata_uint64 ("swap", free_swap_mb *1024 *1024, "B",
-	                TRUE, warn_print,
-	                TRUE, crit_print,
-	                TRUE, 0,
-	                TRUE, (long) total_swap_mb * 1024 * 1024));
+	                true, warn_print,
+	                true, crit_print,
+	                true, 0,
+	                true, (long) total_swap_mb * 1024 * 1024));
 
 	return result;
 }
@@ -514,7 +514,7 @@ process_arguments (int argc, char **argv)
 				}
 			  }
 		case 'a':									/* all swap */
-			allswaps = TRUE;
+			allswaps = true;
 			break;
 		case 'n':
 			if ((no_swap_state = mp_translate_state(optarg)) == ERROR) {

--- a/plugins/check_tcp.c
+++ b/plugins/check_tcp.c
@@ -41,7 +41,7 @@ const char *email = "devel@monitoring-plugins.org";
 #include <sys/select.h>
 
 #ifdef HAVE_SSL
-static int check_cert = FALSE;
+static bool check_cert = false;
 static int days_till_exp_warn, days_till_exp_crit;
 # define my_recv(buf, len) ((flags & FLAG_SSL) ? np_net_ssl_read(buf, len) : read(sd, buf, len))
 # define my_send(buf, len) ((flags & FLAG_SSL) ? np_net_ssl_write(buf, len) : send(sd, buf, len, 0))
@@ -65,7 +65,7 @@ static int READ_TIMEOUT = 2;
 
 static int server_port = 0;
 static char *server_address = NULL;
-static int host_specified = FALSE;
+static bool host_specified = false;
 static char *server_send = NULL;
 static char *server_quit = NULL;
 static char **server_expect;
@@ -88,7 +88,7 @@ static int match_flags = NP_MATCH_EXACT;
 
 #ifdef HAVE_SSL
 static char *sni = NULL;
-static int sni_specified = FALSE;
+static bool sni_specified = false;
 #endif
 
 #define FLAG_SSL 0x01
@@ -247,7 +247,7 @@ main (int argc, char **argv)
 #ifdef HAVE_SSL
 	if (flags & FLAG_SSL){
 		result = np_net_ssl_init_with_hostname(sd, (sni_specified ? sni : NULL));
-		if (result == STATE_OK && check_cert == TRUE) {
+		if (result == STATE_OK && check_cert) {
 			result = np_net_ssl_check_cert(days_till_exp_warn, days_till_exp_crit);
 		}
 	}
@@ -378,18 +378,18 @@ main (int argc, char **argv)
 	if(match == NP_MATCH_FAILURE)
 		printf ("|%s",
 				fperfdata ("time", elapsed_time, "s",
-				(flags & FLAG_TIME_WARN ? TRUE : FALSE), 0,
-				(flags & FLAG_TIME_CRIT ? TRUE : FALSE), 0,
-				TRUE, 0,
-				TRUE, socket_timeout)
+				(flags & FLAG_TIME_WARN ? true : false), 0,
+				(flags & FLAG_TIME_CRIT ? true : false), 0,
+				true, 0,
+				true, socket_timeout)
 			);
 	else
 		printf("|%s",
 				fperfdata ("time", elapsed_time, "s",
-				(flags & FLAG_TIME_WARN ? TRUE : FALSE), warning_time,
-				(flags & FLAG_TIME_CRIT ? TRUE : FALSE), critical_time,
-				TRUE, 0,
-				TRUE, socket_timeout)
+				(flags & FLAG_TIME_WARN ? true : false), warning_time,
+				(flags & FLAG_TIME_CRIT ? true : false), critical_time,
+				true, 0,
+				true, socket_timeout)
 			);
 
 	putchar('\n');
@@ -399,11 +399,9 @@ main (int argc, char **argv)
 
 
 /* process command-line arguments */
-static int
-process_arguments (int argc, char **argv)
-{
+static int process_arguments (int argc, char **argv) {
 	int c;
-	int escape = 0;
+	bool escape = false;
 	char *temp;
 
 	enum {
@@ -492,7 +490,7 @@ process_arguments (int argc, char **argv)
 #endif
 			break;
 		case 'H':                 /* hostname */
-			host_specified = TRUE;
+			host_specified = true;
 			server_address = optarg;
 			break;
 		case 'c':                 /* critical */
@@ -527,7 +525,7 @@ process_arguments (int argc, char **argv)
 				server_port = atoi (optarg);
 			break;
 		case 'E':
-			escape = 1;
+			escape = true;
 			break;
 		case 's':
 			if (escape)
@@ -601,7 +599,7 @@ process_arguments (int argc, char **argv)
 				usage2 (_("Invalid certificate expiration period"), optarg);
 			    days_till_exp_warn = atoi (optarg);
 			}
-			check_cert = TRUE;
+			check_cert = true;
 			flags |= FLAG_SSL;
 			break;
 #  endif /* USE_OPENSSL */
@@ -617,7 +615,7 @@ process_arguments (int argc, char **argv)
 		case SNI_OPTION:
 #ifdef HAVE_SSL
 			flags |= FLAG_SSL;
-			sni_specified = TRUE;
+			sni_specified = true;
 			sni = optarg;
 #else
 			die (STATE_UNKNOWN, _("Invalid option - SSL is not available"));
@@ -630,15 +628,15 @@ process_arguments (int argc, char **argv)
 	}
 
 	c = optind;
-	if(host_specified == FALSE && c < argc)
+	if(!host_specified && c < argc)
 		server_address = strdup (argv[c++]);
 
 	if (server_address == NULL)
 		usage4 (_("You must provide a server address"));
-	else if (server_address[0] != '/' && is_host (server_address) == FALSE)
+	else if (server_address[0] != '/' && !is_host(server_address))
 		die (STATE_CRITICAL, "%s %s - %s: %s\n", SERVICE, state_text(STATE_CRITICAL), _("Invalid hostname, address or socket"), server_address);
 
-	return TRUE;
+	return OK;
 }
 
 

--- a/plugins/check_ups.c
+++ b/plugins/check_ups.c
@@ -75,8 +75,8 @@ char *server_address;
 char *ups_name = NULL;
 double warning_value = 0.0;
 double critical_value = 0.0;
-int check_warn = FALSE;
-int check_crit = FALSE;
+bool check_warn = false;
+bool check_crit = false;
 int check_variable = UPS_NONE;
 int supported_options = UPS_NONE;
 int status = UPSSTATUS_NONE;
@@ -86,7 +86,7 @@ double ups_battery_percent = 0.0;
 double ups_load_percent = 0.0;
 double ups_temperature = 0.0;
 char *ups_status;
-int temp_output_c = 0;
+bool temp_output_c = false;
 
 int determine_status (void);
 int get_ups_variable (const char *, char *);
@@ -205,21 +205,21 @@ main (int argc, char **argv)
 			ups_utility_deviation = ups_utility_voltage - 120.0;
 
 		if (check_variable == UPS_UTILITY) {
-			if (check_crit==TRUE && ups_utility_deviation>=critical_value) {
+			if (check_crit && ups_utility_deviation>=critical_value) {
 				result = STATE_CRITICAL;
 			}
-			else if (check_warn==TRUE && ups_utility_deviation>=warning_value) {
+			else if (check_warn && ups_utility_deviation>=warning_value) {
 				result = max_state (result, STATE_WARNING);
 			}
 			xasprintf (&data, "%s",
 			          perfdata ("voltage", (long)(1000*ups_utility_voltage), "mV",
 			                    check_warn, (long)(1000*warning_value),
 			                    check_crit, (long)(1000*critical_value),
-			                    TRUE, 0, FALSE, 0));
+			                    true, 0, false, 0));
 		} else {
 			xasprintf (&data, "%s",
 			          perfdata ("voltage", (long)(1000*ups_utility_voltage), "mV",
-			                    FALSE, 0, FALSE, 0, TRUE, 0, FALSE, 0));
+			                    false, 0, false, 0, true, 0, false, 0));
 		}
 	}
 
@@ -234,21 +234,21 @@ main (int argc, char **argv)
 		xasprintf (&message, "%sBatt=%3.1f%% ", message, ups_battery_percent);
 
 		if (check_variable == UPS_BATTPCT) {
-			if (check_crit==TRUE && ups_battery_percent <= critical_value) {
+			if (check_crit && ups_battery_percent <= critical_value) {
 				result = STATE_CRITICAL;
 			}
-			else if (check_warn==TRUE && ups_battery_percent<=warning_value) {
+			else if (check_warn && ups_battery_percent<=warning_value) {
 				result = max_state (result, STATE_WARNING);
 			}
 			xasprintf (&data, "%s %s", data,
 			          perfdata ("battery", (long)ups_battery_percent, "%",
 			                    check_warn, (long)(warning_value),
 			                    check_crit, (long)(critical_value),
-			                    TRUE, 0, TRUE, 100));
+			                    true, 0, true, 100));
 		} else {
 			xasprintf (&data, "%s %s", data,
 			          perfdata ("battery", (long)ups_battery_percent, "%",
-			                    FALSE, 0, FALSE, 0, TRUE, 0, TRUE, 100));
+			                    false, 0, false, 0, true, 0, true, 100));
 		}
 	}
 
@@ -263,21 +263,21 @@ main (int argc, char **argv)
 		xasprintf (&message, "%sLoad=%3.1f%% ", message, ups_load_percent);
 
 		if (check_variable == UPS_LOADPCT) {
-			if (check_crit==TRUE && ups_load_percent>=critical_value) {
+			if (check_crit && ups_load_percent>=critical_value) {
 				result = STATE_CRITICAL;
 			}
-			else if (check_warn==TRUE && ups_load_percent>=warning_value) {
+			else if (check_warn && ups_load_percent>=warning_value) {
 				result = max_state (result, STATE_WARNING);
 			}
 			xasprintf (&data, "%s %s", data,
 			          perfdata ("load", (long)ups_load_percent, "%",
 			                    check_warn, (long)(warning_value),
 			                    check_crit, (long)(critical_value),
-			                    TRUE, 0, TRUE, 100));
+			                    true, 0, true, 100));
 		} else {
 			xasprintf (&data, "%s %s", data,
 			          perfdata ("load", (long)ups_load_percent, "%",
-			                    FALSE, 0, FALSE, 0, TRUE, 0, TRUE, 100));
+			                    false, 0, false, 0, true, 0, true, 100));
 		}
 	}
 
@@ -300,21 +300,21 @@ main (int argc, char **argv)
 		}
 
 		if (check_variable == UPS_TEMP) {
-			if (check_crit==TRUE && ups_temperature>=critical_value) {
+			if (check_crit && ups_temperature>=critical_value) {
 				result = STATE_CRITICAL;
 			}
-			else if (check_warn == TRUE && ups_temperature>=warning_value) {
+			else if (check_warn && ups_temperature>=warning_value) {
 				result = max_state (result, STATE_WARNING);
 			}
 			xasprintf (&data, "%s %s", data,
 			          perfdata ("temp", (long)ups_temperature, tunits,
 			                    check_warn, (long)(warning_value),
 			                    check_crit, (long)(critical_value),
-			                    TRUE, 0, FALSE, 0));
+			                    true, 0, false, 0));
 		} else {
 			xasprintf (&data, "%s %s", data,
 			          perfdata ("temp", (long)ups_temperature, tunits,
-			                    FALSE, 0, FALSE, 0, TRUE, 0, FALSE, 0));
+			                    false, 0, false, 0, true, 0, false, 0));
 		}
 	}
 
@@ -508,7 +508,7 @@ process_arguments (int argc, char **argv)
 			}
 			break;
 		case 'T': /* FIXME: to be improved (ie "-T C" for Celsius or "-T F" for Fahrenheit) */
-			temp_output_c = 1;
+			temp_output_c = true;
 			break;
 		case 'u':									/* ups name */
 			ups_name = optarg;
@@ -524,7 +524,7 @@ process_arguments (int argc, char **argv)
 		case 'c':									/* critical time threshold */
 			if (is_intnonneg (optarg)) {
 				critical_value = atoi (optarg);
-				check_crit = TRUE;
+				check_crit = true;
 			}
 			else {
 				usage2 (_("Critical time must be a positive integer"), optarg);
@@ -533,7 +533,7 @@ process_arguments (int argc, char **argv)
 		case 'w':									/* warning time threshold */
 			if (is_intnonneg (optarg)) {
 				warning_value = atoi (optarg);
-				check_warn = TRUE;
+				check_warn = true;
 			}
 			else {
 				usage2 (_("Warning time must be a positive integer"), optarg);

--- a/plugins/check_users.c
+++ b/plugins/check_users.c
@@ -179,7 +179,7 @@ main (int argc, char **argv)
 		printf (_("USERS %s - %d users currently logged in |%s\n"),
 				state_text(result), users,
 				sperfdata_int("users", users, "", warning_range,
-							critical_range, TRUE, 0, FALSE, 0));
+							critical_range, true, 0, false, 0));
 	}
 
 	return result;
@@ -202,7 +202,7 @@ process_arguments (int argc, char **argv)
 	if (argc < 2)
 		usage ("\n");
 
-	while (1) {
+	while (true) {
 		c = getopt_long (argc, argv, "+hVvc:w:", longopts, &option);
 
 		if (c == -1 || c == EOF || c == 1)

--- a/plugins/common.h
+++ b/plugins/common.h
@@ -184,14 +184,6 @@ enum {
 	ERROR = -1
 };
 
-/* AIX seems to have this defined somewhere else */
-#ifndef FALSE
-enum {
-	FALSE,
-	TRUE
-};
-#endif
-
 enum {
 	STATE_OK,
 	STATE_WARNING,

--- a/plugins/negate.c
+++ b/plugins/negate.c
@@ -47,7 +47,7 @@ static const char **process_arguments (int, char **);
 void validate_arguments (char **);
 void print_help (void);
 void print_usage (void);
-int subst_text = FALSE;
+bool subst_text = false;
 
 static int state[4] = {
 	STATE_OK,
@@ -122,7 +122,7 @@ static const char **
 process_arguments (int argc, char **argv)
 {
 	int c;
-	int permute = TRUE;
+	bool permute = true;
 
 	int option = 0;
 	static struct option longopts[] = {
@@ -168,26 +168,26 @@ process_arguments (int argc, char **argv)
 		case 'o':     /* replacement for OK */
 			if ((state[STATE_OK] = mp_translate_state(optarg)) == ERROR)
 				usage4 (_("Ok must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer (0-3)."));
-			permute = FALSE;
+			permute = false;
 			break;
 
 		case 'w':     /* replacement for WARNING */
 			if ((state[STATE_WARNING] = mp_translate_state(optarg)) == ERROR)
 				usage4 (_("Warning must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer (0-3)."));
-			permute = FALSE;
+			permute = false;
 			break;
 		case 'c':     /* replacement for CRITICAL */
 			if ((state[STATE_CRITICAL] = mp_translate_state(optarg)) == ERROR)
 				usage4 (_("Critical must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer (0-3)."));
-			permute = FALSE;
+			permute = false;
 			break;
 		case 'u':     /* replacement for UNKNOWN */
 			if ((state[STATE_UNKNOWN] = mp_translate_state(optarg)) == ERROR)
 				usage4 (_("Unknown must be a valid state name (OK, WARNING, CRITICAL, UNKNOWN) or integer (0-3)."));
-			permute = FALSE;
+			permute = false;
 			break;
 		case 's':     /* Substitute status text */
-			subst_text = TRUE;
+			subst_text = true;
 			break;
 		}
 	}

--- a/plugins/netutils.c
+++ b/plugins/netutils.c
@@ -34,7 +34,7 @@ unsigned int socket_timeout = DEFAULT_SOCKET_TIMEOUT;
 unsigned int socket_timeout_state = STATE_CRITICAL;
 
 int econn_refuse_state = STATE_CRITICAL;
-int was_refused = FALSE;
+bool was_refused = false;
 #if USE_IPV6
 int address_family = AF_UNSPEC;
 #else
@@ -215,14 +215,14 @@ np_net_connect (const char *host_name, int port, int *sd, int proto)
 			result = connect (*sd, r->ai_addr, r->ai_addrlen);
 
 			if (result == 0) {
-				was_refused = FALSE;
+				was_refused = false;
 				break;
 			}
 
 			if (result < 0) {
 				switch (errno) {
 				case ECONNREFUSED:
-					was_refused = TRUE;
+					was_refused = true;
 					break;
 				}
 			}
@@ -246,7 +246,7 @@ np_net_connect (const char *host_name, int port, int *sd, int proto)
 		}
 		result = connect(*sd, (struct sockaddr *)&su, sizeof(su));
 		if (result < 0 && errno == ECONNREFUSED)
-			was_refused = TRUE;
+			was_refused = true;
 	}
 
 	if (result == 0)
@@ -326,13 +326,11 @@ send_request (int sd, int proto, const char *send_buffer, char *recv_buffer, int
 }
 
 
-int
-is_host (const char *address)
-{
+bool is_host (const char *address) {
 	if (is_addr (address) || is_hostname (address))
-		return (TRUE);
+		return (true);
 
-	return (FALSE);
+	return (false);
 }
 
 void
@@ -342,20 +340,18 @@ host_or_die(const char *str)
 		usage_va(_("Invalid hostname/address - %s"), str);
 }
 
-int
-is_addr (const char *address)
-{
+bool is_addr (const char *address) {
 #ifdef USE_IPV6
 	if (address_family == AF_INET && is_inet_addr (address))
-		return TRUE;
+		return true;
 	else if (address_family == AF_INET6 && is_inet6_addr (address))
-		return TRUE;
+		return true;
 #else
 	if (is_inet_addr (address))
-		return (TRUE);
+		return (true);
 #endif
 
-	return (FALSE);
+	return (false);
 }
 
 int
@@ -370,10 +366,10 @@ dns_lookup (const char *in, struct sockaddr_storage *ss, int family)
 
 	retval = getaddrinfo (in, NULL, &hints, &res);
 	if (retval != 0)
-		return FALSE;
+		return false;
 
 	if (ss != NULL)
 		memcpy (ss, res->ai_addr, res->ai_addrlen);
 	freeaddrinfo (res);
-	return TRUE;
+	return true;
 }

--- a/plugins/netutils.h
+++ b/plugins/netutils.h
@@ -73,8 +73,8 @@ int send_request (int sd, int proto, const char *send_buffer, char *recv_buffer,
 
 
 /* "is_*" wrapper macros and functions */
-int is_host (const char *);
-int is_addr (const char *);
+bool is_host (const char *);
+bool is_addr (const char *);
 int dns_lookup (const char *, struct sockaddr_storage *, int);
 void host_or_die(const char *str);
 #define resolve_host_or_addr(addr, family) dns_lookup(addr, NULL, family)
@@ -89,7 +89,7 @@ void host_or_die(const char *str);
 extern unsigned int socket_timeout;
 extern unsigned int socket_timeout_state;
 extern int econn_refuse_state;
-extern int was_refused;
+extern bool was_refused;
 extern int address_family;
 
 void socket_timeout_alarm_handler (int) __attribute__((noreturn));

--- a/plugins/utils.c
+++ b/plugins/utils.c
@@ -147,98 +147,80 @@ print_revision (const char *command_name, const char *revision)
 	         command_name, revision, PACKAGE, VERSION);
 }
 
-int
-is_numeric (char *number)
-{
+bool is_numeric (char *number) {
 	char tmp[1];
 	float x;
 
 	if (!number)
-		return FALSE;
+		return false;
 	else if (sscanf (number, "%f%c", &x, tmp) == 1)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
-int
-is_positive (char *number)
-{
+bool is_positive (char *number) {
 	if (is_numeric (number) && atof (number) > 0.0)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
-int
-is_negative (char *number)
-{
+bool is_negative (char *number) {
 	if (is_numeric (number) && atof (number) < 0.0)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
-int
-is_nonnegative (char *number)
-{
+bool is_nonnegative (char *number) {
 	if (is_numeric (number) && atof (number) >= 0.0)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
-int
-is_percentage (char *number)
-{
+bool is_percentage (char *number) {
 	int x;
 	if (is_numeric (number) && (x = atof (number)) >= 0 && x <= 100)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
-int
-is_integer (char *number)
-{
+bool is_integer (char *number) {
 	long int n;
 
 	if (!number || (strspn (number, "-0123456789 ") != strlen (number)))
-		return FALSE;
+		return false;
 
 	n = strtol (number, NULL, 10);
 
 	if (errno != ERANGE && n >= INT_MIN && n <= INT_MAX)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
-int
-is_intpos (char *number)
-{
+bool is_intpos (char *number) {
 	if (is_integer (number) && atoi (number) > 0)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
-int
-is_intneg (char *number)
-{
+bool is_intneg (char *number) {
 	if (is_integer (number) && atoi (number) < 0)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
-int
-is_intnonneg (char *number)
-{
+bool is_intnonneg (char *number) {
 	if (is_integer (number) && atoi (number) >= 0)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
 /*
@@ -246,19 +228,19 @@ is_intnonneg (char *number)
  * On success the number will be written to the _target_ address, if _target_ is not set
  * to NULL.
  */
-int is_int64(char *number, int64_t *target) {
+bool is_int64(char *number, int64_t *target) {
 	errno = 0;
 	uint64_t tmp = strtoll(number, NULL, 10);
 	if (errno != 0) {
-		return 0;
+		return false;
 	}
 	if (tmp < INT64_MIN || tmp > INT64_MAX) {
-		return 0;
+		return false;
 	}
 	if (target != NULL) {
 		*target = tmp;
 	}
-	return 1;
+	return true;
 }
 
 /*
@@ -266,40 +248,36 @@ int is_int64(char *number, int64_t *target) {
  * On success the number will be written to the _target_ address, if _target_ is not set
  * to NULL.
  */
-int is_uint64(char *number, uint64_t *target) {
+bool is_uint64(char *number, uint64_t *target) {
 	errno = 0;
 	uint64_t tmp = strtoll(number, NULL, 10);
 	if (errno != 0) {
-		return 0;
+		return false;
 	}
 	if (tmp < 0 || tmp > UINT64_MAX) {
-		return 0;
+		return false;
 	}
 	if (target != NULL) {
 		*target = tmp;
 	}
-	return 1;
+	return true;
 }
 
-int
-is_intpercent (char *number)
-{
+bool is_intpercent (char *number) {
 	int i;
 	if (is_integer (number) && (i = atoi (number)) >= 0 && i <= 100)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
-int
-is_option (char *str)
-{
+bool is_option (char *str) {
 	if (!str)
-		return FALSE;
+		return false;
 	else if (strspn (str, "-") == 1 || strspn (str, "-") == 2)
-		return TRUE;
+		return true;
 	else
-		return FALSE;
+		return false;
 }
 
 #ifdef NEED_GETTIMEOFDAY

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -16,6 +16,8 @@ suite of plugins. */
 /* now some functions etc are being defined in ../lib/utils_base.c */
 #include "utils_base.h"
 
+#include <stdbool.h>
+
 
 #ifdef NP_EXTRA_OPTS
 /* Include extra-opts functions if compiled in */
@@ -34,21 +36,21 @@ extern time_t start_time, end_time;
 
 /* Test input types */
 
-int is_integer (char *);
-int is_intpos (char *);
-int is_intneg (char *);
-int is_intnonneg (char *);
-int is_intpercent (char *);
-int is_uint64(char *number, uint64_t *target);
-int is_int64(char *number, int64_t *target);
+bool is_integer (char *);
+bool is_intpos (char *);
+bool is_intneg (char *);
+bool is_intnonneg (char *);
+bool is_intpercent (char *);
+bool is_uint64(char *number, uint64_t *target);
+bool is_int64(char *number, int64_t *target);
 
-int is_numeric (char *);
-int is_positive (char *);
-int is_negative (char *);
-int is_nonnegative (char *);
-int is_percentage (char *);
+bool is_numeric (char *);
+bool is_positive (char *);
+bool is_negative (char *);
+bool is_nonnegative (char *);
+bool is_percentage (char *);
 
-int is_option (char *);
+bool is_option (char *);
 
 /* Generalized timer that will do milliseconds if available */
 #ifndef HAVE_STRUCT_TIMEVAL


### PR DESCRIPTION
This PR aims to replace all "old school boolean" (`ints` declared as `ints`) with the C99 `bool` (probably still `int` but the compiler can do whatever it wants here).

This should enhance readability, might prevent some really weird edge-case bugs and allows for some optimizations from the compiler side.

Mostly though the readability thing.

There a quite probably some variables which I did not find on this first try.

Also this is probably what @sni calls a "PR from hell" :-)

I can split it up if this is wished for.