### PR TITLE
fixes check_users build on OpenBSD (without utmpx)

### DIFF
--- a/plugins/check_users.c
+++ b/plugins/check_users.c
@@ -51,8 +51,6 @@ const char *email = "devel@monitoring-plugins.org";
 #	define ERROR -1
 #elif HAVE_UTMPX_H
 #	include <utmpx.h>
-#else
-#	include "popen.h"
 #endif
 
 #ifdef HAVE_LIBSYSTEMD

--- a/plugins/check_users.d/users.c
+++ b/plugins/check_users.d/users.c
@@ -113,8 +113,8 @@ get_num_of_users_wrapper get_num_of_users_utmp() {
 #			ifndef HAVE_UTMPX_H
 //  Fall back option here for the others (probably still not on windows)
 
-#				include "../popen.h"
 #				include "../common.h"
+#				include "../popen.h"
 #				include "../utils.h"
 
 get_num_of_users_wrapper get_num_of_users_who_command() {


### PR DESCRIPTION
This fixes building check_users on OpenBSD (ref #2152)