### PR TITLE
check_curl: check certificates and exit before checking for curl_easy_perform result

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -247,13 +247,8 @@ mp_subcheck check_http(const check_curl_config config, check_curl_working_state 
 		printf("**** REQUEST CONTENT ****\n%s\n", workingState.http_post_data);
 	}
 
-	/* If SSL cert checking is enabled, check the certs before checking for curl errors.
-	 * curl_state is updated after curl_easy_perform, and a cert check can be done at this point
-	 * check_http tries to check certs as early as possible, and returns afterwards unless
-	 * continue_after_check_cert is enabled. there may be servers with valid certificates
-	 * that return erroneous responses, but check_http returns OK since it only concerned with
-	 * certificates. Behave similarly here and check CURLcode after certificates.
-	 */
+	 // curl_state is updated after curl_easy_perform, and with updated curl_state certificate checks can be done
+	 // Check_http tries to check certs as early as possible, and exits with certificate check result by default. Behave similarly.
 #ifdef LIBCURL_FEATURE_SSL
 	if (workingState.use_ssl && config.check_cert) {
 		if (verbose > 1) {


### PR DESCRIPTION
Continuing from #2209

If SSL cert checking is enabled, check the certs before checking for curl_easy_perform errors. This makes it work similarly to check_http, and makes more sense with the optional use argument continue_after_check_cert.

The problematic code is right after performing the [request](https://github.com/monitoring-plugins/monitoring-plugins/blob/b9cd60ec3a2eaa8155286c6b2ee131030f7feec7/plugins/check_curl.c#L240)

```c
	// ==============
	// do the request
	// ==============
	CURLcode res = curl_easy_perform(curl_state.curl);

	if (verbose >= 2 && workingState.http_post_data) {
		printf("**** REQUEST CONTENT ****\n%s\n", workingState.http_post_data);
	}

	mp_subcheck sc_curl = mp_subcheck_init();

	/* Curl errors, result in critical Nagios state */
	if (res != CURLE_OK) {
		xasprintf(&sc_curl.output, _("Error while performing connection: cURL returned %d - %s"),
				  res, errbuf[0] ? errbuf : curl_easy_strerror(res));
		sc_curl = mp_set_subcheck_state(sc_curl, STATE_CRITICAL);
		mp_add_subcheck_to_subcheck(&sc_result, sc_curl);
		return sc_result;
	}

	/* get status line of answer, check sanity of HTTP code */
	if (curlhelp_parse_statusline(curl_state.header_buf->buf, curl_state.status_line) < 0) {
		sc_result = mp_set_subcheck_state(sc_result, STATE_CRITICAL);
		/* we cannot know the major/minor version here for sure as we cannot parse the first
		 * line */
		xasprintf(&sc_result.output, "HTTP/x.x unknown - Unparsable status line");
		return sc_result;
	}

	curl_state.status_line_initialized = true;

	size_t page_len = get_content_length(curl_state.header_buf, curl_state.body_buf);

	double total_time;
	handle_curl_option_return_code(
		curl_easy_getinfo(curl_state.curl, CURLINFO_TOTAL_TIME, &total_time),
		"CURLINFO_TOTAL_TIME");

	xasprintf(
		&sc_curl.output, "%s %d %s - %ld bytes in %.3f second response time",
		string_statuscode(curl_state.status_line->http_major, curl_state.status_line->http_minor),
		curl_state.status_line->http_code, curl_state.status_line->msg, page_len, total_time);
	sc_curl = mp_set_subcheck_state(sc_curl, STATE_OK);
	mp_add_subcheck_to_subcheck(&sc_result, sc_curl);

	// ==========
	// Evaluation
	// ==========

#ifdef LIBCURL_FEATURE_SSL
	if (workingState.use_ssl && config.check_cert) {
		mp_subcheck sc_certificate = check_curl_certificate_checks(
			curl_state.curl, cert, config.days_till_exp_warn, config.days_till_exp_crit);

		mp_add_subcheck_to_subcheck(&sc_result, sc_certificate);
		if (!config.continue_after_check_cert) {
			return sc_result;
		}
	}
#endif
```


- curl_state.curl is updated after curl_easy_perform, and with updated curl_state certificate checks can be done. 

- Check_http tries to check certs as early as possible, and exits with certificate check result, before checking if the response is valid. Invalid responses like an empty response is not important in a certificate check, since check_http quits with an exit code about validity of certificate before that.

- It only continues the rest of the check if continue_after_check_cert is enabled. This option is available in both check_http and check_curl. If users want to exit if certificate is invalid AND continue doing other checks if certificate is valid they can toggle this option.

Behave similarly for check_curl, as there are servers that present valid certificates, but that return erroneous codes e.g ```res != CURLE_OK``` according to libcurl. There are other servers that cut the connection, but after the certificate handshake is being done etc.

In the big fleet test between check_curl and check_http, this was the main cause for >95% return code differences.

The code changes are simple, it just moves the certificate check block upwards and places it before the ```res != CURLE_OK``` and prints out some messages in verbose mode.

