### PR TITLE
Add clang-format config file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: LLVM
+UseTab: ForContinuationAndIndentation
+IndentWidth: 4
+TabWidth: 4
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBraces: Attach
+AlignConsecutiveMacros: true
+ColumnLimit: 180
+IndentPPDirectives: AfterHash
+SortIncludes: Never


### PR DESCRIPTION
# Small commit, huge decision

I propose to define the code style of the C part of the project in the `golang` style.
Whatever `clang-format` does with the config is the right style.
I do get annoyed everytime with mixed indentation in the code and stuff like that.

Will this totally ruin the first level of `git blame`? yes

Nonetheless it makes things better IMHO.
In addition to this change and reformatting stuff, when convenient, we should adapt all relevant documentation.


