### PR TITLE
plugins: move duplicate input validation to shared utility

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -105,8 +105,9 @@ noinst_PROGRAMS = @EXTRA_PLUGIN_TESTS@
 # These two lines support "make check", but we use "make test"
 check_PROGRAMS = @EXTRA_PLUGIN_TESTS@
 
-libnpcommon_a_SOURCES = utils.c netutils.c sslutils.c runcmd.c	\
-	popen.c utils.h netutils.h popen.h common.h runcmd.c runcmd.h
+libnpcommon_a_SOURCES = utils.c utils_validate.c netutils.c sslutils.c runcmd.c	\
+	popen.c utils.h utils_validate.h netutils.h popen.h \
+	common.h runcmd.c runcmd.h
 
 
 BASEOBJS = libnpcommon.a ../lib/libmonitoringplug.a ../gl/libgnu.a $(LIB_CRYPTO)

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -48,6 +48,7 @@ const char *email = "devel@monitoring-plugins.org";
 #include <assert.h>
 #include "common.h"
 #include "utils.h"
+#include "utils_validate.h"
 #include "./check_curl.d/check_curl_helpers.h"
 
 #ifndef LIBCURL_PROTOCOL_HTTP
@@ -1084,7 +1085,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 #ifndef LIBCURL_FEATURE_SSL
 			usage4(_("Invalid option - SSL is not available"));
 #endif
-			test_file(optarg);
+			validate_file_exists(optarg);
 			result.config.curl_config.client_cert = optarg;
 			enable_tls = true;
 			break;
@@ -1092,7 +1093,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 #ifndef LIBCURL_FEATURE_SSL
 			usage4(_("Invalid option - SSL is not available"));
 #endif
-			test_file(optarg);
+			validate_file_exists(optarg);
 			result.config.curl_config.client_privkey = optarg;
 			enable_tls = true;
 			break;
@@ -1100,7 +1101,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 #ifndef LIBCURL_FEATURE_SSL
 			usage4(_("Invalid option - SSL is not available"));
 #endif
-			test_file(optarg);
+			validate_file_exists(optarg);
 			result.config.curl_config.ca_cert = optarg;
 			enable_tls = true;
 			break;

--- a/plugins/check_curl.d/check_curl_helpers.c
+++ b/plugins/check_curl.d/check_curl_helpers.c
@@ -1151,14 +1151,6 @@ char *string_statuscode(int major, int minor) {
 	return buf;
 }
 
-/* check whether a file exists */
-void test_file(char *path) {
-	if (access(path, R_OK) == 0) {
-		return;
-	}
-	usage2(_("file does not exist or is not readable"), path);
-}
-
 mp_subcheck mp_net_ssl_check_certificate(X509 *certificate, int days_till_exp_warn,
 										 int days_till_exp_crit);
 

--- a/plugins/check_curl.d/check_curl_helpers.h
+++ b/plugins/check_curl.d/check_curl_helpers.h
@@ -118,7 +118,6 @@ void cleanup(check_curl_global_state global_state);
 bool expected_statuscode(const char *reply, const char *statuscodes);
 char *string_statuscode(int major, int minor);
 
-void test_file(char *path);
 mp_subcheck check_curl_certificate_checks(CURL *curl, X509 *cert, int warn_days_till_exp,
 										  int crit_days_till_exp);
 char *fmt_url(check_curl_working_state workingState);

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -41,6 +41,7 @@ const char *email = "devel@monitoring-plugins.org";
 #include "base64.h"
 #include "netutils.h"
 #include "utils.h"
+#include "utils_validate.h"
 #include <ctype.h>
 
 #define STICKY_NONE 0
@@ -181,14 +182,6 @@ int main(int argc, char **argv) {
 
 	result = check_http();
 	return result;
-}
-
-/* check whether a file exists */
-void test_file(char *path) {
-	if (access(path, R_OK) == 0) {
-		return;
-	}
-	usage2(_("file does not exist or is not readable"), path);
 }
 
 /*
@@ -354,13 +347,13 @@ bool process_arguments(int argc, char **argv) {
 #endif
 		case 'J': /* use client certificate */
 #ifdef HAVE_SSL
-			test_file(optarg);
+			validate_file_exists(optarg);
 			client_cert = optarg;
 			goto enable_ssl;
 #endif
 		case 'K': /* use client private key */
 #ifdef HAVE_SSL
-			test_file(optarg);
+			validate_file_exists(optarg);
 			client_privkey = optarg;
 			goto enable_ssl;
 #endif

--- a/plugins/utils_validate.c
+++ b/plugins/utils_validate.c
@@ -1,0 +1,36 @@
+/*****************************************************************************
+ *
+ * Library of useful input validation functions for plugins
+ *
+ * License: GPL
+ * Copyright (c) 2000 Karl DeBisschop (karl@debisschop.net)
+ * Copyright (c) 2002-2024 Monitoring Plugins Development Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *****************************************************************************/
+
+#include "common.h"
+#include "./utils_validate.h"
+#include "./utils.h"
+#include <unistd.h>
+
+/* check whether a file exists */
+void validate_file_exists(char *path) {
+	if (access(path, R_OK) == 0) {
+		return;
+	}
+	usage2(_("file does not exist or is not readable"), path);
+}

--- a/plugins/utils_validate.h
+++ b/plugins/utils_validate.h
@@ -1,0 +1,12 @@
+#ifndef NP_UTILS_VALIDATE_H
+#define NP_UTILS_VALIDATE_H
+/* Header file for Monitoring Plugins utils_validate.c */
+
+/* This file should be included in all plugins where user
+input needs to be validated */
+
+/* The purpose of this package is to provide reusable logic
+for the purpose of validating user input. */
+
+void validate_file_exists(char *path);
+#endif /* NP_UTILS_VALIDATE_H */


### PR DESCRIPTION
both check_curl and check_http have implemented the same validation function. this change relocates the implementation to a shared location to be used by both.