### PR TITLE
use %lld for time_t and cast parameters

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -941,15 +941,15 @@ int main(int argc, char **argv) {
 
 	if (debug) {
 		if (max_completion_time > (timeout * 1000000)) {
-			printf("max_completion_time: %ld  timeout: %u\n", max_completion_time, timeout);
-			printf("Timeout must be at least %ld\n", (max_completion_time / 1000000) + 1);
+			printf("max_completion_time: %lld  timeout: %u\n", (long long)max_completion_time, timeout);
+			printf("Timeout must be at least %lld\n", (long long)(max_completion_time / 1000000) + 1);
 		}
 	}
 
 	if (debug) {
-		printf("crit = {%ld, %u%%}, warn = {%ld, %u%%}\n", config.crit.rta, config.crit.pl,
-			   config.warn.rta, config.warn.pl);
-		printf("target_interval: %ld\n", config.target_interval);
+		printf("crit = {%lld, %u%%}, warn = {%lld, %u%%}\n", (long long)config.crit.rta, config.crit.pl,
+			   (long long)config.warn.rta, config.warn.pl);
+		printf("target_interval: %lld\n", (long long)config.target_interval);
 		printf("icmp_pkt_size: %u  timeout: %u\n", config.icmp_data_size + ICMP_MINLEN, timeout);
 	}
 
@@ -1050,8 +1050,8 @@ static void run_checks(unsigned short icmp_pkt_size, time_t *target_interval,
 		time_t final_wait = max_completion_time - time_passed;
 
 		if (debug) {
-			printf("time_passed: %ld  final_wait: %ld  max_completion_time: %ld\n", time_passed,
-				   final_wait, max_completion_time);
+			printf("time_passed: %lld  final_wait: %lld  max_completion_time: %lld\n",
+				   (long long)time_passed, (long long)final_wait, (long long)max_completion_time);
 		}
 		if (time_passed > max_completion_time) {
 			if (debug) {
@@ -1063,7 +1063,7 @@ static void run_checks(unsigned short icmp_pkt_size, time_t *target_interval,
 		/* catch the packets that might come in within the timeframe, but
 		 * haven't yet */
 		if (debug) {
-			printf("Waiting for %ld micro-seconds (%0.3f msecs)\n", final_wait,
+			printf("Waiting for %lld micro-seconds (%0.3f msecs)\n", (long long)final_wait,
 				   (float)final_wait / 1000);
 		}
 		if (targets_alive(number_of_targets, program_state->targets_down) ||
@@ -1126,7 +1126,7 @@ static int wait_for_reply(check_icmp_socket_set sockset, const time_t time_inter
 						 &loop_time_interval, &packet_received_timestamp);
 		if (!recv_foo.received) {
 			if (debug > 1) {
-				printf("recvfrom_wto() timed out during a %ld usecs wait\n", per_pkt_wait);
+				printf("recvfrom_wto() timed out during a %lld usecs wait\n", (long long)per_pkt_wait);
 			}
 			continue; /* timeout for this one, so keep trying */
 		}

--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -263,8 +263,8 @@ int main(int argc, char **argv) {
 			*filesystem = get_path_stats(*filesystem, fsp, config.freespace_ignore_reserved);
 
 			if (verbose >= 3) {
-				printf("For %s, used_units=%lu free_units=%lu total_units=%lu "
-					   "fsp.fsu_blocksize=%lu\n",
+				printf("For %s, used_units=%llu free_units=%llu total_units=%llu "
+					   "fsp.fsu_blocksize=%ju\n",
 					   mount_entry->me_mountdir, filesystem->used_bytes, filesystem->free_bytes,
 					   filesystem->total_bytes, fsp.fsu_blocksize);
 			}

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -97,7 +97,7 @@ gen_state_string_type gen_state_string(check_snmp_state_entry *entries, size_t n
 	if (verbose > 1) {
 		printf("%s:\n", __FUNCTION__);
 		for (size_t i = 0; i < num_of_entries; i++) {
-			printf("Entry timestamp %lu: %s", entries[i].timestamp, ctime(&entries[i].timestamp));
+			printf("Entry timestamp %lld: %s", (long long)entries[i].timestamp, ctime(&entries[i].timestamp));
 			switch (entries[i].type) {
 			case ASN_GAUGE:
 				printf("Type GAUGE\n");
@@ -197,7 +197,7 @@ recover_state_data_type recover_state_data(char *state_string, idx_t state_strin
 			   (size_t)outlen / sizeof(check_snmp_state_entry), outlen);
 
 		for (size_t i = 0; i < (size_t)outlen / sizeof(check_snmp_state_entry); i++) {
-			printf("Entry timestamp %lu: %s", result.state[i].timestamp,
+			printf("Entry timestamp %lld: %s", (long long)result.state[i].timestamp,
 				   ctime(&result.state[i].timestamp));
 			switch (result.state[i].type) {
 			case ASN_GAUGE:
@@ -286,7 +286,7 @@ int main(int argc, char **argv) {
 	time(&current_time);
 
 	if (verbose > 2) {
-		printf("current time: %s (timestamp: %lu)\n", ctime(&current_time), current_time);
+		printf("current time: %s (timestamp: %lld)\n", ctime(&current_time), (long long)current_time);
 	}
 
 	snmp_responces response = do_snmp_query(config.snmp_params);

--- a/plugins/check_snmp.d/check_snmp_helpers.c
+++ b/plugins/check_snmp.d/check_snmp_helpers.c
@@ -668,7 +668,7 @@ void np_state_write_string(state_key stateKey, time_t timestamp, char *stringToS
 	fprintf(temp_file_pointer, "# NP State file\n");
 	fprintf(temp_file_pointer, "%d\n", NP_STATE_FORMAT_VERSION);
 	fprintf(temp_file_pointer, "%d\n", stateKey.data_version);
-	fprintf(temp_file_pointer, "%lu\n", current_time);
+	fprintf(temp_file_pointer, "%lld\n", (long long)current_time);
 	fprintf(temp_file_pointer, "%s\n", stringToStore);
 
 	fchmod(temp_file_desc, S_IRUSR | S_IWUSR | S_IRGRP);


### PR DESCRIPTION
some OS define time_t as 64-bit on all architectures including 32-bit ones; adjust format strings to allow for this