### PR TITLE
check_icmp: Populate progname before np_extra_opts call

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -277,15 +277,6 @@ typedef struct {
 	check_icmp_config config;
 } check_icmp_config_wrapper;
 check_icmp_config_wrapper process_arguments(int argc, char **argv) {
-	/* get calling name the old-fashioned way for portability instead
-	 * of relying on the glibc-ism __progname */
-	char *ptr = strrchr(argv[0], '/');
-	if (ptr) {
-		progname = &ptr[1];
-	} else {
-		progname = argv[0];
-	}
-
 	check_icmp_config_wrapper result = {
 		.errorcode = OK,
 		.config = check_icmp_config_init(),
@@ -827,6 +818,14 @@ int main(int argc, char **argv) {
 
 	/* POSIXLY_CORRECT might break things, so unset it (the portable way) */
 	environ = NULL;
+
+	/* determine program- and service-name quickly */
+	progname = strrchr(argv[0], '/');
+	if (progname != NULL) {
+		progname++;
+	} else {
+		progname = argv[0];
+	}
 
 	/* Parse extra opts if any */
 	argv = np_extra_opts(&argc, argv, progname);


### PR DESCRIPTION
Within `np_extra_opts`, the ini parser expects a valid `progname` as the default section to select a configuration section in the ini file. However, within the `check_icmp` codebase, the `progname` is being populated directly after the `np_extra_opts` call, being a null pointer before.

```
$ ./check_icmp --extra-opts=@foo.ini
Segmentation fault (core dumped)
```

```
#0  strlen () at /usr/src/lib/libc/arch/amd64/string/strlen.S:125
#1  0x000003989615d032 in _libc_strdup (str=Variable "str" is not available.) at /usr/src/lib/libc/string/strdup.c:44
#2  0x000003966f751b74 in np_get_defaults (locator=0x73ede1e538ea "@foo.ini", default_section=0x0) at parse_ini.c:91
#3  0x000003966f7518ce in np_extra_opts (argc=0x73ede1e5369c, argv=0x73ede1e53728, plugin_name=0x0) at extra_opts.c:98
#4  0x000003966f74165a in main (argc=1, argv=0x0) at check_icmp.c:832
```

The `progname` variable is set within the process_arguments function, requiring the already enriched arguments from `np_extra_opts`. Thus, I moved the `progname` detection out of this function, directly before the `np_extra_opts` call. This pattern does already exists in `check_tcp`.

I briefly looked for similar issues in other plugins, but found none.