### PR TITLE
Fix check_ntp_time without a socket

### DIFF
--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -348,7 +348,6 @@ static offset_request_wrapper offset_request(const char *host, const char *port,
 		is_socket = false;
 
 		/* fill in ai with the list of hosts resolved by the host name */
-		struct addrinfo *addresses = NULL;
 		int ga_result = getaddrinfo(host, port, &hints, &addresses);
 		if (ga_result != 0) {
 			die(STATE_UNKNOWN, "error getting address for %s: %s\n", host, gai_strerror(ga_result));


### PR DESCRIPTION
In the previous commit I unintentionally introduced an error through symbol shadowing.
This should fix check_ntp_time when the target address is a network address.