### PR TITLE
check_curl: abort redir if location is not found

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -672,6 +672,11 @@ redir_wrapper redir(curlhelp_write_curlbuf *header_buf, const check_curl_config 
 
 	char *location = get_header_value(headers, nof_headers, "location");
 
+	if (location == NULL) {
+		// location header not found
+		die(STATE_UNKNOWN, "HTTP UNKNOWN - could not find \"location\" header\n");
+	}
+
 	if (verbose >= 2) {
 		printf(_("* Seen redirect location %s\n"), location);
 	}


### PR DESCRIPTION
This commit changes the behaviour of check_curl slightly. Previously when the redirection method was set to the old 'check_http' style redirection and there was no "location" header in the original answer 'check_curl' segfaulted.
Now, at least it dies properly with a message.

should "fix" #2167