### PR TITLE
check_mysql: Fix MariaDB casing

### DIFF
--- a/plugins/check_mysql.c
+++ b/plugins/check_mysql.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv) {
 
 	mp_check overall = mp_check_init();
 
-	mp_set_ok_summary(&overall, "Mariadb/MySQL seems to be ok");
+	mp_set_ok_summary(&overall, "MariaDB/MySQL seems to be ok");
 
 	mp_subcheck sc_connection = mp_subcheck_init();
 	/* establish a connection to the server and check for errors */


### PR DESCRIPTION
Correctly stylizes `MariaDB` (from `Mariadb`) in the `check_mysql` plugin output.