### PR TITLE
check_http: Adding deprecation text

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1724,6 +1724,14 @@ print_help (void)
   printf ("%s\n", _("strings and regular expressions, check connection times, and report on"));
   printf ("%s\n", _("certificate expiration times."));
 
+  printf ("\n");
+  printf ("%s\n", _("ATTENTION!"));
+  printf ("\n");
+  printf ("%s\n", _("This plugin is going to be deprecated. The functionality was reimplemented"));
+  printf ("%s\n", _("by the check_curl plugin, which can be used as a drop-in replacement. You"));
+  printf ("%s\n", _("should migrate your checks over to check_curl in advance, because check_http"));
+  printf ("%s\n", _("is going to be removed sooner than later."));
+
   printf ("\n\n");
 
   print_usage ();


### PR DESCRIPTION
As I think that #1806 will not happen soon, I think we should start informing users about deprecation of `check_http`.

I'm right now in the process of getting the Debian monitoring-plugins package bringing into shape for the upcoming Trixi release. This would be a great oportunity to patch check_http to bring our plans to the attention of the Debian users. Do you think this is the right way? Is there some better way or something to improve? I'd like to have a patch ready by the end of week 17 this year.

Thanks a lot, Jan.