### PR TITLE
Improve readability and reliability of test prepare scripts

### DIFF
--- a/.github/mock.sh
+++ b/.github/mock.sh
@@ -2,6 +2,8 @@
 
 set -x
 
+set -euo pipefail
+
 export DEBIAN_FRONTEND=noninteractive
 
 BASE_PATH="/src"

--- a/.github/mock.sh
+++ b/.github/mock.sh
@@ -20,7 +20,11 @@ SPEC_FILE="${SPEC_DIR}monitoring-plugins.spec"
 cd ${BASE_PATH}
 
 dnf -y --setopt="tsflags=nodocs" update && \
-  if [ ${distro_id} != "fedora" ]; then dnf -y --setopt="tsflags=nodocs" install epel-release; else platform_id="$(echo ${platform_id} | sed s/^f/fc/)"; fi && \
+  if [ "${distro_id}" != "fedora" ]; then
+     dnf -y --setopt="tsflags=nodocs" install epel-release;
+  else
+    platform_id="$(echo "${platform_id}" | sed s/^f/fc/)";
+  fi && \
   case ${distro_id} in
     ol)
       case ${platform_id} in
@@ -34,19 +38,27 @@ dnf -y --setopt="tsflags=nodocs" update && \
       ;;
   esac
   dnf -y --setopt="tsflags=nodocs" install mock rpm-build git-core && \
-  usermod -a -G mock $(whoami)
+  usermod -a -G mock "$(whoami)"
+
 SRC_RPM="monitoring-plugins-*-1.${platform_id}.src.rpm"
+
 if command -v git > /dev/null 2>&1; then
   git config --global --add safe.directory ${BASE_PATH}
   SHA="$(git rev-parse HEAD)"
   sed "s/^%global commit.*/%global commit ${SHA}/" ${SPEC_FILE} > ${SPEC_DIR}monitoring-plugins-git.spec
   sed -i "s/^%global fromgit.*/%global fromgit 1/" ${SPEC_DIR}monitoring-plugins-git.spec
   SPEC_FILE="${SPEC_DIR}monitoring-plugins-git.spec"
-  SRC_RPM="monitoring-plugins-*git.$(echo ${SHA:0:7})*.${platform_id}.src.rpm"
+  SRC_RPM="monitoring-plugins-*git.${SHA:0:7}*.${platform_id}.src.rpm"
 fi
+
 mkdir -p "${SRCRPM_DIR}" "${RPM_DIR}"
 #rpmbuild --undefine=_disable_source_fetch --define "_sourcedir ${SOURCE_DIR}" -ba ${SPEC_FILE}
-dnf -y --setopt="tsflags=nodocs" install rpmdevtools && spectool -g -C ${SOURCE_DIR} ${SPEC_FILE} && \
-mock --dnf --clean --spec ${SPEC_FILE} --sources=${SOURCE_DIR} --result=${SRCRPM_DIR} --build || { cat ${SRCRPM_DIR}/{root,build}.log; exit 1; }
-mock --dnf --clean --sources=${SOURCE_DIR} --result=${RPM_DIR} --rebuild ${SRCRPM_DIR}/${SRC_RPM} || { cat ${RPM_DIR}/{root,build}.log; exit 1; }
+dnf -y --setopt="tsflags=nodocs" install rpmdevtools && \
+  spectool -g -C ${SOURCE_DIR} ${SPEC_FILE} && \
+  { mock --dnf --clean --spec ${SPEC_FILE} --sources=${SOURCE_DIR} --result=${SRCRPM_DIR} --build || \
+  { cat ${SRCRPM_DIR}/{root,build}.log; exit 1; } }
+
+mock --dnf --clean --sources=${SOURCE_DIR} --result=${RPM_DIR} --rebuild "${SRCRPM_DIR}/${SRC_RPM}" || \
+  { cat ${RPM_DIR}/{root,build}.log; exit 1; }
+
 ls -la ${SOURCE_DIR} ${SRCRPM_DIR} ${RPM_DIR}

--- a/.github/mock.sh
+++ b/.github/mock.sh
@@ -58,7 +58,7 @@ dnf -y --setopt="tsflags=nodocs" install rpmdevtools && \
   { mock --dnf --clean --spec ${SPEC_FILE} --sources=${SOURCE_DIR} --result=${SRCRPM_DIR} --build || \
   { cat ${SRCRPM_DIR}/{root,build}.log; exit 1; } }
 
-mock --dnf --clean --sources=${SOURCE_DIR} --result=${RPM_DIR} --rebuild "${SRCRPM_DIR}/${SRC_RPM}" || \
+mock --dnf --clean --sources=${SOURCE_DIR} --result=${RPM_DIR} --rebuild "${SRCRPM_DIR}"/${SRC_RPM} || \
   { cat ${RPM_DIR}/{root,build}.log; exit 1; }
 
 ls -la ${SOURCE_DIR} ${SRCRPM_DIR} ${RPM_DIR}

--- a/.github/prepare_debian.sh
+++ b/.github/prepare_debian.sh
@@ -127,5 +127,5 @@ sed "/NP_HOST_TLS_CERT/s/.*/'NP_HOST_TLS_CERT' => '$(hostname)',/" -i /src/.gith
 
 # create some test files to lower inodes
 for i in $(seq 10); do
-    touch /media/ramdisk2/test.$1
+    touch /media/ramdisk2/test.$i
 done

--- a/.github/prepare_debian.sh
+++ b/.github/prepare_debian.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -x
-set -e
+set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
While trying to find the reason for failing test in other PRs I found the test scripts to be a bit too obscure and prone to fail in weird ways.
So I added some options to fail early in the pipeline if an error occurs in any of the steps and attempted to fix some common expansion problems.
Incindently this seems to fix the pipeline errors.