### PR TITLE
add new github test workflow for debian:testing and fedora:rawhide

### DIFF
--- a/.github/workflows/test-next.yml
+++ b/.github/workflows/test-next.yml
@@ -2,6 +2,7 @@
 name: Tests Debian:Testing and Fedora:Rawhide
 
 on:
+  workflow_dispatch: {}
   push:
     branches-ignore:
       - '*'

--- a/.github/workflows/test-next.yml
+++ b/.github/workflows/test-next.yml
@@ -1,11 +1,13 @@
 ---
-name: Tests
+name: Tests Debian:Testing and Fedora:Rawhide
 
 on:
   push:
-    branches:
+    branches-ignore:
       - '*'
-  pull_request:
+  schedule:
+    # Run every week on Monday at 9:00 AM (UTC)
+    - cron: '0 9 * * 1'
 
 jobs:
   full-test:
@@ -15,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - 'debian:stable'
+          - 'debian:testing'
         include:
-          - distro: 'debian:stable'
+          - distro: 'debian:testing'
             prepare: .github/prepare_debian.sh
     steps:
       - name: Git clone repository
@@ -53,10 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {"distro": "fedora:latest", "build": ".github/mock.sh"}
-          - {"distro": "rockylinux:8", "build": ".github/mock.sh"}
-          - {"distro": "almalinux:9", "build": ".github/mock.sh"}
-#          - {"distro": "oraclelinux:9", "build": ".github/mock.sh"}
+          - {"distro": "fedora:rawhide", "build": ".github/mock.sh"}
     steps:
       - name: Git clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
this workflow runs scheduled once a week, so it does not prevent PRs from being merged but still allows us to notice if anything will go wrong with the next release.
Remove rawhide test from the mandatory tests like we did with debian testing already.