### PR TITLE
Check fping 5.3 options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1519,7 +1519,6 @@ then
 fi
 
 AC_PATH_PROG(PATH_TO_FPING,fping)
-AC_PATH_PROG(PATH_TO_FPING6,fping6)
 
 AC_ARG_WITH(fping_command,
             ACX_HELP_STRING([--with-fping-command=PATH],

--- a/configure.ac
+++ b/configure.ac
@@ -1523,10 +1523,44 @@ AC_PATH_PROG(PATH_TO_FPING,fping)
 AC_ARG_WITH(fping_command,
             ACX_HELP_STRING([--with-fping-command=PATH],
                             [Path to fping command]), PATH_TO_FPING=$withval)
-if test -n "$PATH_TO_FPING"
-then
+if test -n "$PATH_TO_FPING"; then
 	AC_DEFINE_UNQUOTED(PATH_TO_FPING,"$PATH_TO_FPING",[path to fping])
 	EXTRAS="$EXTRAS check_fping\$(EXEEXT)"
+
+	if test -z "$($PATH_TO_FPING --version)"  ; then
+		AC_MSG_NOTICE([failed to get version of fping])
+	else
+		FPING_MAJOR_VERSION="$($PATH_TO_FPING --version | sed 's/.*fping: Version //' | sed 's/\..*//')"
+		FPING_MINOR_VERSION="$($PATH_TO_FPING --version | sed 's/.*fping: Version //' | sed 's/.*\.//')"
+
+		if test $FPING_MAJOR_VERSION -eq 5 ; then
+			if test $FPING_MINOR_VERSION -ge 3 ; then
+				AC_DEFINE(FPING_VERSION_5_3_OR_HIGHER, "true", [fping is of version 5.3 or higher])
+				AC_MSG_NOTICE([fping is of version 5.3 or higher])
+				AC_DEFINE(FPING_VERSION_5_2_OR_HIGHER, "true", [fping is of version 5.2 or higher])
+				AC_MSG_NOTICE([fping is of version 5.2 or higher])
+			elif test $FPING_MINOR_VERSION -ge 2 ; then
+				AC_DEFINE(FPING_VERSION_5_2_OR_HIGHER, "true", [fping is of version 5.2 or higher])
+				AC_MSG_NOTICE([fping is of version 5.2 or higher])
+			else
+				AC_MSG_NOTICE([fping is of a version lower then 5.2])
+			fi
+
+		elif $FPING_MAJOR_VERSION > 5 ; then
+			AC_DEFINE(FPING_VERSION_5_2_OR_HIGHER, "true", [fping is of version 5.2 or higher])
+			AC_MSG_NOTICE([fping is of version 5.2 or higher])
+			AC_DEFINE(FPING_VERSION_5_3_OR_HIGHER, "true", [fping is of version 5.2 or higher])
+			AC_MSG_NOTICE([fping is of version 5.3 or higher])
+		fi
+
+		if test "`fping --version | sed 's/.*fping: Version //'`" =  "5.2" ; then
+			AC_DEFINE(FPING_VERSION, "5.2", [the version of fping available])
+			AC_MSG_NOTICE([fping version: 5.2])
+		elif test "`fping --version | sed 's/.*fping: Version //'`" =  "5.3"; then
+			AC_DEFINE(FPING_VERSION, "5.3", [the version of fping available])
+			AC_MSG_NOTICE([fping version: 5.3])
+		fi
+	fi
 else
 	AC_MSG_WARN([Get fping from http://www.fping.com in order to make check_fping plugin])
 fi

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -315,11 +315,15 @@ check_fping_config_wrapper process_arguments(int argc, char **argv) {
 									   {"use-ipv6", no_argument, 0, '6'},
 									   {"dontfrag", no_argument, 0, 'M'},
 									   {"random", no_argument, 0, 'R'},
-									   // only available with fping version >= 5.3
+#ifdef FPING_VERSION_5_2_OR_HIGHER
+									   // only available with fping version >= 5.2
 									   {"fwmark", required_argument, NULL, FWMARK_OPT},
+#	ifdef FPING_VERSION_5_3_OR_HIGHER
 									   // only available with fping version >= 5.3
 									   {"icmp-timestamp", no_argument, NULL, ICMP_TIMESTAMP_OPT},
 									   {"check-source", no_argument, NULL, CHECK_SOURCE_OPT},
+#	endif
+#endif
 									   {0, 0, 0, 0}};
 
 	char *rv[2];

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -320,7 +320,6 @@ check_fping_config_wrapper process_arguments(int argc, char **argv) {
 									   // only available with fping version >= 5.3
 									   {"icmp-timestamp", no_argument, NULL, ICMP_TIMESTAMP_OPT},
 									   {"check-source", no_argument, NULL, CHECK_SOURCE_OPT},
-
 									   {0, 0, 0, 0}};
 
 	char *rv[2];

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -132,7 +132,7 @@ int main(int argc, char **argv) {
 	char *command_line = NULL;
 
 	if (config.icmp_timestamp) {
-		// no paket size settable for ICMP timestamp
+		// no packet size settable for ICMP timestamp
 		xasprintf(&command_line, "%s %s -c %d %s", fping_prog, option_string, config.packet_count, server);
 	} else {
 		xasprintf(&command_line, "%s %s-b %d -c %d %s", fping_prog, option_string, config.packet_size, config.packet_count, server);
@@ -346,7 +346,7 @@ check_fping_config_wrapper process_arguments(int argc, char **argv) {
 		argc--;
 	}
 
-	while (1) {
+	while (true) {
 		int option_index = getopt_long(argc, argv, "+hVvaH:S:c:w:b:n:T:i:I:M:R:46", longopts, &option);
 
 		if (option_index == -1 || option_index == EOF || option_index == 1) {

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -117,8 +117,26 @@ int main(int argc, char **argv) {
 		xasprintf(&option_string, "%s-R ", option_string);
 	}
 
+	if (config.fwmark_set) {
+		xasprintf(&option_string, "%s--fwmark %u ", option_string, config.fwmark);
+	}
+
+	if (config.icmp_timestamp) {
+		xasprintf(&option_string, "%s--icmp-timestamp ", option_string);
+	}
+
+	if (config.check_source) {
+		xasprintf(&option_string, "%s--check-source ", option_string);
+	}
+
 	char *command_line = NULL;
-	xasprintf(&command_line, "%s %s-b %d -c %d %s", fping_prog, option_string, config.packet_size, config.packet_count, server);
+
+	if (config.icmp_timestamp) {
+		// no paket size settable for ICMP timestamp
+		xasprintf(&command_line, "%s %s -c %d %s", fping_prog, option_string, config.packet_count, server);
+	} else {
+		xasprintf(&command_line, "%s %s-b %d -c %d %s", fping_prog, option_string, config.packet_size, config.packet_count, server);
+	}
 
 	if (verbose) {
 		printf("%s\n", command_line);
@@ -275,13 +293,35 @@ mp_state_enum textscan(char *buf, const char *server_name, bool crta_p, double c
 
 /* process command-line arguments */
 check_fping_config_wrapper process_arguments(int argc, char **argv) {
-	static struct option longopts[] = {
-		{"hostname", required_argument, 0, 'H'}, {"sourceip", required_argument, 0, 'S'}, {"sourceif", required_argument, 0, 'I'},
-		{"critical", required_argument, 0, 'c'}, {"warning", required_argument, 0, 'w'},  {"alive", no_argument, 0, 'a'},
-		{"bytes", required_argument, 0, 'b'},    {"number", required_argument, 0, 'n'},   {"target-timeout", required_argument, 0, 'T'},
-		{"interval", required_argument, 0, 'i'}, {"verbose", no_argument, 0, 'v'},        {"version", no_argument, 0, 'V'},
-		{"help", no_argument, 0, 'h'},           {"use-ipv4", no_argument, 0, '4'},       {"use-ipv6", no_argument, 0, '6'},
-		{"dontfrag", no_argument, 0, 'M'},       {"random", no_argument, 0, 'R'},         {0, 0, 0, 0}};
+	enum {
+		FWMARK_OPT = CHAR_MAX + 1,
+		ICMP_TIMESTAMP_OPT,
+		CHECK_SOURCE_OPT,
+	};
+	static struct option longopts[] = {{"hostname", required_argument, 0, 'H'},
+									   {"sourceip", required_argument, 0, 'S'},
+									   {"sourceif", required_argument, 0, 'I'},
+									   {"critical", required_argument, 0, 'c'},
+									   {"warning", required_argument, 0, 'w'},
+									   {"alive", no_argument, 0, 'a'},
+									   {"bytes", required_argument, 0, 'b'},
+									   {"number", required_argument, 0, 'n'},
+									   {"target-timeout", required_argument, 0, 'T'},
+									   {"interval", required_argument, 0, 'i'},
+									   {"verbose", no_argument, 0, 'v'},
+									   {"version", no_argument, 0, 'V'},
+									   {"help", no_argument, 0, 'h'},
+									   {"use-ipv4", no_argument, 0, '4'},
+									   {"use-ipv6", no_argument, 0, '6'},
+									   {"dontfrag", no_argument, 0, 'M'},
+									   {"random", no_argument, 0, 'R'},
+									   // only available with fping version >= 5.3
+									   {"fwmark", required_argument, NULL, FWMARK_OPT},
+									   // only available with fping version >= 5.3
+									   {"icmp-timestamp", no_argument, NULL, ICMP_TIMESTAMP_OPT},
+									   {"check-source", no_argument, NULL, CHECK_SOURCE_OPT},
+
+									   {0, 0, 0, 0}};
 
 	char *rv[2];
 	rv[PL] = NULL;
@@ -409,6 +449,20 @@ check_fping_config_wrapper process_arguments(int argc, char **argv) {
 		case 'M':
 			result.config.dontfrag = true;
 			break;
+		case FWMARK_OPT:
+			if (is_intpos(optarg)) {
+				result.config.fwmark = (unsigned int)atol(optarg);
+				result.config.fwmark_set = true;
+			} else {
+				usage(_("fwmark must be a positive integer"));
+			}
+			break;
+		case ICMP_TIMESTAMP_OPT:
+			result.config.icmp_timestamp = true;
+			break;
+		case CHECK_SOURCE_OPT:
+			result.config.check_source = true;
+			break;
 		}
 	}
 
@@ -496,6 +550,16 @@ void print_help(void) {
 	printf("    %s\n", _("set the Don't Fragment flag"));
 	printf(" %s\n", "-R, --random");
 	printf("    %s\n", _("random packet data (to foil link data compression)"));
+#ifdef FPING_VERSION_5_2_OR_HIGHER
+	printf(" %s\n", "--fwmark=INTEGER");
+	printf("    %s\n", _("set the routing mark to INTEGER (fping option)"));
+#	ifdef FPING_VERSION_5_3_OR_HIGHER
+	printf(" %s\n", "--icmp-timestamp");
+	printf("    %s\n", _("use ICMP Timestamp instead of ICMP Echo (fping option)"));
+	printf(" %s\n", "--check-source");
+	printf("    %s\n", _("discard replies not from target address (fping option)"));
+#	endif
+#endif
 	printf(UT_VERBOSE);
 	printf("\n");
 	printf(" %s\n", _("THRESHOLD is <rta>,<pl>%% where <rta> is the round trip average travel time (ms)"));

--- a/plugins/check_fping.d/config.h
+++ b/plugins/check_fping.d/config.h
@@ -29,6 +29,21 @@ typedef struct {
 	bool cpl_p;
 	int wpl;
 	bool wpl_p;
+
+	// only available with fping version >= 5.2
+	// for a given uint _fwmark_ fping sets _fwmark_ as a firewall mark
+	// in the pakets
+	unsigned int fwmark;
+	bool fwmark_set;
+
+
+	// only available with fping version >= 5.3
+	// Setting icmp_timestamp tells fping to use ICMP Timestamp (ICMP type 13) instead
+	// of ICMP Echo
+	bool icmp_timestamp;
+
+	// Setting check_source lets fping  discard replies which are not from the target address
+	bool check_source;
 } check_fping_config;
 
 check_fping_config check_fping_config_init() {
@@ -53,6 +68,15 @@ check_fping_config check_fping_config_init() {
 		.cpl_p = false,
 		.wpl = 0,
 		.wpl_p = false,
+
+		// only available with fping version >= 5.2
+		.fwmark = 0,
+		.fwmark_set = false, // just to be deterministic
+
+		// only available with fping version >= 5.3
+		.icmp_timestamp = false,
+		.check_source = false,
+
 	};
 	return tmp;
 }

--- a/plugins/check_fping.d/config.h
+++ b/plugins/check_fping.d/config.h
@@ -32,7 +32,7 @@ typedef struct {
 
 	// only available with fping version >= 5.2
 	// for a given uint _fwmark_ fping sets _fwmark_ as a firewall mark
-	// in the pakets
+	// in the packets
 	unsigned int fwmark;
 	bool fwmark_set;
 


### PR DESCRIPTION
This PR adds some command line options to `check_fping` which mirror some options which were
added to `fping` with version 5.2 and 5.3.

closes #2126