### PR TITLE
Do not explicitely disable IPv6 in the CI

### DIFF
--- a/.github/workflows/test-next.yml
+++ b/.github/workflows/test-next.yml
@@ -38,7 +38,7 @@ jobs:
               ${{ matrix.distro }} \
               /bin/sh -c '${{ matrix.prepare }} && \
                 tools/setup && \
-                ./configure --enable-libtap  --with-ipv6=no && \
+                ./configure --enable-libtap && \
                 make && \
                 make test && \
                 make dist && \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
               ${{ matrix.distro }} \
               /bin/sh -c '${{ matrix.prepare }} && \
                 tools/setup && \
-                ./configure --enable-libtap  --with-ipv6=no && \
+                ./configure --enable-libtap && \
                 make && \
                 make test && \
                 make dist && \


### PR DESCRIPTION
Previously IPv6 functionality was explicitely disabled in the Github CI,
although it is not clear to me why that was the case,
since IPv6 was not used there but there is no good reason
to not compile the functionality at all.

This should fix some of the problems with #2115 