### PR TITLE
fix types for most curl_easy_setopt parameters

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -92,16 +92,16 @@ typedef struct {
 static check_curl_config_wrapper process_arguments(int /*argc*/, char ** /*argv*/);
 
 static mp_subcheck check_http(check_curl_config /*config*/, check_curl_working_state workingState,
-							  int redir_depth);
+							  long redir_depth);
 
 typedef struct {
-	int redir_depth;
+	long redir_depth;
 	check_curl_working_state working_state;
 	int error_code;
 	check_curl_global_state curl_state;
 } redir_wrapper;
 static redir_wrapper redir(curlhelp_write_curlbuf * /*header_buf*/, check_curl_config /*config*/,
-						   int redir_depth, check_curl_working_state working_state);
+						   long redir_depth, check_curl_working_state working_state);
 
 static void print_help(void);
 void print_usage(void);
@@ -198,7 +198,7 @@ CURLcode sslctxfun(CURL *curl, SSL_CTX *sslctx, void *parm) {
 #endif     /* HAVE_SSL */
 
 mp_subcheck check_http(const check_curl_config config, check_curl_working_state workingState,
-					   int redir_depth) {
+					   long redir_depth) {
 
 	// =======================
 	// Initialisation for curl
@@ -441,19 +441,19 @@ mp_subcheck check_http(const check_curl_config config, check_curl_working_state 
 						"CURLINFO_REDIRECT_COUNT");
 
 					if (verbose >= 2) {
-						printf(_("* curl LIBINFO_REDIRECT_COUNT is %d\n"), redir_depth);
+						printf(_("* curl LIBINFO_REDIRECT_COUNT is %ld\n"), redir_depth);
 					}
 
 					mp_subcheck sc_redir_depth = mp_subcheck_init();
 					if (redir_depth > config.max_depth) {
 						xasprintf(&sc_redir_depth.output,
-								  "maximum redirection depth %d exceeded in libcurl",
+								  "maximum redirection depth %ld exceeded in libcurl",
 								  config.max_depth);
 						sc_redir_depth = mp_set_subcheck_state(sc_redir_depth, STATE_CRITICAL);
 						mp_add_subcheck_to_subcheck(&sc_result, sc_redir_depth);
 						return sc_result;
 					}
-					xasprintf(&sc_redir_depth.output, "redirection depth %d (of a maximum %d)",
+					xasprintf(&sc_redir_depth.output, "redirection depth %ld (of a maximum %ld)",
 							  redir_depth, config.max_depth);
 					mp_add_subcheck_to_subcheck(&sc_result, sc_redir_depth);
 
@@ -653,7 +653,7 @@ char *uri_string(const UriTextRangeA range, char *buf, size_t buflen) {
 }
 
 redir_wrapper redir(curlhelp_write_curlbuf *header_buf, const check_curl_config config,
-					int redir_depth, check_curl_working_state working_state) {
+					long redir_depth, check_curl_working_state working_state) {
 	curlhelp_statusline status_line;
 	struct phr_header headers[255];
 	size_t msglen;
@@ -678,7 +678,7 @@ redir_wrapper redir(curlhelp_write_curlbuf *header_buf, const check_curl_config 
 	}
 
 	if (++redir_depth > config.max_depth) {
-		die(STATE_WARNING, _("HTTP WARNING - maximum redirection depth %d exceeded - %s\n"),
+		die(STATE_WARNING, _("HTTP WARNING - maximum redirection depth %ld exceeded - %s\n"),
 			config.max_depth, location);
 	}
 
@@ -1400,7 +1400,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 		}
 #endif /* LIBCURL_VERSION_NUM >= MAKE_LIBCURL_VERSION(7, 54, 0) */
 		if (verbose >= 2) {
-			printf(_("* Set SSL/TLS version to %d\n"), result.config.curl_config.ssl_version);
+			printf(_("* Set SSL/TLS version to %ld\n"), result.config.curl_config.ssl_version);
 		}
 		if (!specify_port) {
 			result.config.initial_config.serverPort = HTTPS_PORT;

--- a/plugins/check_curl.d/check_curl_helpers.c
+++ b/plugins/check_curl.d/check_curl_helpers.c
@@ -19,7 +19,7 @@ bool add_sslctx_verify_fun = false;
 check_curl_configure_curl_wrapper
 check_curl_configure_curl(const check_curl_static_curl_config config,
 						  check_curl_working_state working_state, bool check_cert,
-						  bool on_redirect_dependent, int follow_method, int max_depth) {
+						  bool on_redirect_dependent, int follow_method, long max_depth) {
 	check_curl_configure_curl_wrapper result = {
 		.errorcode = OK,
 		.curl_state =
@@ -57,7 +57,7 @@ check_curl_configure_curl(const check_curl_static_curl_config config,
 	result.curl_state.curl_easy_initialized = true;
 
 	if (verbose >= 1) {
-		handle_curl_option_return_code(curl_easy_setopt(result.curl_state.curl, CURLOPT_VERBOSE, 1),
+		handle_curl_option_return_code(curl_easy_setopt(result.curl_state.curl, CURLOPT_VERBOSE, 1L),
 									   "CURLOPT_VERBOSE");
 	}
 
@@ -214,10 +214,10 @@ check_curl_configure_curl(const check_curl_static_curl_config config,
 	if (working_state.http_method) {
 		if (!strcmp(working_state.http_method, "POST")) {
 			handle_curl_option_return_code(
-				curl_easy_setopt(result.curl_state.curl, CURLOPT_POST, 1), "CURLOPT_POST");
+				curl_easy_setopt(result.curl_state.curl, CURLOPT_POST, 1L), "CURLOPT_POST");
 		} else if (!strcmp(working_state.http_method, "PUT")) {
 			handle_curl_option_return_code(
-				curl_easy_setopt(result.curl_state.curl, CURLOPT_UPLOAD, 1), "CURLOPT_UPLOAD");
+				curl_easy_setopt(result.curl_state.curl, CURLOPT_UPLOAD, 1L), "CURLOPT_UPLOAD");
 		} else {
 			handle_curl_option_return_code(curl_easy_setopt(result.curl_state.curl,
 															CURLOPT_CUSTOMREQUEST,
@@ -300,10 +300,10 @@ check_curl_configure_curl(const check_curl_static_curl_config config,
 		/* per default if we have a CA verify both the peer and the
 		 * hostname in the certificate, can be switched off later */
 		handle_curl_option_return_code(
-			curl_easy_setopt(result.curl_state.curl, CURLOPT_SSL_VERIFYPEER, 1),
+			curl_easy_setopt(result.curl_state.curl, CURLOPT_SSL_VERIFYPEER, 1L),
 			"CURLOPT_SSL_VERIFYPEER");
 		handle_curl_option_return_code(
-			curl_easy_setopt(result.curl_state.curl, CURLOPT_SSL_VERIFYHOST, 2),
+			curl_easy_setopt(result.curl_state.curl, CURLOPT_SSL_VERIFYHOST, 2L),
 			"CURLOPT_SSL_VERIFYHOST");
 	} else {
 		/* backward-compatible behaviour, be tolerant in checks
@@ -311,10 +311,10 @@ check_curl_configure_curl(const check_curl_static_curl_config config,
 		 * to be less tolerant about ssl verfications
 		 */
 		handle_curl_option_return_code(
-			curl_easy_setopt(result.curl_state.curl, CURLOPT_SSL_VERIFYPEER, 0),
+			curl_easy_setopt(result.curl_state.curl, CURLOPT_SSL_VERIFYPEER, 0L),
 			"CURLOPT_SSL_VERIFYPEER");
 		handle_curl_option_return_code(
-			curl_easy_setopt(result.curl_state.curl, CURLOPT_SSL_VERIFYHOST, 0),
+			curl_easy_setopt(result.curl_state.curl, CURLOPT_SSL_VERIFYHOST, 0L),
 			"CURLOPT_SSL_VERIFYHOST");
 	}
 
@@ -438,7 +438,7 @@ check_curl_configure_curl(const check_curl_static_curl_config config,
 	if (on_redirect_dependent) {
 		if (follow_method == FOLLOW_LIBCURL) {
 			handle_curl_option_return_code(
-				curl_easy_setopt(result.curl_state.curl, CURLOPT_FOLLOWLOCATION, 1),
+				curl_easy_setopt(result.curl_state.curl, CURLOPT_FOLLOWLOCATION, 1L),
 				"CURLOPT_FOLLOWLOCATION");
 
 			/* default -1 is infinite, not good, could lead to zombie plugins!
@@ -474,7 +474,7 @@ check_curl_configure_curl(const check_curl_static_curl_config config,
 	}
 	/* no-body */
 	if (working_state.no_body) {
-		handle_curl_option_return_code(curl_easy_setopt(result.curl_state.curl, CURLOPT_NOBODY, 1),
+		handle_curl_option_return_code(curl_easy_setopt(result.curl_state.curl, CURLOPT_NOBODY, 1L),
 									   "CURLOPT_NOBODY");
 	}
 
@@ -796,15 +796,17 @@ mp_subcheck check_document_dates(const curlhelp_write_curlbuf *header_buf, const
 						  ((float)last_modified) / (60 * 60 * 24));
 				sc_document_dates = mp_set_subcheck_state(sc_document_dates, STATE_CRITICAL);
 			} else {
-				xasprintf(&sc_document_dates.output, _("Last modified %ld:%02ld:%02ld ago"),
-						  last_modified / (60 * 60), (last_modified / 60) % 60, last_modified % 60);
+				xasprintf(&sc_document_dates.output, _("Last modified %lld:%02d:%02d ago"),
+						  (long long)last_modified / (60 * 60), (int)(last_modified / 60) % 60,
+						  (int)last_modified % 60);
 				sc_document_dates = mp_set_subcheck_state(sc_document_dates, STATE_CRITICAL);
 			}
 		} else {
 			// TODO is this the OK case?
 			time_t last_modified = (srv_data - doc_data);
-			xasprintf(&sc_document_dates.output, _("Last modified %ld:%02ld:%02ld ago"),
-					  last_modified / (60 * 60), (last_modified / 60) % 60, last_modified % 60);
+			xasprintf(&sc_document_dates.output, _("Last modified %lld:%02d:%02d ago"),
+					  (long long)last_modified / (60 * 60), (int)(last_modified / 60) % 60,
+					  (int)last_modified % 60);
 			sc_document_dates = mp_set_subcheck_state(sc_document_dates, STATE_OK);
 		}
 	}

--- a/plugins/check_curl.d/check_curl_helpers.h
+++ b/plugins/check_curl.d/check_curl_helpers.h
@@ -80,7 +80,7 @@ check_curl_configure_curl_wrapper check_curl_configure_curl(check_curl_static_cu
 															check_curl_working_state working_state,
 															bool check_cert,
 															bool on_redirect_dependent,
-															int follow_method, int max_depth);
+															int follow_method, long max_depth);
 
 void handle_curl_option_return_code(CURLcode res, const char *option);
 

--- a/plugins/check_curl.d/config.h
+++ b/plugins/check_curl.d/config.h
@@ -57,10 +57,10 @@ typedef struct {
 	bool haproxy_protocol;
 	long socket_timeout;
 	sa_family_t sin_family;
-	int curl_http_version;
+	long curl_http_version;
 	char **http_opt_headers;
 	size_t http_opt_headers_count;
-	int ssl_version;
+	long ssl_version;
 	char *client_cert;
 	char *client_privkey;
 	char *ca_cert;
@@ -76,7 +76,7 @@ typedef struct {
 	check_curl_working_state initial_config;
 
 	check_curl_static_curl_config curl_config;
-	int max_depth;
+	long max_depth;
 	int followmethod;
 	int followsticky;
 


### PR DESCRIPTION
according to https://curl.se/libcurl/c/curl_easy_setopt.html, parameters are either a long, a function pointer, an object pointer or a curl_off_t, depending on what the option expects; curl 8.16 checks and warns about these.

(this fixes most of them, there's a remaining issue with CURLINFO_CERTINFO in check_curl_helpers.c that I'm not sure about)