### PR TITLE
check_snmp: remove useless headers

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -41,8 +41,6 @@ const char *email = "devel@monitoring-plugins.org";
 #include "../lib/output.h"
 #include "check_snmp.d/check_snmp_helpers.h"
 
-#include <bits/getopt_core.h>
-#include <bits/getopt_ext.h>
 #include <strings.h>
 #include <stdint.h>
 


### PR DESCRIPTION
fixes #2158 