### PR TITLE
Make replacing of mismatching single quotes work

### DIFF
--- a/lib/perfdata.c
+++ b/lib/perfdata.c
@@ -39,7 +39,7 @@ char *pd_to_string(mp_perfdata pd) {
 	} else {
 		// we have a illegal single quote in the string
 		// replace it silently instead of complaining
-		for (char *ptr = pd.label; *ptr == '\0'; ptr++) {
+		for (char *ptr = pd.label; *ptr != '\0'; ptr++) {
 			if (*ptr == '\'') {
 				*ptr = '_';
 			}


### PR DESCRIPTION
Fixes a logic error in the string handling that led to dead code before.