### PR TITLE
OpenBSD: pledge(2) some network-facing checks

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -120,6 +120,14 @@ mp_state_enum np_net_ssl_check_certificate(X509 *certificate, int days_till_exp_
 #endif /* defined(HAVE_SSL) && defined(USE_OPENSSL) */
 
 int main(int argc, char **argv) {
+#ifdef __OpenBSD__
+	/* - rpath is required to read --extra-opts, CA and/or client certs
+	 * - wpath is required to write --cookie-jar (possibly given up later)
+	 * - inet is required for sockets
+	 * - dns is required for name lookups */
+	pledge("stdio rpath wpath inet dns", NULL);
+#endif // __OpenBSD__
+
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
@@ -134,6 +142,15 @@ int main(int argc, char **argv) {
 	}
 
 	const check_curl_config config = tmp_config.config;
+
+#ifdef __OpenBSD__
+	if (!config.curl_config.cookie_jar_file) {
+		if (verbose >= 2) {
+			printf(_("* No \"--cookie-jar\" is used, giving up \"wpath\" pledge(2)\n"));
+		}
+		pledge("stdio rpath inet dns", NULL);
+	}
+#endif // __OpenBSD__
 
 	if (config.output_format_is_set) {
 		mp_set_format(config.output_format);

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -661,6 +661,14 @@ static check_ntp_time_config_wrapper process_arguments(int argc, char **argv) {
 }
 
 int main(int argc, char *argv[]) {
+#ifdef __OpenBSD__
+	/* - rpath is required to read --extra-opts (given up later)
+	 * - inet is required for sockets
+	 * - unix is required for Unix domain sockets
+	 * - dns is required for name lookups */
+	pledge("stdio rpath inet unix dns", NULL);
+#endif // __OpenBSD__
+
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
@@ -673,6 +681,10 @@ int main(int argc, char *argv[]) {
 	if (tmp_config.errorcode == ERROR) {
 		usage4(_("Could not parse arguments"));
 	}
+
+#ifdef __OpenBSD__
+	pledge("stdio inet unix dns", NULL);
+#endif // __OpenBSD__
 
 	const check_ntp_time_config config = tmp_config.config;
 

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -100,6 +100,14 @@ static int my_close(int /*socket_descriptor*/);
 static int verbose = 0;
 
 int main(int argc, char **argv) {
+#ifdef __OpenBSD__
+	/* - rpath is required to read --extra-opts (given up later)
+	 * - inet is required for sockets
+	 * - unix is required for Unix domain sockets
+	 * - dns is required for name lookups */
+	pledge("stdio rpath inet unix dns", NULL);
+#endif // __OpenBSD__
+
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
@@ -112,6 +120,10 @@ int main(int argc, char **argv) {
 	if (tmp_config.errorcode == ERROR) {
 		usage4(_("Could not parse arguments"));
 	}
+
+#ifdef __OpenBSD__
+	pledge("stdio inet unix dns", NULL);
+#endif // __OpenBSD__
 
 	const check_smtp_config config = tmp_config.config;
 

--- a/plugins/check_ssh.c
+++ b/plugins/check_ssh.c
@@ -61,6 +61,14 @@ static int ssh_connect(mp_check *overall, char *haddr, int hport, char *remote_v
 					   char *remote_protocol);
 
 int main(int argc, char **argv) {
+#ifdef __OpenBSD__
+	/* - rpath is required to read --extra-opts (given up later)
+	 * - inet is required for sockets
+	 * - unix is required for Unix domain sockets
+	 * - dns is required for name lookups */
+	pledge("stdio rpath inet unix dns", NULL);
+#endif // __OpenBSD__
+
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
@@ -73,6 +81,10 @@ int main(int argc, char **argv) {
 	if (tmp_config.errorcode == ERROR) {
 		usage4(_("Could not parse arguments"));
 	}
+
+#ifdef __OpenBSD__
+	pledge("stdio inet unix dns", NULL);
+#endif // __OpenBSD__
 
 	check_ssh_config config = tmp_config.config;
 

--- a/plugins/check_tcp.c
+++ b/plugins/check_tcp.c
@@ -89,6 +89,14 @@ const int DEFAULT_NNTPS_PORT = 563;
 const int DEFAULT_CLAMD_PORT = 3310;
 
 int main(int argc, char **argv) {
+#ifdef __OpenBSD__
+	/* - rpath is required to read --extra-opts (given up later)
+	 * - inet is required for sockets
+	 * - unix is required for Unix domain sockets
+	 * - dns is required for name lookups */
+	pledge("stdio rpath inet unix dns", NULL);
+#endif // __OpenBSD__
+
 	setlocale(LC_ALL, "");
 	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
@@ -215,6 +223,10 @@ int main(int argc, char **argv) {
 	if (paw.errorcode == ERROR) {
 		usage4(_("Could not parse arguments"));
 	}
+
+#ifdef __OpenBSD__
+	pledge("stdio inet unix dns", NULL);
+#endif // __OpenBSD__
 
 	config = paw.config;
 


### PR DESCRIPTION
OpenBSD's [`pledge(2)`](https://man.openbsd.org/pledge.2) system call allows the current process to self-restrict itself, being reduced to promised pledges. For example, unless a process says it wants to write to files, it is not allowed to do so any longer.

This change starts by calling `pledge(2)` in some network-facing checks, removing the more dangerous privileges, such as executing other files.

My initial motivation came from `check_icmp`, being installed as a setuid binary and (temporarily) running with root privileges. There, the `pledge(2)` calls result in `check_icmp` to only being allowed to interact with the network and to `setuid(2)` to the calling user later on.

Afterwards, I went through my most commonly used monitoring plugins directly interacting with the network. Thus, I continued with `pledge(2)`-ing `check_curl` - having a huge codebase and all -, `check_ntp_time`, `check_smtp`, `check_ssh`, and `check_tcp`.

For most of those, the changes were quite similar: start with network-friendly promises, parse the configuration, give up file access, and proceed with the actual check.

---

While this change might only address a niche, I would argue it might help a lot by only a few lines in case of disaster. But I am open for other opinions.