### PR TITLE
Rename USE_OPENSSL to MOPL_USE_OPENSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -578,7 +578,7 @@ if test "$FOUNDOPENSSL" = "yes" || test "$FOUNDGNUTLS" = "yes"; then
 	AC_SUBST(SSLLIBS)
 	AC_DEFINE(HAVE_SSL,1,[Define if SSL libraries are found])
 	if test "$FOUNDOPENSSL" = "yes"; then
-		AC_DEFINE(USE_OPENSSL,1,[Define if using OpenSSL libraries])
+		AC_DEFINE(MOPL_USE_OPENSSL,1,[Define if using OpenSSL libraries])
 		with_openssl="yes"
 		with_gnutls="no"
 	else

--- a/lib/utils_base.h
+++ b/lib/utils_base.h
@@ -9,7 +9,7 @@
 #include "./thresholds.h"
 #include "states.h"
 
-#ifndef USE_OPENSSL
+#ifndef MOPL_USE_OPENSSL
 #	include "sha256.h"
 #endif
 

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -62,7 +62,7 @@ const char *email = "devel@monitoring-plugins.org";
 #include <arpa/inet.h>
 #include <netinet/in.h>
 
-#if defined(HAVE_SSL) && defined(USE_OPENSSL)
+#if defined(HAVE_SSL) && defined(MOPL_USE_OPENSSL)
 #	include <openssl/opensslv.h>
 #endif
 
@@ -81,9 +81,9 @@ extern char errbuf[MAX_INPUT_BUFFER];
 extern bool is_openssl_callback;
 extern bool add_sslctx_verify_fun;
 
-#if defined(HAVE_SSL) && defined(USE_OPENSSL)
+#if defined(HAVE_SSL) && defined(MOPL_USE_OPENSSL)
 static X509 *cert = NULL;
