### PR TITLE
Improve handling of -4/-6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1524,17 +1524,10 @@ AC_PATH_PROG(PATH_TO_FPING6,fping6)
 AC_ARG_WITH(fping_command,
             ACX_HELP_STRING([--with-fping-command=PATH],
                             [Path to fping command]), PATH_TO_FPING=$withval)
-AC_ARG_WITH(fping6_command,
-            ACX_HELP_STRING([--with-fping6-command=PATH],
-                            [Path to fping6 command]), PATH_TO_FPING6=$withval)
-
 if test -n "$PATH_TO_FPING"
 then
 	AC_DEFINE_UNQUOTED(PATH_TO_FPING,"$PATH_TO_FPING",[path to fping])
 	EXTRAS="$EXTRAS check_fping\$(EXEEXT)"
-	if test x"$with_ipv6" != xno && test -n "$PATH_TO_FPING6"; then
-		AC_DEFINE_UNQUOTED(PATH_TO_FPING6,"$PATH_TO_FPING6",[path to fping6])
-	fi
 else
 	AC_MSG_WARN([Get fping from http://www.fping.com in order to make check_fping plugin])
 fi

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -82,28 +82,8 @@ int main(int argc, char **argv) {
 	char *fping_prog = NULL;
 
 	/* First determine if the target is dualstack or ipv6 only. */
-#ifdef USE_IPV6
 	bool server_is_inet6_addr = is_inet6_addr(server);
-#else
-	bool server_is_inet6_addr = false;
-#endif
 
-	/* PATH_TO_FPING6 implies USE_IPV6 */
-#ifdef PATH_TO_FPING6
-	/*
-	 * If the user requested -6 OR the user made no assertion and the address is v6 or dualstack
-	 *   -> we use ipv6
-	 * If the user requested -4 OR the user made no assertion and the address is v4 ONLY
-	 *   -> we use ipv4
-	 */
-	if (address_family == AF_INET6 || (address_family == AF_UNSPEC && server_is_inet6_addr)) {
-		fping_prog = strdup(PATH_TO_FPING6);
-	} else {
-		xasprintf(&option_string, "%s-4 ", option_string);
-		fping_prog = strdup(PATH_TO_FPING);
-	}
-#else
-#ifdef USE_IPV6
 	/*
 	 * If the user requested -6 OR the user made no assertion and the address is v6 or dualstack
 	 *   -> we use ipv6
@@ -115,25 +95,7 @@ int main(int argc, char **argv) {
 	} else {
 		xasprintf(&option_string, "%s-4 ", option_string);
 	}
-#else
-	/*
-	 * If the user requested -6
-	 *   -> warn that v6 is not available
-	 * -> we use ipv4
-	 */
-	if (address_family == AF_INET6) {
-		usage4(_("IPv6 support not available"));
-	}
-	/*
-	 * Note here we still have to call with -4, else in the case of a dual stacked target
-	 * we could potentially silently use ipv6 despite having just warned that it is not available
-	 */
-	xasprintf(&option_string, "%s-4 ", option_string);
-	/* end USE_IPV6 */
-#endif
 	fping_prog = strdup(PATH_TO_FPING);
-	/* end PATH_TO_FPING6 */
-#endif
 
 	/* compose the command */
 	if (config.target_timeout) {
@@ -385,11 +347,7 @@ check_fping_config_wrapper process_arguments(int argc, char **argv) {
 			address_family = AF_INET;
 			break;
 		case '6': /* IPv6 only */
-#ifdef USE_IPV6
 			address_family = AF_INET6;
-#else
-			usage(_("IPv6 support not available\n"));
-#endif
 			break;
 		case 'c':
 			get_threshold(optarg, rv);

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -83,14 +83,14 @@ int main(int argc, char **argv) {
 
 	/* compose the command */
 #ifdef PATH_TO_FPING6
-	if (address_family != AF_INET && is_inet6_addr(server)) {
+	if (address_family == AF_INET6 || (address_family == AF_UNSPEC && is_inet6_addr(server))) {
 		fping_prog = strdup(PATH_TO_FPING6);
 	} else {
 		xasprintf(&option_string, "%s-4 ", option_string);
 		fping_prog = strdup(PATH_TO_FPING);
 	}
 #else
-	if (address_family != AF_INET) {
+	if (address_family == AF_INET6 || (address_family == AF_UNSPEC && is_inet6_addr(server))) {
 		// -4 / -6 must be set explicitly as when a host has dual stack
 		// if we don't specify -4 then fping selects ipv6 which can mess
 		// with some checks.


### PR DESCRIPTION

    If fping is used with a target that has dual stack v4/v6, then due to
    the logic during command construction, ipv4 will never be checked as v6
    is preferred by fping.

    This explicitly flags -4/-6 when it is requested by the user.