### PR TITLE
check_mysql: Assume MySQL server by default (in replica check)

### DIFF
--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -219,16 +219,13 @@ int main(int argc, char **argv) {
 					use_deprecated_slave_status = true;
 				}
 			}
-		} else if (strstr(server_version, "MySQL") != NULL) {
-			// Looks like MySQL
+		} else {
+			// Looks like MySQL or at least not like MariaDB
 			if (major_version < 8) {
 				use_deprecated_slave_status = true;
 			} else if (major_version == 10 && minor_version < 4) {
 				use_deprecated_slave_status = true;
 			}
-		} else {
-			printf("Not a known sever implementation: %s\n", server_version);
-			exit(STATE_UNKNOWN);
 		}
 
 		char *replica_query = NULL;


### PR DESCRIPTION
In the Debian Bug tracker (and then Github) a person pointed out, that a MySQL server does not respond with a hint that is indeed the MySQL software but only with the version string.
Which makes sense if one assumes to be the only implementation.

This commit changes the behaviour of the Replica check to assume that the counterpart is a MySQL server if there are no hints that it is a MariaDB server.

I was made aware of this in #2068 (set comments) (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1116027)