### PR TITLE
Check ntp time delay

### DIFF
--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -43,6 +43,7 @@
 #include "thresholds.h"
 #include "check_ntp_time.d/config.h"
 #include <netinet/in.h>
+#include <string.h>
 #include <sys/socket.h>
 
 static int verbose = 0;
@@ -395,7 +396,10 @@ static offset_request_wrapper offset_request(const char *host, const char *port,
 			.sun_family = AF_UNIX,
 		};
 
-		strncpy(unix_socket.sun_path, host, strlen(host));
+		if (strlen(host) > sizeof(unix_socket.sun_path)) {
+			die(STATE_UNKNOWN, "host argument is too long (%lu) for a socket path\n", strlen(host));
+		}
+		strncpy(unix_socket.sun_path, host, sizeof(unix_socket.sun_path));
 
 		if (connect(socklist[0], &unix_socket, sizeof(unix_socket))) {
 			/* don't die here, because it is enough if there is one server

--- a/plugins/check_ntp_time.d/config.h
+++ b/plugins/check_ntp_time.d/config.h
@@ -5,6 +5,9 @@
 #include "thresholds.h"
 #include <stddef.h>
 
+/* Time in microseconds to delay between polling to avoid a blocking response. */
+const long default_polling_delay = 500000L;
+
 typedef struct {
 	char *server_address;
 	char *port;
@@ -15,6 +18,7 @@ typedef struct {
 	mp_thresholds offset_thresholds;
 
 	bool output_format_is_set;
+	long poll_delay;
 	mp_output_format output_format;
 } check_ntp_time_config;
 
@@ -29,6 +33,7 @@ check_ntp_time_config check_ntp_time_config_init() {
 		.offset_thresholds = mp_thresholds_init(),
 
 		.output_format_is_set = false,
+		.poll_delay = default_polling_delay,
 	};
 
 	mp_range warning = mp_range_init();


### PR DESCRIPTION
This patch set mainly adds a delay to requests made with `check_ntp_time` to avoid
triggering rate limits on NTP servers.
Additionaly to a default delay, it adds an option to set the delay.

Another change in here validates whether a given socket path fits into the
target struct and aborts execution if not (which might cause a segfault oder other
problems otherwise.

The original patch set comes from a Paul Crawford which I hope is adequatly reflected
in the authorship of the commits.

This should fix #1295 and #1142 