### PR TITLE
check_disk: fix crash on opensuse15sp6

### DIFF
--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -163,7 +163,7 @@ int main(int argc, char **argv) {
 	char *perf_ilabel;
 	char *preamble = " - free space:";
 	char *ignored_preamble = " - ignored paths:";
-	char *flag_header;
+	char *flag_header = NULL;
 	int temp_result;
 
 	struct mount_entry *me;


### PR DESCRIPTION
somehow check_disk crashes on opensuse 15 sp6:

    Core was generated by `.../monitoring-plugins/check_disk -w 80% -c 90% -p /'.
    Program terminated with signal SIGSEGV, Segmentation fault.
    #0  0x00007ffff74ca6b6 in __strlen_sse2 () from /lib64/libc.so.6
    (gdb) bt
    #0  0x00007ffff74ca6b6 in __strlen_sse2 () from /lib64/libc.so.6
    #1  0x00007ffff7f81aed in dopr (buffer=0x0, maxlen=0, format=0x40a607 "%s inode=-)%s;", args_in=0x7fffffffda30) at lib/snprintf.c:712
    #2  0x00007ffff7f82c6c in smb_vsnprintf (str=0x0, count=0, fmt=0x40a5f0 "%s%s %s %llu%s (%.1f%%", args=0x7fffffffda30) at lib/snprintf.c:1197
    #3  0x00007ffff7f82d79 in vasprintf (ptr=0x7fffffffdba8, format=0x40a5f0 "%s%s %s %llu%s (%.1f%%", ap=0x7fffffffda78) at lib/snprintf.c:1232
    #4  0x0000000000405cf9 in xvasprintf (strp=0x7fffffffdba8, fmt=<optimized out>, ap=<optimized out>) at utils.c:563
    #5  0x0000000000405db7 in xasprintf (strp=strp@entry=0x7fffffffdba8, fmt=fmt@entry=0x40a5f0 "%s%s %s %llu%s (%.1f%%") at utils.c:575
    #6  0x0000000000402d9f in main (argc=<optimized out>, argv=<optimized out>) at check_disk.c:434
    (gdb) f 6
    #6  0x0000000000402d9f in main (argc=<optimized out>, argv=<optimized out>) at check_disk.c:434
    434               xasprintf (&output, "%s%s %s %llu%s (%.1f%%",
    (gdb) p flag_header
    $1 = 0x1cbf0 <error: Cannot access memory at address 0x1cbf0>
    (gdb)

initializing flag_header helps. The line numbers do not match exactly, the crash happens here:

https://github.com/monitoring-plugins/monitoring-plugins/blob/master/plugins/check_disk.c#L425