### PR TITLE
check_by_ssh: Ignore output on stderr by default

### DIFF
--- a/plugins/check_by_ssh.d/config.h
+++ b/plugins/check_by_ssh.d/config.h
@@ -21,6 +21,7 @@ typedef struct {
 	command_construct cmd;
 
 	bool unknown_timeout;
+	bool unknown_on_stderr;
 	bool warn_on_stderr;
 	int skip_stdout;
 	int skip_stderr;
@@ -46,6 +47,7 @@ check_by_ssh_config check_by_ssh_config_init() {
 			},
 
 		.unknown_timeout = false,
+		.unknown_on_stderr = false,
 		.warn_on_stderr = false,
 		.skip_stderr = 0,
 		.skip_stdout = 0,


### PR DESCRIPTION
check_by_ssh no longer returns UNKNOWN if ssh(1) returns data on stderr. But it can be enforced again by the new "--unknown-on-stderr" option.

---

The default logic of check_by_ssh results in an UNKNOWN state if the ssh(1) process produces output on stderr. Using the "--skip-stderr=[n]" option allows ignoring a certain amount of lines or disabling this check altogether. Furthermore, passing the "--warn-on-stderr" option reduces the exit code to WARNING.

The "--help" output does not document this behavior, only states that "--warn-on-stderr" will result in the WARNING, but does not mention the UNKNOWN by default.

The man page of ssh(1) mentions that debug information is logged to stderr. This conflicts with the described logic, resulting in check_by_ssh to go UNKNOWN, unless additional options are set.

Starting with OpenSSH version 10.1, ssh(1) will report warnings to stderr if the opposite server does not support post-quantum cryptography, <https://www.openssh.com/pq.html>.

This change, slowly being rolled out throughout the next months/years, might result in mass-breakages of check_by_ssh.

By introducing a new "--unknown-on-stderr" option, enforcing the prior default logic of an UNKNOWN state for data on stderr, and ignoring output on stderr by default, check_by_ssh will continue to work. One might even argue that this change converges actual implementation and the documented behavior, as argued above.

---

$ ssh example '/usr/lib/nagios/plugins/check_dummy 0 demo' ** WARNING: connection is not using a post-quantum key exchange algorithm. ** This session may be vulnerable to "store now, decrypt later" attacks. ** The server may need to be upgraded. See https://openssh.com/pq.html OK: demo

$ echo $?
0

$ ./check_by_ssh -H example -C '/usr/lib/nagios/plugins/check_dummy 0 demo' OK: demo

$ echo $?
0

$ ./check_by_ssh -H example -C '/usr/lib/nagios/plugins/check_dummy 0 demo' --warn-on-stderr Remote command execution failed: ** WARNING: connection is not using a post-quantum key exchange algorithm.

$ echo $?
1

$ ./check_by_ssh -H example -C '/usr/lib/nagios/plugins/check_dummy 0 demo' --unknown-on-stderr Remote command execution failed: ** WARNING: connection is not using a post-quantum key exchange algorithm.

$ echo $?
3

---

Fixes #2147.