### PR TITLE
Add a hint about libfreeradius version in REQUIREMENTS

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -70,6 +70,8 @@ check_radius:
 	  http://radcli.github.io/radcli/
 	- As an alternative, the FreeRADIUS Client library may be used:
 	  http://freeradius.org/freeradius-client/
+	  The minimal version is 1.1.8, since it broke compatibility in that
+	  release. Later versions may be used if that does not happen again
 	- As another alternative, the radiusclient-ng library may be used:
 	  http://sourceforge.net/projects/radiusclient-ng.berlios/
 	- This plugin also works with the original radiusclient library from


### PR DESCRIPTION
kinda solves #2264 

I am not really willing to add further complexity to the `configure.ac` to determine
the version of `libfreeradius` and tend to leave it as an excercise to the
distro maintainers to get to a more recent version.