### PR TITLE
Make IPv6 unconditional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,30 +475,6 @@ AC_ARG_WITH([ipv6],
 	[AS_HELP_STRING([--with-ipv6], [support IPv6 @<:@default=check@:>@])],
 	[], [with_ipv6=check])
 
-dnl Check for AF_INET6 support - unistd.h required for Darwin
-if test "$with_ipv6" != "no"; then
-	AC_CACHE_CHECK([for IPv6 support], np_cv_sys_ipv6, [
-		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#ifdef HAVE_UNISTD_H
-			#include <unistd.h>
-			#endif
-			#include <netinet/in.h>
-			#include <sys/socket.h>]], [[struct sockaddr_in6 sin6;
-			void *p;
-
-			sin6.sin6_family = AF_INET6;
-			sin6.sin6_port = 587;
-			p = &sin6.sin6_addr;]])],[np_cv_sys_ipv6=yes],[np_cv_sys_ipv6=no])
-		])
-	if test "$np_cv_sys_ipv6" = "no" -a "$with_ipv6" != "check"; then
-		AC_MSG_FAILURE([--with-ipv6 was given, but test for IPv6 support failed])
-	fi
-	if test "$np_cv_sys_ipv6" = "yes"; then
-		AC_DEFINE(USE_IPV6,1,[Enable IPv6 support])
-	fi
-	with_ipv6="$np_cv_sys_ipv6"
-fi
-
-
 dnl Checks for Kerberos. Must come before openssl checks for Redhat EL 3
 AC_CHECK_HEADERS(krb5.h,FOUNDINCLUDE=yes,FOUNDINCLUDE=no)
 if test "$FOUNDINCLUDE" = "no"; then

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1248,7 +1248,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 			result.config.curl_config.sin_family = AF_INET;
 			break;
 		case '6':
-#if defined(USE_IPV6) && defined(LIBCURL_FEATURE_IPV6)
+#if defined(LIBCURL_FEATURE_IPV6)
 			result.config.curl_config.sin_family = AF_INET6;
 #else
 			usage4(_("IPv6 support not available"));

--- a/plugins/check_curl.d/check_curl_helpers.c
+++ b/plugins/check_curl.d/check_curl_helpers.c
@@ -488,7 +488,7 @@ check_curl_configure_curl(const check_curl_static_curl_config config,
 			curl_easy_setopt(result.curl_state.curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4),
 			"CURLOPT_IPRESOLVE(CURL_IPRESOLVE_V4)");
 	}
