### PR TITLE
check_http and check_curl: custom timeout return state

### DIFF
--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -276,7 +276,7 @@ mp_subcheck check_http(const check_curl_config config, check_curl_working_state 
 		xasprintf(&sc_curl.output, _("cURL got a timeout error"));
 		sc_curl = mp_set_subcheck_state(sc_curl, config.on_timeout_result_state);
 		mp_add_subcheck_to_subcheck(&sc_result, sc_curl);
-		return sc_curl;
+		return sc_result;
 	}
 
 	/* Curl errors, result in critical Nagios state */
@@ -898,7 +898,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 		STATE_REGEX,
 		OUTPUT_FORMAT,
 		NO_PROXY,
-		TIMEOUT_CUSTOM_RESULT_STATE,
+		TIMEOUT_RESULT,
 	};
 
 	static struct option longopts[] = {
@@ -948,7 +948,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 		{"cookie-jar", required_argument, 0, COOKIE_JAR},
 		{"haproxy-protocol", no_argument, 0, HAPROXY_PROTOCOL},
 		{"output-format", required_argument, 0, OUTPUT_FORMAT},
-		{"timeout-custom-result-state", required_argument, 0, TIMEOUT_CUSTOM_RESULT_STATE},
+		{"timeout-result", required_argument, 0, TIMEOUT_RESULT},
 		{0, 0, 0, 0}};
 
 	check_curl_config_wrapper result = {
@@ -1014,17 +1014,17 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 				result.config.curl_config.socket_timeout = (int)strtol(optarg, NULL, 10);
 			}
 			break;
