### PR TITLE
changed filename in cmd_file_read to const char * (check_apt warning)

### DIFF
--- a/lib/utils_cmd.c
+++ b/lib/utils_cmd.c
@@ -346,7 +346,7 @@ int cmd_run_array(char *const *argv, output *out, output *err, int flags) {
 	return _cmd_close(fd);
 }
 
-int cmd_file_read(char *filename, output *out, int flags) {
+int cmd_file_read(const char *filename, output *out, int flags) {
 	int fd;
 	if (out)
 		memset(out, 0, sizeof(output));

--- a/lib/utils_cmd.h
+++ b/lib/utils_cmd.h
@@ -20,7 +20,7 @@ typedef struct output output;
 /** prototypes **/
 int cmd_run(const char *, output *, output *, int);
 int cmd_run_array(char *const *, output *, output *, int);
-int cmd_file_read(char *, output *, int);
+int cmd_file_read(const char *, output *, int);
 
 /* only multi-threaded plugins need to bother with this */
 void cmd_init(void);


### PR DESCRIPTION
The warning I got on gcc 15.1.1 (Arch) was:

```
check_apt.c: In function ‘run_upgrade’:
check_apt.c:319:50: warning: passing argument 1 of ‘cmd_file_read’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  319 |                 result.errorcode = cmd_file_read(input_filename, &chld_out, 0);
      |                                                  ^~~~~~~~~~~~~~
In file included from runcmd.h:28,
                 from check_apt.c:38:
../lib/utils_cmd.h:23:19: note: expected ‘char *’ but argument is of type ‘const char *’
   23 | int cmd_file_read(char *, output *, int);
      |                   ^~~~~~
```

The man page of glibc states than `int open(const char *path, int oflag, ...);` is the
prottype. `cmd_file_read` uses open here `if ((fd = open(filename, O_RDONLY)) == -1) `