### PR TITLE
Implement JSON output parsing for tests

### DIFF
--- a/NPTest.pm
+++ b/NPTest.pm
@@ -17,7 +17,7 @@ use File::Basename;
 
 use JSON;
 
-use feature 'try';
+use Try::Tiny;
 
 use IO::File;
 use Data::Dumper;
@@ -623,7 +623,7 @@ sub testCmd {
 
     try {
       $object->{'mp_test_result'} = decode_json($output);
-    }
+    };
 
     alarm(0);
 

--- a/NPTest.pm
+++ b/NPTest.pm
@@ -15,6 +15,8 @@ use warnings;
 use Cwd;
 use File::Basename;
 
+use JSON;
+
 use IO::File;
 use Data::Dumper;
 
@@ -616,6 +618,8 @@ sub testCmd {
     }
     chomp $output;
     $object->output($output);
+
+    $object->{'mp_test_result'} = decode_json($output);
 
     alarm(0);
 

--- a/NPTest.pm
+++ b/NPTest.pm
@@ -17,6 +17,8 @@ use File::Basename;
 
 use JSON;
 
+use feature 'try';
+
 use IO::File;
 use Data::Dumper;
 
@@ -619,7 +621,9 @@ sub testCmd {
     chomp $output;
     $object->output($output);
 
-    $object->{'mp_test_result'} = decode_json($output);
+    try {
+      $object->{'mp_test_result'} = decode_json($output);
+    }
 
     alarm(0);
 

--- a/plugins/t/check_swap.t
+++ b/plugins/t/check_swap.t
@@ -17,42 +17,35 @@ my $message = '/^[0-9]+\% free \([0-9]+MiB out of [0-9]+MiB\)/';
 
 $result = NPTest->testCmd( "./check_swap $outputFormat" );					# Always OK
 cmp_ok( $result->return_code, "==", 0, "Always OK" );
-$output = decode_json($result->output);
-is($output->{'state'}, "OK", "State was correct");
-like($output->{'checks'}->[0]->{'output'}, $message, "Output was correct");
+is($result->{'mp_test_result'}->{'state'}, "OK", "State was correct");
+like($result->{'mp_test_result'}->{'checks'}->[0]->{'output'}, $message, "Output was correct");
 
 $result = NPTest->testCmd( "./check_swap -w 1048576 -c 1048576 $outputFormat" );		# 1 MB free
 cmp_ok( $result->return_code, "==", 0, "Always OK" );
-$output = decode_json($result->output);
-is($output->{'state'}, "OK", "State was correct");
-like($output->{'checks'}->[0]->{'output'}, $message, "Output was correct");
+is($result->{'mp_test_result'}->{'state'}, "OK", "State was correct");
+like($result->{'mp_test_result'}->{'checks'}->[0]->{'output'}, $message, "Output was correct");
 
 $result = NPTest->testCmd( "./check_swap -w 1% -c 1% $outputFormat" );			# 1% free
 cmp_ok( $result->return_code, "==", 0, "Always OK" );
-$output = decode_json($result->output);
-is($output->{'state'}, "OK", "State was correct");
-like($output->{'checks'}->[0]->{'output'}, $message, "Output was correct");
+is($result->{'mp_test_result'}->{'state'}, "OK", "State was correct");
+like($result->{'mp_test_result'}->{'checks'}->[0]->{'output'}, $message, "Output was correct");
 
 $result = NPTest->testCmd( "./check_swap -w 100% -c 100% $outputFormat" );			# 100% (always critical)
 cmp_ok( $result->return_code, "==", 0, "Always OK" );
-$output = decode_json($result->output);
-is($output->{'state'}, "CRITICAL", "State was correct");
-like($output->{'checks'}->[0]->{'output'}, $message, "Output was correct");
+is($result->{'mp_test_result'}->{'state'}, "CRITICAL", "State was correct");
+like($result->{'mp_test_result'}->{'checks'}->[0]->{'output'}, $message, "Output was correct");
 
 $result = NPTest->testCmd( "./check_swap -w 100% -c 1% $outputFormat" );			# 100% (always warn)
 cmp_ok( $result->return_code, "==", 0, "Always OK" );
-$output = decode_json($result->output);
-is($output->{'state'}, "WARNING", "State was correct");
-like($output->{'checks'}->[0]->{'output'}, $message, "Output was correct");
+is($result->{'mp_test_result'}->{'state'}, "WARNING", "State was correct");
+like($result->{'mp_test_result'}->{'checks'}->[0]->{'output'}, $message, "Output was correct");
 
 $result = NPTest->testCmd( "./check_swap -w 100% $outputFormat" );				# 100% (single threshold, always warn)
 cmp_ok( $result->return_code, "==", 0, "Always OK" );
-$output = decode_json($result->output);
-is($output->{'state'}, "WARNING", "State was correct");
-like($output->{'checks'}->[0]->{'output'}, $message, "Output was correct");
+is($result->{'mp_test_result'}->{'state'}, "WARNING", "State was correct");
+like($result->{'mp_test_result'}->{'checks'}->[0]->{'output'}, $message, "Output was correct");
 
 $result = NPTest->testCmd( "./check_swap -c 100% $outputFormat" );				# 100% (single threshold, always critical)
 cmp_ok( $result->return_code, "==", 0, "Always OK" );
-$output = decode_json($result->output);
-is($output->{'state'}, "CRITICAL", "State was correct");
-like($output->{'checks'}->[0]->{'output'}, $message, "Output was correct");
+is($result->{'mp_test_result'}->{'state'}, "CRITICAL", "State was correct");
+like($result->{'mp_test_result'}->{'checks'}->[0]->{'output'}, $message, "Output was correct");


### PR DESCRIPTION
Adds some logic to try to always parse the plugin output in tests as JSON.
This should remove some duplicate code from the test files and for the `check_swap` tests this is also contained in this commit