### PR TITLE
Fix/check smtp successfull auth

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -481,6 +481,10 @@ int main(int argc, char **argv) {
 	if (config.authtype != NULL) {
 		mp_subcheck sc_auth = mp_subcheck_init();
 
+		// set sucess values here, failure will be set below
+		sc_auth = mp_set_subcheck_default_state(sc_auth, STATE_OK);
+		xasprintf(&sc_auth.output, "Login succeded");
+
 		if (strcmp(config.authtype, "LOGIN") == 0) {
 			char *abuf;
 			int ret;

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -483,9 +483,9 @@ int main(int argc, char **argv) {
 	if (config.authtype != NULL) {
 		mp_subcheck sc_auth = mp_subcheck_init();
 
-		// set sucess values here, failure will be set below
+		// set success values here, failure will be set below
 		sc_auth = mp_set_subcheck_default_state(sc_auth, STATE_OK);
-		xasprintf(&sc_auth.output, "Login succeded");
+		xasprintf(&sc_auth.output, "Login succeeded");
 
 		if (strcmp(config.authtype, "LOGIN") == 0) {
 			char *abuf;

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -489,7 +489,6 @@ int main(int argc, char **argv) {
 
 		if (strcmp(config.authtype, "LOGIN") == 0) {
 			char *abuf;
-			int ret;
 			do {
 				/* send AUTH LOGIN */
 				my_send(config, SMTP_AUTH_LOGIN, strlen(SMTP_AUTH_LOGIN), socket_descriptor,
@@ -499,8 +498,8 @@ int main(int argc, char **argv) {
 					printf(_("sent %s\n"), "AUTH LOGIN");
 				}
 
-				if ((ret = recvlines(config, buffer, MAX_INPUT_BUFFER, socket_descriptor,
-									 ssl_established)) <= 0) {
+				if ((recvlines(config, buffer, MAX_INPUT_BUFFER, socket_descriptor,
+							   ssl_established)) <= 0) {
 					xasprintf(&sc_auth.output, _("recv() failed after AUTH LOGIN"));
 					sc_auth = mp_set_subcheck_state(sc_auth, STATE_WARNING);
 					break;
@@ -524,8 +523,8 @@ int main(int argc, char **argv) {
 					printf(_("sent %s\n"), abuf);
 				}
 
-				if ((ret = recvlines(config, buffer, MAX_INPUT_BUFFER, socket_descriptor,
-									 ssl_established)) <= 0) {
+				if ((recvlines(config, buffer, MAX_INPUT_BUFFER, socket_descriptor,
+							   ssl_established)) <= 0) {
 					xasprintf(&sc_auth.output, "recv() failed after sending authuser");
 					sc_auth = mp_set_subcheck_state(sc_auth, STATE_CRITICAL);
 					break;
@@ -550,8 +549,8 @@ int main(int argc, char **argv) {
 					printf(_("sent %s\n"), abuf);
 				}
 
-				if ((ret = recvlines(config, buffer, MAX_INPUT_BUFFER, socket_descriptor,
-									 ssl_established)) <= 0) {
+				if ((recvlines(config, buffer, MAX_INPUT_BUFFER, socket_descriptor,
+							   ssl_established)) <= 0) {
 					xasprintf(&sc_auth.output, "recv() failed after sending authpass");
 					sc_auth = mp_set_subcheck_state(sc_auth, STATE_CRITICAL);
 					break;

--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -474,6 +474,8 @@ int main(int argc, char **argv) {
 				xasprintf(&sc_expected_responses.output, "regexec execute error: %s", errbuf);
 				sc_expected_responses = mp_set_subcheck_state(sc_expected_responses, STATE_UNKNOWN);
 			}
+
+			mp_add_subcheck_to_check(&overall, sc_expected_responses);
 		}
 		counter++;
 	}


### PR DESCRIPTION
The subcheck for authentication in `check_smtp` had not output set for successful authentication. This patch set fixes this.

Additionaly it removes an unused variable.

And the test for an expected response was not used at all.

fixes #2284 