### PR TITLE
Check curl regex state

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1775,9 +1775,9 @@ process_arguments (int argc, char **argv)
       invert_regex = true;
       break;
     case STATE_REGEX:
-      if (!strcmp (optarg, "critical"))
+      if (!strcasecmp (optarg, "critical"))
         state_regex = STATE_CRITICAL;
-      else if (!strcmp (optarg, "warning"))
+      else if (!strcasecmp (optarg, "warning"))
         state_regex = STATE_WARNING;
       else usage2 (_("Invalid state-regex option"), optarg);
       break;

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -2062,7 +2062,7 @@ print_help (void)
   printf ("    %s\n", _("Return STATE if found, OK if not (STATE is CRITICAL, per default)"));
   printf ("    %s\n", _("can be changed with --state--regex)"));
   printf (" %s\n", "--state-regex=STATE");
-  printf ("    %s\n", _("Return STATE if regex is found, OK if not\nSTATE can be one of \"critical\",\"warning\""));
+  printf ("    %s\n", _("Return STATE if regex is found, OK if not. STATE can be one of \"critical\",\"warning\""));
   printf (" %s\n", "-a, --authorization=AUTH_PAIR");
   printf ("    %s\n", _("Username:password on sites with basic authentication"));
   printf (" %s\n", "-b, --proxy-authorization=AUTH_PAIR");

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -2061,8 +2061,8 @@ print_help (void)
   printf (" %s\n", "--invert-regex");
   printf ("    %s\n", _("Return STATE if found, OK if not (STATE is CRITICAL, per default)"));
   printf ("    %s\n", _("can be changed with --state--regex)"));
-  printf (" %s\n", "--regex-state=STATE");
-  printf ("    %s\n", _("Return STATE if regex is found, OK if not\n"));
+  printf (" %s\n", "--state-regex=STATE");
+  printf ("    %s\n", _("Return STATE if regex is found, OK if not\nSTATE can be one of \"critical\",\"warning\""));
   printf (" %s\n", "-a, --authorization=AUTH_PAIR");
   printf ("    %s\n", _("Username:password on sites with basic authentication"));
   printf (" %s\n", "-b, --proxy-authorization=AUTH_PAIR");


### PR DESCRIPTION
This mainly fixes a problem introduced in #2006 ( f29785f5035e489576d2ba74be774273b73dd149 ), where the option really is `state-regex` but the help says `regex-state`.