### PR TITLE
check_curl: enable internal cookie handling

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -818,8 +818,11 @@ int check_http(void) {
 
 	/* cookie handling */
 	if (cookie_jar_file != NULL) {
-		handle_curl_option_return_code(curl_easy_setopt(curl, CURLOPT_COOKIEJAR, cookie_jar_file), "CURLOPT_COOKIEJAR");
+		/* enable reading cookies from a file, and if the filename is an empty string, only enable the curl cookie engine */
 		handle_curl_option_return_code(curl_easy_setopt(curl, CURLOPT_COOKIEFILE, cookie_jar_file), "CURLOPT_COOKIEFILE");
+		/* now enable saving cookies to a file, but only if the filename is not an empty string, since writing it would fail */
+		if (*cookie_jar_file)
+			handle_curl_option_return_code(curl_easy_setopt(curl, CURLOPT_COOKIEJAR, cookie_jar_file), "CURLOPT_COOKIEJAR");
 	}
 
 	/* do the request */
@@ -2011,6 +2014,9 @@ void print_help(void) {
 	printf("    %s\n", _("Send HAProxy proxy protocol v1 header (CURLOPT_HAPROXYPROTOCOL)."));
 	printf(" %s\n", "--cookie-jar=FILE");
 	printf("    %s\n", _("Store cookies in the cookie jar and send them out when requested."));
+	printf("    %s\n", _("Specify an empty string as FILE to enable curl's cookie engine without saving"));
+	printf("    %s\n", _("the cookies to disk. Only enabling the engine without saving to disk requires"));
+	printf("    %s\n", _("handling multiple requests internally to curl, so use it with --onredirect=curl"));
 	printf("\n");
 
 	printf(UT_WARN_CRIT);


### PR DESCRIPTION
This enables us to enable curl cookie engine by specifying an empty filename as the cookie jar file.

This works, since curl's CURLOPT_COOKIEFILE option allows passing an empty string as filename, which it interprets as a request to enable the cookie processing. But since CURLOPT_COOKIEJAR would now attempt to write to a file named by an empty filename, it would break again (or at least produce a warning in verbose output).

Overall this is allows to handle checking URLs with cookie based sessions without persisting the cookies to disk, by using the curl-internal redirect following.