### PR TITLE
check_swap: Possibility to run check_swap without thresholds

### DIFF
--- a/plugins/check_swap.c
+++ b/plugins/check_swap.c
@@ -401,7 +401,7 @@ check_swap(float free_swap_mb, float total_swap_mb)
 	uint64_t free_swap = free_swap_mb * (1024 * 1024);		/* Convert back to bytes as warn and crit specified in bytes */
 	uint64_t usage_percentage = ((total_swap_mb - free_swap_mb) / total_swap_mb) * 100;
 
-	if (warn.value && crit.value) {                                 /* Thresholds defined */
+	if (warn.value || crit.value) {                                 /* Thresholds defined */
 	        if (!crit.is_percentage && crit.value >= free_swap) return STATE_CRITICAL;
 	        if (!warn.is_percentage && warn.value >= free_swap) return STATE_WARNING;
 
@@ -546,13 +546,7 @@ process_arguments (int argc, char **argv)
 int
 validate_arguments (void)
 {
-        if (warn.value && !crit.value) {
-                usage4(_("Must define both warning and critical thresholds"));
-        }
-        else if (crit.value && !warn.value) {
-                usage4(_("Must define both warning and critical thresholds"));
-        }
-	else if ((warn.is_percentage == crit.is_percentage) && (warn.value < crit.value)) {
+	if ((warn.is_percentage == crit.is_percentage) && (warn.value < crit.value)) {
 		/* This is NOT triggered if warn and crit are different units, e.g warn is percentage
 		 * and crit is absolute. We cannot determine the condition at this point since we
 		 * dont know the value of total swap yet

--- a/plugins/t/check_swap.t
+++ b/plugins/t/check_swap.t
@@ -5,7 +5,7 @@
 #
 
 use strict;
-use Test::More tests => 8;
+use Test::More tests => 14;
 use NPTest;
 
 my $successOutput = '/^SWAP OK - [0-9]+\% free \([0-9]+MB out of [0-9]+MB\)/';

--- a/plugins/t/check_swap.t
+++ b/plugins/t/check_swap.t
@@ -14,6 +14,10 @@ my $warnOutput    = '/^SWAP WARNING - [0-9]+\% free \([0-9]+MB out of [0-9]+MB\)
 
 my $result;
 
+$result = NPTest->testCmd( "./check_swap" );					# Always OK
+cmp_ok( $result->return_code, "==", 0, "Always OK" );
+like( $result->output, $successOutput, "Right output" );
+
 $result = NPTest->testCmd( "./check_swap -w 1048576 -c 1048576" );		# 1 MB free
 cmp_ok( $result->return_code, "==", 0, "At least 1MB free" );
 like( $result->output, $successOutput, "Right output" );
@@ -28,4 +32,12 @@ like( $result->output, $failureOutput, "Right output" );
 
 $result = NPTest->testCmd( "./check_swap -w 100% -c 1%" );			# 100% (always warn)
 cmp_ok( $result->return_code, "==", 1, 'Get warning because not 100% free' );
+like( $result->output, $warnOutput, "Right output" );
+
+$result = NPTest->testCmd( "./check_swap -w 100%" );				# 100% (single threshold, always warn)
+cmp_ok( $result->return_code, "==", 1, 'Get warning because not 100% free' );
+like( $result->output, $warnOutput, "Right output" );
+
+$result = NPTest->testCmd( "./check_swap -c 100%" );				# 100% (single threshold, always critical)
+cmp_ok( $result->return_code, "==", 2, 'Get critical because not 100% free' );
 like( $result->output, $warnOutput, "Right output" );

--- a/plugins/t/check_swap.t
+++ b/plugins/t/check_swap.t
@@ -40,4 +40,4 @@ like( $result->output, $warnOutput, "Right output" );
 
 $result = NPTest->testCmd( "./check_swap -c 100%" );				# 100% (single threshold, always critical)
 cmp_ok( $result->return_code, "==", 2, 'Get critical because not 100% free' );
-like( $result->output, $warnOutput, "Right output" );
+like( $result->output, $failureOutput, "Right output" );


### PR DESCRIPTION
This PR adds the possibility to run check_swap without having to define the thresholds. Previously to that PR, check_swap could not be run without setting thresholds.

The plugin returns OK if no thresholds are defined. This can be very helpful if Swap Usage is purely monitored for informational (and observability) purposes but without any need to alert.

```
$ ./check_swap
SWAP OK - 3% free (208MB out of 8651MB) |swap=218103808B;0;0;0;9071230976
```

Thresholds still work, of course, but are not mandatory anymore:

```
$ ./check_swap -w 10% -c 5%
SWAP CRITICAL - 3% free (208MB out of 8651MB) |swap=218103808B;907123090;453561545;0;9071230976
```

As thresholds were a must before, the change from this PR will not break any existing configurations, as they already have thresholds defined. 
