### PR TITLE
Remove experimental state from check_curl

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -2190,8 +2190,6 @@ print_usage (void)
   printf ("%s\n", _("In the first form, make an HTTP request."));
   printf ("%s\n\n", _("In the second form, connect to the server and check the TLS certificate."));
 #endif
-  printf ("%s\n", _("WARNING: check_curl is experimental. Please use"));
-  printf ("%s\n\n", _("check_http if you need a stable version."));
 }
 
 void


### PR DESCRIPTION
I think `check_curl` should now be considered to be ready for productive usage.