### PR TITLE
check_dig: add -E/--require-flags and -X/--forbid-flags

### DIFF
--- a/plugins/check_dig.d/config.h
+++ b/plugins/check_dig.d/config.h
@@ -19,6 +19,8 @@ typedef struct {
 
 	double warning_interval;
 	double critical_interval;
+	char *require_flags;
+	char *forbid_flags;
 } check_dig_config;
 
 check_dig_config check_dig_config_init() {
@@ -34,6 +36,8 @@ check_dig_config check_dig_config_init() {
 
 		.warning_interval = UNDEFINED,
 		.critical_interval = UNDEFINED,
+		.require_flags = NULL,
+		.forbid_flags = NULL,
 
 	};
 	return tmp;


### PR DESCRIPTION
Hello maintainers,

this PR adds two optional switches to validate DNS header flags from `dig` output:

* `-E, --require-flags=LIST` — flags that must be present (e.g. `aa,qr`)
* `-X, --forbid-flags=LIST` — flags that must not be present (e.g. `rd`)

Includes small helpers to parse the `flags:` line and CSV lists. Help/usage updated. No behavior change if the options are not used.

### Why

Operational/SecOps cases often need to assert `aa` on authoritative servers or ensure `rd` isn’t set. So I guess we need such a feature.

### Usage

```bash
# require aa and qr
check_dig -H <dns> -l <name> -E aa,qr

# forbid rd (e.g., with +norecurse it should be absent)
check_dig -H <dns> -l <name> -X rd -A "+norecurse"
```

### Testing

* Manually tested against internal authoritative servers with various `dig` options (`+norecurse`, time/retry).
* Two colleagues tested independently; no issues found.
* Note: presence of `rd` depends on your `+norecurse`/recursion settings, as expected.

### Review

I don’t write C here every day, so please take a close look, especially around memory handling (e.g., `realloc`/`strdup`). I’m happy to adjust style/i18n/helper placement, or switch to aggregated error messages for multiple flags if preferred.

Related / closes monitoring-plugins/monitoring-plugins#1097

Thanks!
Dennis