### PR TITLE
check_curl: accept non standard compliant status line

### DIFF
--- a/plugins/check_curl.d/check_curl_helpers.c
+++ b/plugins/check_curl.d/check_curl_helpers.c
@@ -817,6 +817,8 @@ int curlhelp_parse_statusline(const char *buf, curlhelp_statusline *status_line)
 		buf = start;
 	}
 
+	// Accept either LF or CRLF as end of line for the status line
+	// CRLF is the standard (RFC9112), but it is recommended to accept both
 	size_t length_of_first_line = strcspn(buf, "\r\n");
 	const char *first_line_end = &buf[length_of_first_line];
 	if (first_line_end == NULL) {


### PR DESCRIPTION
If the status line from a server ended with '\n' instead of '\r\n' (defined by RFC 9112), check_curl failed to parse it and exited with an alarm.
The RFC recommends to be lenient here and this change follows that suggestion.