### PR TITLE
Fix/check mysql variables

### DIFF
--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -59,7 +59,7 @@ bool ssl = false;
 char *opt_file = NULL;
 char *opt_group = NULL;
 unsigned int db_port = MYSQL_PORT;
-int check_slave = 0, warn_sec = 0, crit_sec = 0;
+int check_slave = 0;
 int ignore_auth = 0;
 int verbose = 0;
 

--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -59,8 +59,8 @@ bool ssl = false;
 char *opt_file = NULL;
 char *opt_group = NULL;
 unsigned int db_port = MYSQL_PORT;
-int check_slave = 0;
-int ignore_auth = 0;
+bool check_slave = false;
+bool ignore_auth = false;
 int verbose = 0;
 
 static double warning_time = 0;
@@ -456,10 +456,10 @@ process_arguments (int argc, char **argv)
 			db_port = atoi (optarg);
 			break;
 		case 'S':
-			check_slave = 1;							/* check-slave */
+			check_slave = true;							/* check-slave */
 			break;
 		case 'n':
-			ignore_auth = 1;							/* ignore-auth */
+			ignore_auth = true;							/* ignore-auth */
 			break;
 		case 'w':
 			warning = optarg;


### PR DESCRIPTION
Two commits for `check_mysql`:
One removes unused variables (which were not discovered earlier, since they are global ...).
The other one makes two integers to booleans which should make it easier to the read the code.