### PR TITLE
More renaming due to MySQL name chances

### DIFF
--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -282,17 +282,32 @@ int main(int argc, char **argv) {
 			num_fields = mysql_num_fields(res);
 			fields = mysql_fetch_fields(res);
 			for (int i = 0; i < num_fields; i++) {
-				if (strcmp(fields[i].name, "Slave_IO_Running") == 0) {
-					replica_io_field = i;
-					continue;
-				}
-				if (strcmp(fields[i].name, "Slave_SQL_Running") == 0) {
-					replica_sql_field = i;
-					continue;
-				}
-				if (strcmp(fields[i].name, "Seconds_Behind_Master") == 0) {
-					seconds_behind_field = i;
-					continue;
+				if (use_deprecated_slave_status) {
+					if (strcmp(fields[i].name, "Slave_IO_Running") == 0) {
+						replica_io_field = i;
+						continue;
+					}
+					if (strcmp(fields[i].name, "Slave_SQL_Running") == 0) {
+						replica_sql_field = i;
+						continue;
+					}
+					if (strcmp(fields[i].name, "Seconds_Behind_Master") == 0) {
+						seconds_behind_field = i;
+						continue;
+					}
+				} else {
+					if (strcmp(fields[i].name, "Replica_IO_Running") == 0) {
+						replica_io_field = i;
+						continue;
+					}
+					if (strcmp(fields[i].name, "Replica_SQL_Running") == 0) {
+						replica_sql_field = i;
+						continue;
+					}
+					if (strcmp(fields[i].name, "Seconds_Behind_Source") == 0) {
+						seconds_behind_field = i;
+						continue;
+					}
 				}
 			}
 


### PR DESCRIPTION
Due to MySQL changing several term in Version 8.0.22 the way to determine the status of replicas has changed.
To adapt to these changes in a517dc614e44650a7e9204c4202feec7a40fd37f check_mysql was modified to adapt to different versions. Some parts were missed though which results in failures to detect the replica status properly.

This parts should be contained in this commit.

Should also fix some of the problems discussed in #2068

Ping @waja therefore. these changes have to added to the maintenance branch