-#endif /* defined(HAVE_SSL) && defined(USE_OPENSSL) */
+#endif /* defined(HAVE_SSL) && defined(MOPL_USE_OPENSSL) */
 
 typedef struct {
 	int errorcode;
@@ -114,10 +114,10 @@ static void print_curl_version(void);
 // check_curl_evaluation_wrapper check_curl_evaluate(check_curl_config config,
 // 												  mp_check overall[static 1]) {}
 
-#if defined(HAVE_SSL) && defined(USE_OPENSSL)
+#if defined(HAVE_SSL) && defined(MOPL_USE_OPENSSL)
 mp_state_enum np_net_ssl_check_certificate(X509 *certificate, int days_till_exp_warn,
 										   int days_till_exp_crit);
-#endif /* defined(HAVE_SSL) && defined(USE_OPENSSL) */
+#endif /* defined(HAVE_SSL) && defined(MOPL_USE_OPENSSL) */
 
 int main(int argc, char **argv) {
 #ifdef __OpenBSD__
@@ -167,7 +167,7 @@ int main(int argc, char **argv) {
 }
 
 #ifdef HAVE_SSL
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 int verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx) {
 	(void)preverify_ok;
 	/* TODO: we get all certificates of the chain, so which ones
@@ -190,11 +190,11 @@ int verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx) {
 	}
 	return 1;
 }
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 #endif     /* HAVE_SSL */
 
 #ifdef HAVE_SSL
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 CURLcode sslctxfun(CURL *curl, SSL_CTX *sslctx, void *parm) {
 	(void)curl; // ignore unused parameter
 	(void)parm; // ignore unused parameter
@@ -211,7 +211,7 @@ CURLcode sslctxfun(CURL *curl, SSL_CTX *sslctx, void *parm) {
 
 	return CURLE_OK;
 }
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 #endif     /* HAVE_SSL */
 
 mp_subcheck check_http(const check_curl_config config, check_curl_working_state workingState,
@@ -1867,7 +1867,7 @@ void print_usage(void) {
 void print_curl_version(void) { printf("%s\n", curl_version()); }
 
 #ifdef LIBCURL_FEATURE_SSL
-#	ifndef USE_OPENSSL
+#	ifndef MOPL_USE_OPENSSL
 time_t parse_cert_date(const char *s) {
 	if (!s) {
 		return -1;
@@ -1884,11 +1884,11 @@ time_t parse_cert_date(const char *s) {
 
 	return date;
 }
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 #endif     /* LIBCURL_FEATURE_SSL */
 
 #ifdef LIBCURL_FEATURE_SSL
-#	ifndef USE_OPENSSL
+#	ifndef MOPL_USE_OPENSSL
 /* TODO: this needs cleanup in the sslutils.c, maybe we the #else case to
  * OpenSSL could be this function
  */
@@ -2025,5 +2025,5 @@ int net_noopenssl_check_certificate(cert_ptr_union *cert_ptr, int days_till_exp_
 	}
 	return status;
 }
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 #endif     /* LIBCURL_FEATURE_SSL */

--- a/plugins/check_curl.d/check_curl_helpers.c
+++ b/plugins/check_curl.d/check_curl_helpers.c
@@ -439,11 +439,11 @@ check_curl_configure_curl(const check_curl_static_curl_config config,
 		case CURLHELP_SSL_LIBRARY_LIBRESSL:
 			/* set callback to extract certificate with OpenSSL context function (works with
 			 * OpenSSL-style libraries only!) */
-#		ifdef USE_OPENSSL
+#		ifdef MOPL_USE_OPENSSL
 			/* libcurl and monitoring plugins built with OpenSSL, good */
 			add_sslctx_verify_fun = true;
 			is_openssl_callback = true;
-#		endif /* USE_OPENSSL */
+#		endif /* MOPL_USE_OPENSSL */
 			/* libcurl is built with OpenSSL, monitoring plugins, so falling
 			 * back to manually extracting certificate information */
 			handle_curl_option_return_code(
@@ -1312,16 +1312,16 @@ mp_subcheck check_curl_certificate_checks(CURL *curl, X509 *cert, int warn_days_
 
 #ifdef LIBCURL_FEATURE_SSL
 	if (is_openssl_callback) {
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 		/* check certificate with OpenSSL functions, curl has been built against OpenSSL
 		 * and we actually have OpenSSL in the monitoring tools
 		 */
 		return mp_net_ssl_check_certificate(cert, warn_days_till_exp, crit_days_till_exp);
-#	else  /* USE_OPENSSL */
+#	else  /* MOPL_USE_OPENSSL */
 		xasprintf(&result.output, "HTTP CRITICAL - Cannot retrieve certificates - OpenSSL "
 								  "callback used and not linked against OpenSSL\n");
 		mp_set_subcheck_state(result, STATE_CRITICAL);
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 	} else {
 		struct curl_slist *slist;
 
@@ -1329,7 +1329,7 @@ mp_subcheck check_curl_certificate_checks(CURL *curl, X509 *cert, int warn_days_
 		cert_ptr.to_info = NULL;
 		CURLcode res = curl_easy_getinfo(curl, CURLINFO_CERTINFO, &cert_ptr.to_certinfo);
 		if (!res && cert_ptr.to_info) {
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 			/* We have no OpenSSL in libcurl, but we can use OpenSSL for X509 cert
 			 * parsing We only check the first certificate and assume it's the one of
 			 * the server
@@ -1375,13 +1375,13 @@ mp_subcheck check_curl_certificate_checks(CURL *curl, X509 *cert, int warn_days_
 
 			BIO_free(cert_BIO);
 			return mp_net_ssl_check_certificate(cert, warn_days_till_exp, crit_days_till_exp);
-#	else  /* USE_OPENSSL */
+#	else  /* MOPL_USE_OPENSSL */
 			/* We assume we don't have OpenSSL and np_net_ssl_check_certificate at our
 			 * disposal, so we use the libcurl CURLINFO data
 			 */
 			return net_noopenssl_check_certificate(&cert_ptr, days_till_exp_warn,
 												   days_till_exp_crit);
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 		} else {
 			xasprintf(&sc_cert_result.output,
 					  _("Cannot retrieve certificates - cURL returned %d - %s"), res,

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -350,7 +350,7 @@ int main(int argc, char **argv) {
 		}
 	}
 
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 	if (ssl_established) {
 		net_ssl_check_cert_result cert_check_result =
 			np_net_ssl_check_cert2(config.days_till_exp_warn, config.days_till_exp_crit);
@@ -389,7 +389,7 @@ int main(int argc, char **argv) {
 
 		mp_add_subcheck_to_check(&overall, sc_cert_check);
 	}
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 
 #endif
 
@@ -764,7 +764,7 @@ check_smtp_config_wrapper process_arguments(int argc, char **argv) {
 			break;
 		case 'D': {
 			/* Check SSL cert validity */
-#ifdef USE_OPENSSL
+#ifdef MOPL_USE_OPENSSL
 			char *temp;
 			if ((temp = strchr(optarg, ',')) != NULL) {
 				*temp = '\0';

--- a/plugins/check_tcp.c
+++ b/plugins/check_tcp.c
@@ -683,7 +683,7 @@ static check_tcp_config_wrapper process_arguments(int argc, char **argv, check_t
 			break;
 		case 'D': /* Check SSL cert validity - days 'til certificate expiration */
 #ifdef HAVE_SSL
-#	ifdef USE_OPENSSL /* XXX */
+#	ifdef MOPL_USE_OPENSSL /* XXX */
 		{
 			char *temp;
 			if ((temp = strchr(optarg, ',')) != NULL) {
@@ -708,7 +708,7 @@ static check_tcp_config_wrapper process_arguments(int argc, char **argv, check_t
 			config.check_cert = true;
 			config.use_tls = true;
 		} break;
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 #endif
 			/* fallthrough if we don't have ssl */
 		case 'S':

--- a/plugins/sslutils.c
+++ b/plugins/sslutils.c
@@ -127,7 +127,7 @@ int np_net_ssl_init_with_hostname_version_and_cert(int sd, char *host_name, int 
 	}
 
 	if (cert && privkey) {
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 		if (!SSL_CTX_use_certificate_chain_file(ctx, cert)) {
 #	elif USE_GNUTLS
 		if (!SSL_CTX_use_certificate_file(ctx, cert, SSL_FILETYPE_PEM)) {
@@ -138,7 +138,7 @@ int np_net_ssl_init_with_hostname_version_and_cert(int sd, char *host_name, int 
 			return STATE_CRITICAL;
 		}
 		SSL_CTX_use_PrivateKey_file(ctx, privkey, SSL_FILETYPE_PEM);
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 		if (!SSL_CTX_check_private_key(ctx)) {
 			printf("%s\n", _("CRITICAL - Private key does not seem to match certificate!\n"));
 			return STATE_CRITICAL;
@@ -161,9 +161,9 @@ int np_net_ssl_init_with_hostname_version_and_cert(int sd, char *host_name, int 
 			return OK;
 		} else {
 			printf("%s\n", _("CRITICAL - Cannot make SSL connection."));
-#	ifdef USE_OPENSSL /* XXX look into ERR_error_string */
+#	ifdef MOPL_USE_OPENSSL /* XXX look into ERR_error_string */
 			ERR_print_errors_fp(stdout);
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 		}
 	} else {
 		printf("%s\n", _("CRITICAL - Cannot initiate SSL handshake."));
@@ -192,7 +192,7 @@ int np_net_ssl_read(void *buf, int num) { return SSL_read(s, buf, num); }
 
 mp_state_enum np_net_ssl_check_certificate(X509 *certificate, int days_till_exp_warn,
 										   int days_till_exp_crit) {
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 	if (!certificate) {
 		printf("%s\n", _("CRITICAL - No server certificate present to inspect."));
 		return STATE_CRITICAL;
@@ -306,14 +306,14 @@ mp_state_enum np_net_ssl_check_certificate(X509 *certificate, int days_till_exp_
 	}
 	X509_free(certificate);
 	return status;
-#	else  /* ifndef USE_OPENSSL */
+#	else  /* ifndef MOPL_USE_OPENSSL */
 	printf("%s\n", _("WARNING - Plugin does not support checking certificates."));
 	return STATE_WARNING;
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 }
 
 retrieve_expiration_time_result np_net_ssl_get_cert_expiration(X509 *certificate) {
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 	retrieve_expiration_time_result result = {
 		.errors = ALL_OK,
 		.remaining_seconds = 0,
@@ -404,14 +404,14 @@ retrieve_expiration_time_result np_net_ssl_get_cert_expiration(X509 *certificate
 	X509_free(certificate);
 
 	return result;
-#	else  /* ifndef USE_OPENSSL */
+#	else  /* ifndef MOPL_USE_OPENSSL */
 	printf("%s\n", _("WARNING - Plugin does not support checking certificates."));
 	return STATE_WARNING;
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 }
 
 net_ssl_check_cert_result np_net_ssl_check_cert2(int days_till_exp_warn, int days_till_exp_crit) {
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 	X509 *certificate = NULL;
 	certificate = SSL_get_peer_certificate(s);
 
@@ -438,27 +438,27 @@ net_ssl_check_cert_result np_net_ssl_check_cert2(int days_till_exp_warn, int day
 
 	return result;
 
-#	else  /* ifndef USE_OPENSSL */
+#	else  /* ifndef MOPL_USE_OPENSSL */
 	printf("%s\n", _("WARNING - Plugin does not support checking certificates."));
 	return STATE_WARNING;
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 }
 
 mp_state_enum np_net_ssl_check_cert(int days_till_exp_warn, int days_till_exp_crit) {
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 	X509 *certificate = NULL;
 	certificate = SSL_get_peer_certificate(s);
 	return (np_net_ssl_check_certificate(certificate, days_till_exp_warn, days_till_exp_crit));
-#	else  /* ifndef USE_OPENSSL */
+#	else  /* ifndef MOPL_USE_OPENSSL */
 	printf("%s\n", _("WARNING - Plugin does not support checking certificates."));
 	return STATE_WARNING;
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 }
 
 mp_subcheck mp_net_ssl_check_certificate(X509 *certificate, int days_till_exp_warn,
 										 int days_till_exp_crit) {
 	mp_subcheck sc_cert = mp_subcheck_init();
-#	ifdef USE_OPENSSL
+#	ifdef MOPL_USE_OPENSSL
 	if (!certificate) {
 		xasprintf(&sc_cert.output, _("No server certificate present to inspect"));
 		sc_cert = mp_set_subcheck_state(sc_cert, STATE_CRITICAL);
@@ -581,10 +581,10 @@ mp_subcheck mp_net_ssl_check_certificate(X509 *certificate, int days_till_exp_wa
 	}
 	X509_free(certificate);
 	return sc_cert;
-#	else  /* ifndef USE_OPENSSL */
+#	else  /* ifndef MOPL_USE_OPENSSL */
 	xasprintf(&sc_cert.output, _("Plugin does not support checking certificates"));
 	sc_cert = mp_set_subcheck_state(sc_cert, STATE_WARNING);
 	return sc_cert;
-#	endif /* USE_OPENSSL */
+#	endif /* MOPL_USE_OPENSSL */
 }
 #endif /* HAVE_SSL */


### PR DESCRIPTION
net-snmp uses the same pre processor name "USE_OPENSSL" as we do. To avoid the conflict, this commit renames it on our side to "MOPL_USE_OPENSSL".
"MOPL" (better "MoPl"?) stands for Monitoring Plugins.

This is an alternative to the simple `undef` implementation in #2227 ( 3e656e64080ce3dbfadd7ea6533cd608cb3e1fda )