### PR TITLE
Fix check_procs -T option

### DIFF
--- a/plugins/check_procs.c
+++ b/plugins/check_procs.c
@@ -430,7 +430,7 @@ check_procs_config_wrapper process_arguments(int argc, char **argv) {
 	while (true) {
 		int option = 0;
 		int option_index =
-			getopt_long(argc, argv, "Vvhkt:c:w:p:s:u:C:a:z:r:m:P:T:X:", longopts, &option);
+			getopt_long(argc, argv, "Vvhkt:c:w:p:s:u:C:a:z:r:m:P:TX:", longopts, &option);
 
 		if (option_index == -1 || option_index == EOF) {
 			break;


### PR DESCRIPTION
Previous PR #1856 introduced an issue where -T is now expecting an argument.

This change fixes the issue.