### PR TITLE
check_http: replace www.mozilla.com with monitoring-plugins.org

### DIFF
--- a/.github/prepare_debian.sh
+++ b/.github/prepare_debian.sh
@@ -64,13 +64,9 @@ apt-get -y install perl \
 	iproute2
 
 # remove ipv6 interface from hosts
-if [ $(ip addr show | grep "inet6 ::1" | wc -l) -eq "0" ]; then
-    sed '/^::1/d' /etc/hosts > /tmp/hosts
-    cp -f /tmp/hosts /etc/hosts
-fi
-
+sed '/^::1/d' /etc/hosts > /tmp/hosts
+cp -f /tmp/hosts /etc/hosts
 ip addr show
-
 cat /etc/hosts
 
 # apache

--- a/plugins/t/check_curl.t
+++ b/plugins/t/check_curl.t
@@ -205,9 +205,9 @@ SKIP: {
         like  ( $res->output, '/time_connect=[\d\.]+/', 'Extended Performance Data Output OK' );
         like  ( $res->output, '/time_ssl=[\d\.]+/', 'Extended Performance Data SSL Output OK' );
 
-        $res = NPTest->testCmd( "./$plugin -H www.mozilla.com -u /firefox -f curl" );
+        $res = NPTest->testCmd( "./$plugin -H monitoring-plugins.org -u /download.html -f follow" );
         is( $res->return_code, 0, "Redirection based on location is okay");
 
-        $res = NPTest->testCmd( "./$plugin -H www.mozilla.com --extended-perfdata" );
+        $res = NPTest->testCmd( "./$plugin -H monitoring-plugins.org --extended-perfdata" );
         like  ( $res->output, '/time_connect=[\d\.]+/', 'Extended Performance Data Output OK' );
 }

--- a/plugins/t/check_http.t
+++ b/plugins/t/check_http.t
@@ -166,10 +166,10 @@ SKIP: {
         like  ( $res->output, '/time_connect=[\d\.]+/', 'Extended Performance Data Output OK' );
         like  ( $res->output, '/time_ssl=[\d\.]+/', 'Extended Performance Data SSL Output OK' );
 
-        $res = NPTest->testCmd( "./$plugin -H www.mozilla.com -u /firefox -f follow" );
+        $res = NPTest->testCmd( "./$plugin -H monitoring-plugins.org -u /download.html -f follow" );
         is( $res->return_code, 0, "Redirection based on location is okay");
 
-        $res = NPTest->testCmd( "./$plugin -H www.mozilla.com --extended-perfdata" );
+        $res = NPTest->testCmd( "./$plugin -H monitoring-plugins.org --extended-perfdata" );
         like  ( $res->output, '/time_connect=[\d\.]+/', 'Extended Performance Data Output OK' );
 }
 


### PR DESCRIPTION
this makes tests more reliable if we test our own sites instead some 3rd party site.