### PR TITLE
added CHECK_EOF to work around warnings about EOF and -1 being the same

### DIFF
--- a/plugins/check_cluster.c
+++ b/plugins/check_cluster.c
@@ -175,7 +175,7 @@ check_cluster_config_wrapper process_arguments(int argc, char **argv) {
 	while (true) {
 		int option_index = getopt_long(argc, argv, "hHsvVw:c:d:l:", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF || option_index == 1) {
+		if (CHECK_EOF(option_index) || option_index == 1) {
 			break;
 		}
 

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -980,7 +980,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 		int option_index = getopt_long(
 			argc, argv, "Vvh46t:c:w:A:k:H:P:j:T:I:a:x:b:d:e:p:s:R:r:u:f:C:J:K:DnlLS::m:M:NEB",
 			longopts, &option);
-		if (option_index == -1 || option_index == EOF || option_index == 1) {
+		if (CHECK_EOF(option_index) || option_index == 1) {
 			break;
 		}
 

--- a/plugins/check_dig.c
+++ b/plugins/check_dig.c
@@ -284,7 +284,7 @@ check_dig_config_wrapper process_arguments(int argc, char **argv) {
 		int option_index =
 			getopt_long(argc, argv, "hVvt:l:H:w:c:T:p:a:A:E:X:46", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF) {
+		if (CHECK_EOF(option_index)) {
 			break;
 		}
 

--- a/plugins/check_disk.c
+++ b/plugins/check_disk.c
@@ -448,7 +448,7 @@ check_disk_config_wrapper process_arguments(int argc, char **argv) {
 		int option_index = getopt_long(
 			argc, argv, "+?VqhvefCt:c:w:K:W:u:p:x:X:N:mklLPg:R:r:i:I:MEAn", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF) {
+		if (CHECK_EOF(option_index)) {
 			break;
 		}
 

--- a/plugins/check_fping.c
+++ b/plugins/check_fping.c
@@ -361,7 +361,7 @@ check_fping_config_wrapper process_arguments(int argc, char **argv) {
 		int option_index =
 			getopt_long(argc, argv, "+hVvaH:S:c:w:b:n:T:i:I:M:R:46", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF || option_index == 1) {
+		if (CHECK_EOF(option_index) || option_index == 1) {
 			break;
 		}
 

--- a/plugins/check_game.c
+++ b/plugins/check_game.c
@@ -186,7 +186,7 @@ check_game_config_wrapper process_arguments(int argc, char **argv) {
 	while (true) {
 		int option_index = getopt_long(argc, argv, "hVvt:H:P:G:g:p:m:", long_opts, &opt_index);
 
-		if (option_index == -1 || option_index == EOF) {
+		if (CHECK_EOF(option_index)) {
 			break;
 		}
 

--- a/plugins/check_hpjd.c
+++ b/plugins/check_hpjd.c
@@ -299,7 +299,7 @@ check_hpjd_config_wrapper process_arguments(int argc, char **argv) {
 	while (true) {
 		int option_index = getopt_long(argc, argv, "+hVH:C:p:D", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF || option_index == 1) {
+		if (CHECK_EOF(option_index) || option_index == 1) {
 			break;
 		}
 

--- a/plugins/check_ide_smart.c
+++ b/plugins/check_ide_smart.c
@@ -169,7 +169,7 @@ static check_ide_smart_config_wrapper process_arguments(int argc, char **argv) {
 		int longindex = 0;
 		int option_index = getopt_long(argc, argv, "+d:iq10nhVv", longopts, &longindex);
 
-		if (option_index == -1 || option_index == EOF || option_index == 1) {
+		if (CHECK_EOF(option_index) || option_index == 1) {
 			break;
 		}
 

--- a/plugins/check_ldap.c
+++ b/plugins/check_ldap.c
@@ -362,7 +362,7 @@ check_ldap_config_wrapper process_arguments(int argc, char **argv) {
 		int option_index =
 			getopt_long(argc, argv, "hvV234TS6t:c:w:H:b:p:a:D:P:C:W:", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF) {
+		if (CHECK_EOF(option_index)) {
 			break;
 		}
 

--- a/plugins/check_load.c
+++ b/plugins/check_load.c
@@ -295,7 +295,7 @@ static check_load_config_wrapper process_arguments(int argc, char **argv) {
 		int option = 0;
 		int option_index = getopt_long(argc, argv, "Vhrc:w:n:", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF) {
+		if (CHECK_EOF(option_index)) {
 			break;
 		}
 

--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -504,7 +504,7 @@ check_mysql_config_wrapper process_arguments(int argc, char **argv) {
 		int option_index =
 			getopt_long(argc, argv, "hlvVnSP:p:u:d:H:s:c:w:a:k:C:D:L:f:g:", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF) {
+		if (CHECK_EOF(option_index)) {
 			break;
 		}
 

--- a/plugins/check_nagios.c
+++ b/plugins/check_nagios.c
@@ -227,7 +227,7 @@ check_nagios_config_wrapper process_arguments(int argc, char **argv) {
 	while (true) {
 		int option_index = getopt_long(argc, argv, "+hVvF:C:e:t:", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF || option_index == 1) {
+		if (CHECK_EOF(option_index) || option_index == 1) {
 			break;
 		}
 

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -221,7 +221,7 @@ check_ping_config_wrapper process_arguments(int argc, char **argv) {
 	while (true) {
 		int option_index = getopt_long(argc, argv, "VvhnL46t:c:w:H:p:", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF) {
+		if (CHECK_EOF(option_index)) {
 			break;
 		}
 

--- a/plugins/check_procs.c
+++ b/plugins/check_procs.c
@@ -432,7 +432,7 @@ check_procs_config_wrapper process_arguments(int argc, char **argv) {
 		int option_index =
 			getopt_long(argc, argv, "Vvhkt:c:w:p:s:u:C:a:z:r:m:P:TX:", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF) {
+		if (CHECK_EOF(option_index)) {
 			break;
 		}
 

--- a/plugins/check_radius.c
+++ b/plugins/check_radius.c
@@ -334,7 +334,7 @@ check_radius_config_wrapper process_arguments(int argc, char **argv) {
 		int option = 0;
 		int option_index = getopt_long(argc, argv, "+hVvH:P:F:u:p:n:N:t:r:e:", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF || option_index == 1) {
+		if (CHECK_EOF(option_index) || option_index == 1) {
 			break;
 		}
 

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -447,7 +447,7 @@ static process_arguments_wrapper process_arguments(int argc, char **argv) {
 			argc, argv,
 			"nhvVO46t:c:w:H:C:o:e:E:d:D:s:t:R:r:l:u:p:m:P:N:L:U:a:x:A:X:M:f:z:", longopts, &option);
 
-		if (option_char == -1 || option_char == EOF) {
+		if (CHECK_EOF(option_char)) {
 			break;
 		}
 
@@ -517,7 +517,7 @@ static process_arguments_wrapper process_arguments(int argc, char **argv) {
 			argc, argv,
 			"nhvVO46t:c:w:H:C:o:e:E:d:D:s:t:R:r:l:u:p:m:P:N:L:U:a:x:A:X:M:f:z:", longopts, &option);
 
-		if (option_char == -1 || option_char == EOF) {
+		if (CHECK_EOF(option_char)) {
 			break;
 		}
 

--- a/plugins/check_tcp.c
+++ b/plugins/check_tcp.c
@@ -562,7 +562,7 @@ static check_tcp_config_wrapper process_arguments(int argc, char **argv, check_t
 		int option_index =
 			getopt_long(argc, argv, "+hVv46EAH:s:e:q:m:c:w:t:p:C:W:d:Sr:jD:M:", longopts, &option);
 
-		if (option_index == -1 || option_index == EOF || option_index == 1) {
+		if (CHECK_EOF(option_index) || option_index == 1) {
 			break;
 		}
 

--- a/plugins/check_time.c
+++ b/plugins/check_time.c
@@ -213,7 +213,7 @@ check_time_config_wrapper process_arguments(int argc, char **argv) {
 		int option = 0;
 		option_char = getopt_long(argc, argv, "hVH:w:c:W:C:p:t:u", longopts, &option);
 
-		if (option_char == -1 || option_char == EOF) {
+		if (CHECK_EOF(option_char)) {
 			break;
 		}
 

--- a/plugins/common.h
+++ b/plugins/common.h
@@ -205,4 +205,11 @@ enum {
 #	define __attribute__(x) /* do nothing */
 #endif
 
+/* for checking the result of getopt_long */
+#if EOF == -1
+#define CHECK_EOF(c) ((c) == EOF)
+#else
+#define CHECK_EOF(c) ((c) == -1 || (c) == EOF)
+#endif
+
 #endif /* _COMMON_H_ */


### PR DESCRIPTION
Partition of #2227

Fixes compiler warnings on systems where `EOF == -1`