### PR TITLE
check for net-snmp-config when buildin check_snmp (fixes #2281)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1445,6 +1445,19 @@ else
 	AC_MSG_WARN([Get smbclient from Samba.org to monitor SMB shares])
 fi
 
+AC_PATH_PROG(PATH_TO_NETSNMPCONFIG,net-snmp-config)
+AC_ARG_WITH(netsnmpconfig_command,
+            ACX_HELP_STRING([--with-net-snmp-config-command=PATH],
+                            [sets path to net-snmp-config]),
+            PATH_TO_NETSNMPCONFIG=$withval)
+if test -n "$PATH_TO_NETSNMPCONFIG"
+then
+	AC_DEFINE_UNQUOTED(PATH_TO_NETSNMPCONFIG,"$PATH_TO_NETSNMPCONFIG",[path to net-snmp-config binary])
+	EXTRAS="$EXTRAS check_snmp"
+else
+	AC_MSG_WARN([Install net-snmp-config to build check_snmp])
+fi
+
 AC_PATH_PROG(PATH_TO_SNMPGET,snmpget)
 AC_ARG_WITH(snmpget_command,
             ACX_HELP_STRING([--with-snmpget-command=PATH],

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -36,8 +36,7 @@ libexec_PROGRAMS = check_apt check_cluster check_disk check_dummy check_http che
 	check_mrtg check_mrtgtraf check_ntp_peer check_ping \
 	check_real check_smtp check_ssh check_tcp check_time check_ntp_time \
 	check_ups check_users negate \
-	urlize @EXTRAS@ \
-	check_snmp
+	urlize @EXTRAS@
 
 check_tcp_programs = check_ftp check_imap check_nntp check_pop \
 	check_udp check_clamd @check_tcp_ssl@
@@ -46,6 +45,7 @@ EXTRA_PROGRAMS = check_mysql check_radius check_pgsql check_hpjd \
 	check_swap check_fping check_ldap check_game check_dig \
 	check_nagios check_by_ssh check_dns check_ide_smart	\
 	check_procs check_mysql_query check_apt check_dbi check_curl \
+	check_snmp \
 	\
 	tests/test_check_swap \
 	tests/test_check_snmp \
@@ -165,8 +165,8 @@ check_radius_LDADD = $(NETLIBS) $(RADIUSLIBS)
 check_real_LDADD = $(NETLIBS)
 check_snmp_SOURCES = check_snmp.c check_snmp.d/check_snmp_helpers.c
 check_snmp_LDADD = $(BASEOBJS)
-check_snmp_LDFLAGS = $(AM_LDFLAGS) -lm `net-snmp-config --libs`
-check_snmp_CFLAGS = $(AM_CFLAGS) `net-snmp-config --cflags | sed 's/-Werror=declaration-after-statement//'`
+check_snmp_LDFLAGS = $(AM_LDFLAGS) -lm `$(PATH_TO_NETSNMPCONFIG) --libs`
+check_snmp_CFLAGS = $(AM_CFLAGS) `$(PATH_TO_NETSNMPCONFIG) --cflags | sed 's/-Werror=declaration-after-statement//'`
 check_smtp_LDADD = $(SSLOBJS)
 check_ssh_LDADD = $(NETLIBS)
 check_swap_SOURCES = check_swap.c check_swap.d/swap.c


### PR DESCRIPTION
this will fix the build error on check_snmp when net-snmp-config is not available.

```
  CC       check_snmp-check_snmp.o
/bin/bash: line 1: net-snmp-config: command not found
In file included from check_snmp.d/check_snmp_helpers.h:3,
                 from check_snmp.c:42:
check_snmp.d/./config.h:16:10: fatal error: net-snmp/net-snmp-config.h: No such file or directory
   16 | #include <net-snmp/net-snmp-config.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[3]: *** [Makefile:3353: check_snmp-check_snmp.o] Error 1
make[3]: Leaving directory '/opt/projects/git/monitoring-plugins/plugins'
```