### PR TITLE
check_http: Abort invalid SSL w/ error

### DIFF
--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1036,7 +1036,7 @@ int check_http(void) {
 			printf("SSL initialized\n");
 		}
 		if (result != STATE_OK) {
-			die(STATE_CRITICAL, NULL);
+			die(STATE_CRITICAL,  _("HTTP CRITICAL - SSL error\n"));
 		}
 		microsec_ssl = deltime(tv_temp);
 		elapsed_time_ssl = (double)microsec_ssl / 1.0e6;


### PR DESCRIPTION
If a SSL connection cannot be established, check_http bailed out with a die function call with a NULL fmt string. This adds a more meaningful message.

The motivation for this patch was to get everything from the OpenBSD ports upstream. It seems like in the old days, this would have resulted in a segfault.

https://codeberg.org/OpenBSD/ports/commit/b8a6b3cae57bbfd67e667dca583c621d45ab0d6f

However, even if "die" now checks for NULL, a human readable error is nice to have.

---

CC @sthen, who wrote this patch back then.