-#if defined(USE_IPV6) && defined(LIBCURL_FEATURE_IPV6)
+#if defined(LIBCURL_FEATURE_IPV6)
 	else if (config.sin_family == AF_INET6) {
 		handle_curl_option_return_code(
 			curl_easy_setopt(result.curl_state.curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6),

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -544,11 +544,7 @@ bool process_arguments(int argc, char **argv) {
 			address_family = AF_INET;
 			break;
 		case '6':
-#ifdef USE_IPV6
 			address_family = AF_INET6;
-#else
-			usage4(_("IPv6 support not available"));
-#endif
 			break;
 		case 'v': /* verbose */
 			verbose = true;

--- a/plugins/check_ldap.c
+++ b/plugins/check_ldap.c
@@ -462,11 +462,7 @@ check_ldap_config_wrapper process_arguments(int argc, char **argv) {
 			}
 			break;
 		case '6':
-#ifdef USE_IPV6
 			address_family = AF_INET6;
-#else
-			usage(_("IPv6 support not available\n"));
-#endif
 			break;
 		case output_format_index: {
 			parsed_output_format parser = mp_parse_output_format(optarg);

--- a/plugins/check_ntp_peer.c
+++ b/plugins/check_ntp_peer.c
@@ -640,11 +640,7 @@ check_ntp_peer_config_wrapper process_arguments(int argc, char **argv) {
 			address_family = AF_INET;
 			break;
 		case '6':
-#ifdef USE_IPV6
 			address_family = AF_INET6;
-#else
-			usage4(_("IPv6 support not available"));
-#endif
 			break;
 		case '?':
 			/* print short usage statement if args not parsable */

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -640,11 +640,7 @@ static check_ntp_time_config_wrapper process_arguments(int argc, char **argv) {
 			address_family = AF_INET;
 			break;
 		case '6':
-#ifdef USE_IPV6
 			address_family = AF_INET6;
-#else
-			usage4(_("IPv6 support not available"));
-#endif
 			break;
 		case '?':
 			/* print short usage statement if args not parsable */

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -246,11 +246,7 @@ check_ping_config_wrapper process_arguments(int argc, char **argv) {
 			address_family = AF_INET;
 			break;
 		case '6': /* IPv6 only */
-#ifdef USE_IPV6
 			address_family = AF_INET6;
-#else
-			usage(_("IPv6 support not available\n"));
-#endif
 			break;
 		case 'H': /* hostname */ {
 			char *ptr = optarg;

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -807,11 +807,7 @@ check_smtp_config_wrapper process_arguments(int argc, char **argv) {
 			address_family = AF_INET;
 			break;
 		case '6':
-#ifdef USE_IPV6
 			address_family = AF_INET6;
-#else
-			usage4(_("IPv6 support not available"));
-#endif
 			break;
 		case 'V': /* version */
 			print_revision(progname, NP_VERSION);

--- a/plugins/check_ssh.c
+++ b/plugins/check_ssh.c
@@ -161,11 +161,7 @@ process_arguments_wrapper process_arguments(int argc, char **argv) {
 			address_family = AF_INET;
 			break;
 		case '6':
-#ifdef USE_IPV6
 			address_family = AF_INET6;
-#else
-			usage4(_("IPv6 support not available"));
-#endif
 			break;
 		case 'r': /* remote version */
 			result.config.remote_version = optarg;

--- a/plugins/check_tcp.c
+++ b/plugins/check_tcp.c
@@ -571,11 +571,7 @@ static check_tcp_config_wrapper process_arguments(int argc, char **argv, check_t
 			address_family = AF_INET;
 			break;
 		case '6': // Apparently unused TODO
-#ifdef USE_IPV6
 			address_family = AF_INET6;
-#else
-			usage4(_("IPv6 support not available"));
-#endif
 			break;
 		case 'H': /* hostname */
 			config.host_specified = true;

--- a/plugins/netutils.c
+++ b/plugins/netutils.c
@@ -38,11 +38,7 @@ mp_state_enum socket_timeout_state = STATE_CRITICAL;
 mp_state_enum econn_refuse_state = STATE_CRITICAL;
 bool was_refused = false;
 
-#if USE_IPV6
 int address_family = AF_UNSPEC;
-#else
-int address_family = AF_INET;
-#endif
 
 /* handles socket timeouts */
 void socket_timeout_alarm_handler(int sig) {
@@ -348,7 +344,6 @@ void host_or_die(const char *str) {
 }
 
 bool is_addr(const char *address) {
-#ifdef USE_IPV6
 	if (address_family == AF_INET && is_inet_addr(address)) {
 		return true;
 	}
@@ -356,11 +351,6 @@ bool is_addr(const char *address) {
 	if (address_family == AF_INET6 && is_inet6_addr(address)) {
 		return true;
 	}
-#else
-	if (is_inet_addr(address)) {
-		return true;
-	}
-#endif
 
 	return false;
 }

--- a/plugins/netutils.h
+++ b/plugins/netutils.h
@@ -78,12 +78,8 @@ bool dns_lookup(const char *, struct sockaddr_storage *, int);
 void host_or_die(const char *str);
 #define resolve_host_or_addr(addr, family) dns_lookup(addr, NULL, family)
 #define is_inet_addr(addr)                 resolve_host_or_addr(addr, AF_INET)
-#ifdef USE_IPV6
 #	define is_inet6_addr(addr) resolve_host_or_addr(addr, AF_INET6)
 #	define is_hostname(addr)   resolve_host_or_addr(addr, address_family)
-#else
-#	define is_hostname(addr) resolve_host_or_addr(addr, AF_INET)
-#endif
 
 extern unsigned int socket_timeout;
 extern mp_state_enum socket_timeout_state;


### PR DESCRIPTION
This commits removes the detection of IPv6 availability. The IPv6 code in the plugins is used unconditionally now.

closes #2122