### PR TITLE
check_procs: ignore our own children

### DIFF
--- a/plugins/check_procs.c
+++ b/plugins/check_procs.c
@@ -255,6 +255,13 @@ main (int argc, char **argv)
 				continue;
 			}
 
+			/* Ignore our own children */
+			if (procppid == mypid) {
+				if (verbose >= 3)
+					 printf("not considering - is our child\n");
+				continue;
+			}
+
 			/* Ignore excluded processes by name */
 			if(options & EXCLUDE_PROGS) {
 			  int found = 0;


### PR DESCRIPTION
On systems with higher core counts check_procs will occasionally see its own "ps" child process with a high CPU percentage and raise a false alarm.

Ignoring the child processes of check_procs prevents this from happening.

Example of such a false alert:

```
S+     109  152286  152285   6492  1040  0.0       00:00 check_procs     /usr/lib/nagios/plugins/check_procs -w 85 -c 95 --metric=CPU -T -vvvproc#=231 uid=109 vsz=6492 rss=1040 pid=152286 ppid=152285 pcpu=0.00 stat=S+ etime=00:00 prog=check_procs args=/usr/lib/nagios/plugins/check_procs -w 85 -c 95 --metric=CPU -T -vvv
not considering - is myself or gone
R+     109  152287  152286   8088  4048  200       00:00 ps              /bin/ps axwwo stat uid pid ppid vsz rss pcpu etime comm argsproc#=231 uid=109 vsz=8088 rss=4048 pid=152287 ppid=152286 pcpu=200.00 stat=R+ etime=00:00 prog=ps args=/bin/ps axwwo stat uid pid ppid vsz rss pcpu etime comm args
Matched: uid=109 vsz=8088 rss=4048 pid=152287 ppid=152286 pcpu=200.00 stat=R+ etime=00:00 prog=ps args=/bin/ps axwwo stat uid pid ppid vsz rss pcpu etime comm args
CPU CRITICAL: 1 crit, 0 warn out of 232 processes [ps] | procs=232;;;0; procs_warn=0;;;0; procs_crit=1;;;0;
```

This is happening on a system with 16 cores.