### PR TITLE
check_swap: Fix Build At Least For OpenBSD

### DIFF
--- a/plugins/check_swap.d/swap.c
+++ b/plugins/check_swap.d/swap.c
@@ -52,10 +52,10 @@ swap_result get_swap_data(swap_config config) {
 	}
 #	else // HAVE_SWAP
 #		ifdef CHECK_SWAP_SWAPCTL_SVR4
-	return getSwapFromSwapctl_SRV4();
+	return getSwapFromSwapctl_SRV4(config);
 #		else // CHECK_SWAP_SWAPCTL_SVR4
 #			ifdef CHECK_SWAP_SWAPCTL_BSD
-	return getSwapFromSwapctl_BSD();
+	return getSwapFromSwapctl_BSD(config);
 #			else // CHECK_SWAP_SWAPCTL_BSD
 #				error No way found to retrieve swap
 #			endif /* CHECK_SWAP_SWAPCTL_BSD */


### PR DESCRIPTION
Fix build of check_swap for both CHECK_SWAP_SWAPCTL_SVR4 and CHECK_SWAP_SWAPCTL_BSD build guards.

> $ make check_swap
>   CC       check_swap.d/swap.o
> check_swap.d/swap.c:58:32: error: too few arguments to function call, single argument 'config' was not specified
>    58 |         return getSwapFromSwapctl_BSD();
>       |                ~~~~~~~~~~~~~~~~~~~~~~ ^
> ././check_swap.d/check_swap.h:48:13: note: 'getSwapFromSwapctl_BSD' declared here
>    48 | swap_result getSwapFromSwapctl_BSD(swap_config config);
>       |             ^                      ~~~~~~~~~~~~~~~~~~
> 1 error generated.
> *** Error 1 in [...]/monitoring-plugins/plugins (Makefile:2869 'check_swap.d/swap.o': @echo "  CC   ...)