### PR TITLE
configure.ac,plugins/common.h: update sys/poll.h -> poll.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -598,7 +598,7 @@ dnl Checks for header files.
 dnl
 
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS(signal.h syslog.h uio.h errno.h sys/time.h sys/socket.h sys/un.h sys/poll.h)
+AC_CHECK_HEADERS(signal.h syslog.h uio.h errno.h sys/time.h sys/socket.h sys/un.h poll.h)
 AC_CHECK_HEADERS(features.h stdarg.h sys/unistd.h ctype.h)
 AC_CHECK_HEADERS_ONCE([sys/time.h])
 

--- a/plugins/common.h
+++ b/plugins/common.h
@@ -115,8 +115,8 @@
 
 #include <locale.h>
 
-#ifdef HAVE_SYS_POLL_H
-#	include "sys/poll.h"
+#ifdef HAVE_POLL_H
+#	include <poll.h>
 #endif
 
 /*


### PR DESCRIPTION
Make these warnings go away:

```
In file included from ../plugins/common.h:119,
                 from check_icmp.c:46:
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
  1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
    |  ^~~~~~~
```

The bare `<poll.h>` is correct according to POSIX (and not just my libc): https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/poll.h.html

There's one more sys/poll.h hiding behind an `#if` for Solaris and HPUX that I left alone since I know nothing about those.
