### PR TITLE
lib: properly separate perfdata from different sub subchecks

### DIFF
--- a/lib/output.c
+++ b/lib/output.c
@@ -42,7 +42,7 @@ static inline char *fmt_subcheck_perfdata(mp_subcheck check) {
 
 	while (subchecks != NULL) {
 		if (added > 0) {
-			added = asprintf(&result, "%s%s", result, fmt_subcheck_perfdata(subchecks->subcheck));
+			added = asprintf(&result, "%s %s", result, fmt_subcheck_perfdata(subchecks->subcheck));
 		} else {
 			// TODO free previous result here?
 			added = asprintf(&result, "%s", fmt_subcheck_perfdata(subchecks->subcheck));


### PR DESCRIPTION
Previously there was a space missing between perfdata from differen sub subchecks which irritated my monitoring system and caused it to interpet two data points as one.
This puts the space back in there.