-		case TIMEOUT_CUSTOM_RESULT_STATE:
-			if (!strcmp(optarg, "ok")) {
+		case TIMEOUT_RESULT:
+			if (!strcmp(optarg, "0") || !strcmp(optarg, "ok")) {
 				result.config.on_timeout_result_state = STATE_OK;
-			} else if (!strcmp(optarg, "warning")) {
+			} else if (!strcmp(optarg, "1") || !strcmp(optarg, "warning")) {
 				result.config.on_timeout_result_state = STATE_WARNING;
-			} else if (!strcmp(optarg, "critical")) {
+			} else if (!strcmp(optarg, "2") || !strcmp(optarg, "critical")) {
 				result.config.on_timeout_result_state = STATE_CRITICAL;
-			} else if (!strcmp(optarg, "unknown")) {
+			} else if (!strcmp(optarg, "3") || !strcmp(optarg, "unknown")) {
 				result.config.on_timeout_result_state = STATE_UNKNOWN;
 			} else {
-				usage2(_("Invalid custom timeout result state option"), optarg);
+				usage2(_("Invalid timeout-result state option, give either a return code or state name in lowercase"), optarg);
 			}
 			break;
 		case 'c': /* critical time threshold */
@@ -1723,6 +1723,10 @@ void print_help(void) {
 	printf(UT_WARN_CRIT);
 
 	printf(UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
+
+	printf(" %s\n", "--timeout-result=RESULT|INTEGER");
+	printf("    %s\n",_("Timeouts default to returning STATE_CRITICAL."));
+	printf("    %s\n",_("This argument changes the return state on timeouts."));
 
 	printf(UT_VERBOSE);
 

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -271,20 +271,18 @@ mp_subcheck check_http(const check_curl_config config, check_curl_working_state 
 
 	mp_subcheck sc_curl = mp_subcheck_init();
 
-	/* Custom handling for timeouts */
-	if (res == CURLE_OPERATION_TIMEDOUT) {
-		xasprintf(&sc_curl.output, _("cURL returned %d - %s"), res,
-				  errbuf[0] ? errbuf : curl_easy_strerror(res));
-		sc_curl = mp_set_subcheck_state(sc_curl, config.on_timeout_result_state);
-		mp_add_subcheck_to_subcheck(&sc_result, sc_curl);
-		return sc_result;
-	}
-
 	/* Curl errors, result in critical Nagios state */
 	if (res != CURLE_OK) {
-		xasprintf(&sc_curl.output, _("Error while performing connection: cURL returned %d - %s"),
+		/* Custom handling for timeouts, state might be set to non CRITICAL */
+		if (res == CURLE_OPERATION_TIMEDOUT) {
+			xasprintf(&sc_curl.output, _("cURL returned %d - %s"), res,
+				  errbuf[0] ? errbuf : curl_easy_strerror(res));
+			sc_curl = mp_set_subcheck_state(sc_curl, config.on_timeout_result_state);
+		} else {
+			xasprintf(&sc_curl.output, _("Error while performing connection: cURL returned %d - %s"),
 				  res, errbuf[0] ? errbuf : curl_easy_strerror(res));
-		sc_curl = mp_set_subcheck_state(sc_curl, STATE_CRITICAL);
+			sc_curl = mp_set_subcheck_state(sc_curl, STATE_CRITICAL);
+		}
 		mp_add_subcheck_to_subcheck(&sc_result, sc_curl);
 		return sc_result;
 	}

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -273,7 +273,8 @@ mp_subcheck check_http(const check_curl_config config, check_curl_working_state 
 
 	/* Custom handling for timeouts */
 	if (res == CURLE_OPERATION_TIMEDOUT) {
-		xasprintf(&sc_curl.output, _("cURL got a timeout error"));
+		xasprintf(&sc_curl.output, _("cURL returned %d - %s"),
+			res, errbuf[0] ? errbuf : curl_easy_strerror(res));
 		sc_curl = mp_set_subcheck_state(sc_curl, config.on_timeout_result_state);
 		mp_add_subcheck_to_subcheck(&sc_result, sc_curl);
 		return sc_result;
@@ -1024,7 +1025,9 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 			} else if (!strcmp(optarg, "3") || !strcmp(optarg, "unknown")) {
 				result.config.on_timeout_result_state = STATE_UNKNOWN;
 			} else {
-				usage2(_("Invalid timeout-result state option, give either a return code or state name in lowercase"), optarg);
+				usage2(_("Invalid timeout-result state option, give either a return code or state "
+						 "name in lowercase"),
+					   optarg);
 			}
 			break;
 		case 'c': /* critical time threshold */
@@ -1725,8 +1728,8 @@ void print_help(void) {
 	printf(UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
 
 	printf(" %s\n", "--timeout-result=RESULT|INTEGER");
-	printf("    %s\n",_("Timeouts default to returning STATE_CRITICAL."));
-	printf("    %s\n",_("This argument changes the return state on timeouts."));
+	printf("    %s\n", _("Timeouts default to returning STATE_CRITICAL."));
+	printf("    %s\n", _("This argument changes the return state on timeouts."));
 
 	printf(UT_VERBOSE);
 

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1727,7 +1727,7 @@ void print_help(void) {
 
 	printf(UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
 
-	printf(" %s\n", "--timeout-result=RESULT|INTEGER");
+	printf(" %s\n", "--timeout-result=ok|warning|critical|unknown|0|1|2|3");
 	printf("    %s\n", _("Timeouts default to returning STATE_CRITICAL."));
 	printf("    %s\n", _("This argument changes the return state on timeouts."));
 

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -273,8 +273,8 @@ mp_subcheck check_http(const check_curl_config config, check_curl_working_state 
 
 	/* Custom handling for timeouts */
 	if (res == CURLE_OPERATION_TIMEDOUT) {
-		xasprintf(&sc_curl.output, _("cURL returned %d - %s"),
-			res, errbuf[0] ? errbuf : curl_easy_strerror(res));
+		xasprintf(&sc_curl.output, _("cURL returned %d - %s"), res,
+				  errbuf[0] ? errbuf : curl_easy_strerror(res));
 		sc_curl = mp_set_subcheck_state(sc_curl, config.on_timeout_result_state);
 		mp_add_subcheck_to_subcheck(&sc_result, sc_curl);
 		return sc_result;

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -271,6 +271,14 @@ mp_subcheck check_http(const check_curl_config config, check_curl_working_state 
 
 	mp_subcheck sc_curl = mp_subcheck_init();
 
+	/* Custom handling for timeouts */
+	if (res == CURLE_OPERATION_TIMEDOUT) {
+		xasprintf(&sc_curl.output, _("cURL got a timeout error"));
+		sc_curl = mp_set_subcheck_state(sc_curl, config.on_timeout_result_state);
+		mp_add_subcheck_to_subcheck(&sc_result, sc_curl);
+		return sc_curl;
+	}
+
 	/* Curl errors, result in critical Nagios state */
 	if (res != CURLE_OK) {
 		xasprintf(&sc_curl.output, _("Error while performing connection: cURL returned %d - %s"),
@@ -890,6 +898,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 		STATE_REGEX,
 		OUTPUT_FORMAT,
 		NO_PROXY,
+		TIMEOUT_CUSTOM_RESULT_STATE,
 	};
 
 	static struct option longopts[] = {
@@ -939,6 +948,7 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 		{"cookie-jar", required_argument, 0, COOKIE_JAR},
 		{"haproxy-protocol", no_argument, 0, HAPROXY_PROTOCOL},
 		{"output-format", required_argument, 0, OUTPUT_FORMAT},
+		{"timeout-custom-result-state", required_argument, 0, TIMEOUT_CUSTOM_RESULT_STATE},
 		{0, 0, 0, 0}};
 
 	check_curl_config_wrapper result = {
@@ -1002,6 +1012,19 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 				usage2(_("Timeout interval must be a positive integer"), optarg);
 			} else {
 				result.config.curl_config.socket_timeout = (int)strtol(optarg, NULL, 10);
+			}
+			break;
+		case TIMEOUT_CUSTOM_RESULT_STATE:
+			if (!strcmp(optarg, "ok")) {
+				result.config.on_timeout_result_state = STATE_OK;
+			} else if (!strcmp(optarg, "warning")) {
+				result.config.on_timeout_result_state = STATE_WARNING;
+			} else if (!strcmp(optarg, "critical")) {
+				result.config.on_timeout_result_state = STATE_CRITICAL;
+			} else if (!strcmp(optarg, "unknown")) {
+				result.config.on_timeout_result_state = STATE_UNKNOWN;
+			} else {
+				usage2(_("Invalid custom timeout result state option"), optarg);
 			}
 			break;
 		case 'c': /* critical time threshold */

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -1016,13 +1016,13 @@ check_curl_config_wrapper process_arguments(int argc, char **argv) {
 			}
 			break;
 		case TIMEOUT_RESULT:
-			if (!strcmp(optarg, "0") || !strcmp(optarg, "ok")) {
+			if (!strcmp(optarg, "0") || !strcasecmp(optarg, "ok")) {
 				result.config.on_timeout_result_state = STATE_OK;
-			} else if (!strcmp(optarg, "1") || !strcmp(optarg, "warning")) {
+			} else if (!strcmp(optarg, "1") || !strcasecmp(optarg, "warning")) {
 				result.config.on_timeout_result_state = STATE_WARNING;
-			} else if (!strcmp(optarg, "2") || !strcmp(optarg, "critical")) {
+			} else if (!strcmp(optarg, "2") || !strcasecmp(optarg, "critical")) {
 				result.config.on_timeout_result_state = STATE_CRITICAL;
-			} else if (!strcmp(optarg, "3") || !strcmp(optarg, "unknown")) {
+			} else if (!strcmp(optarg, "3") || !strcasecmp(optarg, "unknown")) {
 				result.config.on_timeout_result_state = STATE_UNKNOWN;
 			} else {
 				usage2(_("Invalid timeout-result state option, give either a return code or state "

--- a/plugins/check_curl.c
+++ b/plugins/check_curl.c
@@ -276,11 +276,12 @@ mp_subcheck check_http(const check_curl_config config, check_curl_working_state 
 		/* Custom handling for timeouts, state might be set to non CRITICAL */
 		if (res == CURLE_OPERATION_TIMEDOUT) {
 			xasprintf(&sc_curl.output, _("cURL returned %d - %s"), res,
-				  errbuf[0] ? errbuf : curl_easy_strerror(res));
+					  errbuf[0] ? errbuf : curl_easy_strerror(res));
 			sc_curl = mp_set_subcheck_state(sc_curl, config.on_timeout_result_state);
 		} else {
-			xasprintf(&sc_curl.output, _("Error while performing connection: cURL returned %d - %s"),
-				  res, errbuf[0] ? errbuf : curl_easy_strerror(res));
+			xasprintf(&sc_curl.output,
+					  _("Error while performing connection: cURL returned %d - %s"), res,
+					  errbuf[0] ? errbuf : curl_easy_strerror(res));
 			sc_curl = mp_set_subcheck_state(sc_curl, STATE_CRITICAL);
 		}
 		mp_add_subcheck_to_subcheck(&sc_result, sc_curl);

--- a/plugins/check_curl.d/check_curl_helpers.c
+++ b/plugins/check_curl.d/check_curl_helpers.c
@@ -755,6 +755,7 @@ check_curl_config check_curl_config_init(void) {
 		.header_expect = "",
 		.on_redirect_result_state = STATE_OK,
 		.on_redirect_dependent = false,
+		.on_timeout_result_state = STATE_CRITICAL,
 
 		.show_extended_perfdata = false,
 		.show_body = false,

--- a/plugins/check_curl.d/config.h
+++ b/plugins/check_curl.d/config.h
@@ -113,8 +113,11 @@ typedef struct {
 	mp_state_enum on_redirect_result_state;
 	bool on_redirect_dependent;
 
+	mp_state_enum on_timeout_result_state;
+
 	bool show_extended_perfdata;
 	bool show_body;
+
 
 	bool output_format_is_set;
 	mp_output_format output_format;

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -1900,7 +1900,7 @@ void print_help(void) {
 
 	printf(UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
 
-	printf(" %s\n", "--timeout-result=RESULT|INTEGER");
+	printf(" %s\n", "--timeout-result=ok|warning|critical|unknown|0|1|2|3");
 	printf("    %s\n", _("Timeouts default to returning STATE_CRITICAL."));
 	printf("    %s\n", _("This argument changes the return state on timeouts."));
 

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -206,7 +206,7 @@ bool process_arguments(int argc, char **argv) {
 		MAX_REDIRS_OPTION,
 		CONTINUE_AFTER_CHECK_CERT,
 		STATE_REGEX,
-		TIMEOUT_CUSTOM_RESULT_STATE
+		TIMEOUT_RESULT
 	};
 
 	int option = 0;
@@ -248,7 +248,7 @@ bool process_arguments(int argc, char **argv) {
 		{"extended-perfdata", no_argument, 0, 'E'},
 		{"show-body", no_argument, 0, 'B'},
 		{"max-redirs", required_argument, 0, MAX_REDIRS_OPTION},
-		{"timeout-custom-result-state", required_argument, 0, TIMEOUT_CUSTOM_RESULT_STATE},
+		{"timeout-result", required_argument, 0, TIMEOUT_RESULT},
 		{0, 0, 0, 0}};
 
 	if (argc < 2) {
@@ -300,17 +300,19 @@ bool process_arguments(int argc, char **argv) {
 				socket_timeout = atoi(optarg);
 			}
 			break;
-		case TIMEOUT_CUSTOM_RESULT_STATE:
-			if (!strcmp(optarg, "ok")) {
+		case TIMEOUT_RESULT:
+			if (!strcmp(optarg, "0") || !strcmp(optarg, "ok")) {
 				socket_timeout_state = STATE_OK;
-			} else if (!strcmp(optarg, "warning")) {
+			} else if (!strcmp(optarg, "1") || !strcmp(optarg, "warning")) {
 				socket_timeout_state = STATE_WARNING;
-			} else if (!strcmp(optarg, "critical")) {
+			} else if (!strcmp(optarg, "2") || !strcmp(optarg, "critical")) {
 				socket_timeout_state = STATE_CRITICAL;
-			} else if (!strcmp(optarg, "unknown")) {
+			} else if (!strcmp(optarg, "3") || !strcmp(optarg, "unknown")) {
 				socket_timeout_state = STATE_UNKNOWN;
 			} else {
-				usage2(_("Invalid custom timeout result state option"), optarg);
+				usage2(_("Invalid timeout-result state option, give either a return code or state "
+						 "name in lowercase"),
+					   optarg);
 			}
 			break;
 		case 'c': /* critical time threshold */
@@ -1047,7 +1049,7 @@ int check_http(void) {
 			printf("SSL initialized\n");
 		}
 		if (result != STATE_OK) {
-			die(STATE_CRITICAL,  _("HTTP CRITICAL - SSL error\n"));
+			die(STATE_CRITICAL, _("HTTP CRITICAL - SSL error\n"));
 		}
 		microsec_ssl = deltime(tv_temp);
 		elapsed_time_ssl = (double)microsec_ssl / 1.0e6;
@@ -1897,6 +1899,10 @@ void print_help(void) {
 	printf(UT_WARN_CRIT);
 
 	printf(UT_CONN_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
+
+	printf(" %s\n", "--timeout-result=RESULT|INTEGER");
+	printf("    %s\n", _("Timeouts default to returning STATE_CRITICAL."));
+	printf("    %s\n", _("This argument changes the return state on timeouts."));
 
 	printf(UT_VERBOSE);
 

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -205,7 +205,8 @@ bool process_arguments(int argc, char **argv) {
 		SNI_OPTION,
 		MAX_REDIRS_OPTION,
 		CONTINUE_AFTER_CHECK_CERT,
-		STATE_REGEX
+		STATE_REGEX,
+		TIMEOUT_CUSTOM_RESULT_STATE
 	};
 
 	int option = 0;
@@ -247,6 +248,7 @@ bool process_arguments(int argc, char **argv) {
 		{"extended-perfdata", no_argument, 0, 'E'},
 		{"show-body", no_argument, 0, 'B'},
 		{"max-redirs", required_argument, 0, MAX_REDIRS_OPTION},
+		{"timeout-custom-result-state", required_argument, 0, TIMEOUT_CUSTOM_RESULT_STATE},
 		{0, 0, 0, 0}};
 
 	if (argc < 2) {
@@ -296,6 +298,19 @@ bool process_arguments(int argc, char **argv) {
 				usage2(_("Timeout interval must be a positive integer"), optarg);
 			} else {
 				socket_timeout = atoi(optarg);
+			}
+			break;
+		case TIMEOUT_CUSTOM_RESULT_STATE:
+			if (!strcmp(optarg, "ok")) {
+				socket_timeout_state = STATE_OK;
+			} else if (!strcmp(optarg, "warning")) {
+				socket_timeout_state = STATE_WARNING;
+			} else if (!strcmp(optarg, "critical")) {
+				socket_timeout_state = STATE_CRITICAL;
+			} else if (!strcmp(optarg, "unknown")) {
+				socket_timeout_state = STATE_UNKNOWN;
+			} else {
+				usage2(_("Invalid custom timeout result state option"), optarg);
 			}
 			break;
 		case 'c': /* critical time threshold */

--- a/plugins/check_http.c
+++ b/plugins/check_http.c
@@ -301,13 +301,13 @@ bool process_arguments(int argc, char **argv) {
 			}
 			break;
 		case TIMEOUT_RESULT:
-			if (!strcmp(optarg, "0") || !strcmp(optarg, "ok")) {
+			if (!strcmp(optarg, "0") || !strcasecmp(optarg, "ok")) {
 				socket_timeout_state = STATE_OK;
-			} else if (!strcmp(optarg, "1") || !strcmp(optarg, "warning")) {
+			} else if (!strcmp(optarg, "1") || !strcasecmp(optarg, "warning")) {
 				socket_timeout_state = STATE_WARNING;
-			} else if (!strcmp(optarg, "2") || !strcmp(optarg, "critical")) {
+			} else if (!strcmp(optarg, "2") || !strcasecmp(optarg, "critical")) {
 				socket_timeout_state = STATE_CRITICAL;
-			} else if (!strcmp(optarg, "3") || !strcmp(optarg, "unknown")) {
+			} else if (!strcmp(optarg, "3") || !strcasecmp(optarg, "unknown")) {
 				socket_timeout_state = STATE_UNKNOWN;
 			} else {
 				usage2(_("Invalid timeout-result state option, give either a return code or state "

--- a/plugins/t/check_curl.t
+++ b/plugins/t/check_curl.t
@@ -69,31 +69,31 @@ $res = NPTest->testCmd(
     );
 cmp_ok( $res->return_code, '==', 2, "Webserver $host_nonresponsive not responding" );
 # was CRITICAL only, but both check_curl and check_http print HTTP CRITICAL (puzzle?!)
-like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - (Connection|Operation) timed out after/", "Output OK");
 
 # timeout return results can be changed using --timeout-result option
 $res = NPTest->testCmd(
     "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result ok"
     );
-like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - (Connection|Operation) timed out after/", "Output OK");
 cmp_ok( $res->return_code, "==", 0, "Return code is correct due argument: --timeout-result ok");
 
 $res = NPTest->testCmd(
     "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result warning"
     );
-like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - (Connection|Operation) timed out after/", "Output OK");
 cmp_ok( $res->return_code, "==", 1, "Return code is correct due argument: --timeout-result warning");
 
 $res = NPTest->testCmd(
     "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result 2"
     );
-like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - (Connection|Operation) timed out after/", "Output OK");
 cmp_ok( $res->return_code, "==", 2, "Return code is correct due argument: --timeout-result 2");
 
 $res = NPTest->testCmd(
     "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result 3"
     );
-like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - (Connection|Operation) timed out after/", "Output OK");
 cmp_ok( $res->return_code, "==", 3, "Return code is correct due argument: --timeout-result 3");
 
 $res = NPTest->testCmd(

--- a/plugins/t/check_curl.t
+++ b/plugins/t/check_curl.t
@@ -13,7 +13,7 @@ use vars qw($tests $has_ipv6);
 BEGIN {
     use NPTest;
     $has_ipv6 = NPTest::has_ipv6();
-    $tests = $has_ipv6 ? 57 : 92;
+    $tests = $has_ipv6 ? 65 : 100;
     plan tests => $tests;
 }
 
@@ -69,7 +69,32 @@ $res = NPTest->testCmd(
     );
 cmp_ok( $res->return_code, '==', 2, "Webserver $host_nonresponsive not responding" );
 # was CRITICAL only, but both check_curl and check_http print HTTP CRITICAL (puzzle?!)
-like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+
+# timeout return results can be changed using --timeout-result option
+$res = NPTest->testCmd(
+    "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result ok"
+    );
+like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+cmp_ok( $res->return_code, "==", 0, "Return code is correct due argument: --timeout-result ok");
+
+$res = NPTest->testCmd(
+    "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result warning"
+    );
+like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+cmp_ok( $res->return_code, "==", 1, "Return code is correct due argument: --timeout-result warning");
+
+$res = NPTest->testCmd(
+    "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result 2"
+    );
+like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+cmp_ok( $res->return_code, "==", 2, "Return code is correct due argument: --timeout-result 2");
+
+$res = NPTest->testCmd(
+    "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result 3"
+    );
+like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+cmp_ok( $res->return_code, "==", 3, "Return code is correct due argument: --timeout-result 3");
 
 $res = NPTest->testCmd(
     "./$plugin $hostname_invalid -wt 1 -ct 2"

--- a/plugins/t/check_curl.t
+++ b/plugins/t/check_curl.t
@@ -69,31 +69,31 @@ $res = NPTest->testCmd(
     );
 cmp_ok( $res->return_code, '==', 2, "Webserver $host_nonresponsive not responding" );
 # was CRITICAL only, but both check_curl and check_http print HTTP CRITICAL (puzzle?!)
-like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
 
 # timeout return results can be changed using --timeout-result option
 $res = NPTest->testCmd(
     "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result ok"
     );
-like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
 cmp_ok( $res->return_code, "==", 0, "Return code is correct due argument: --timeout-result ok");
 
 $res = NPTest->testCmd(
     "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result warning"
     );
-like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
 cmp_ok( $res->return_code, "==", 1, "Return code is correct due argument: --timeout-result warning");
 
 $res = NPTest->testCmd(
     "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result 2"
     );
-like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
 cmp_ok( $res->return_code, "==", 2, "Return code is correct due argument: --timeout-result 2");
 
 $res = NPTest->testCmd(
     "./$plugin $host_nonresponsive -wt 1 -ct 2 -t 3 --timeout-result 3"
     );
-like( $res->output, "/cURL returned 28 - Operation timed out after/", "Output OK");
+like( $res->output, "/cURL returned 28 - Connection timed out after/", "Output OK");
 cmp_ok( $res->return_code, "==", 3, "Return code is correct due argument: --timeout-result 3");
 
 $res = NPTest->testCmd(


### PR DESCRIPTION
As discussed in #2265

Added a new argument to both check-curl and check-http  called ```--timeout-state``` . It customizes the return state when a timeout occurs. Takes either a return code ```0,1,2,3``` or mixed case return state name ```ok,warning,critical,unknown``` .

check_http:  parse the argument and set the ```socket_timeout_state found``` in netutils.c . This is used in the ```SIGALRM``` handler function socket_timeout_alarm_handler. The ```SIGALRM``` is scheduled using ```alarm()``` call.

check_curl: parse the argument and save the given state into the config as on_timeout_result_state . After performing a curl request, check if it returned curl return code ```CURLE_OPERATION_TIMEDOUT``` . If so, change the ```sc_curl``` subcheck to use the ```on_timeout_result_state``` from config, and return ```sc_result``` check immediately.

Clang-format is applied