### PR TITLE
Use debian stable for main tests again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,10 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - 'debian:testing'
+          - 'debian:stable'
           #...
         include:
-          - distro: 'debian:testing'
+          - distro: 'debian:stable'
             prepare: .github/prepare_debian.sh
           #...
     steps:


### PR DESCRIPTION
This switches the main testing stuff back to debian stable since testing is broken again.

I would propose to stay with this and add workflows against testing based on manual or timer based triggers on the `master` branch.