### PR TITLE
CI: Add build and unit tests on FreeBSD, OpenBSD and NetBSD

### DIFF
--- a/.github/workflows/test-unix.yml
+++ b/.github/workflows/test-unix.yml
@@ -19,6 +19,10 @@ on:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
+  push:
+    branches:
+      - '*'
+  pull_request:
 
 jobs:
   freebsd:

--- a/.github/workflows/test-unix.yml
+++ b/.github/workflows/test-unix.yml
@@ -1,0 +1,102 @@
+---
+name: Tests on other Unixes
+
+# Build and run the self-contained unit tests on the Unixes that
+# configure.ac has explicit support for but that GitHub does not offer as a
+# hosted runner. Each job boots a QEMU VM via the vmactions actions.
+#
+# These jobs deliberately do NOT run the top level "make test": that suite
+# needs a full service zoo (apache, squid, slapd, mariadb, postfix, snmpd,
+# sshd, ...) which .github/prepare_debian.sh sets up only for the Linux job.
+# What is exercised here is the autotools bootstrap, the C build of every
+# plugin, and the standalone libtap unit tests under lib/tests.
+
+on:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+jobs:
+  freebsd:
+    name: Running build and unit tests on FreeBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v7
+      - name: Build and test in a FreeBSD VM
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          cache-after-prepare: true
+          prepare: |
+            pkg install -y autoconf automake gmake
+          run: |
+            set -e
+            uname -a
+            tools/setup
+            ./configure --enable-libtap
+            gmake
+            cd lib && gmake test
+
+  openbsd:
+    name: Running build and unit tests on OpenBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v7
+      - name: Build and test in an OpenBSD VM
+        uses: vmactions/openbsd-vm@v1
+        with:
+          usesh: true
+          cache-after-prepare: true
+          # OpenBSD carries about eighteen parallel autoconf packages and a
+          # dozen automake ones, so pkg_add needs an exact version and the
+          # metaauto wrappers then dispatch on AUTO*_VERSION. Both are
+          # resolved at run time -- the newest the mirror offers, and the
+          # version read back off the binary that pkg_add installed -- so
+          # nothing here needs revisiting when the next release lands.
+          prepare: |
+            set -e
+            newest() {
+              pkg_info -Q "$1" | grep -E "^$1-[0-9]" | sort -V | tail -1
+            }
+            pkg_add -I "$(newest autoconf)" "$(newest automake)" gmake
+          run: |
+            set -e
+            AUTOCONF_VERSION=$(ls /usr/local/bin/autoconf-* | sed 's:.*/autoconf-::' | sort -V | tail -1)
+            AUTOMAKE_VERSION=$(ls /usr/local/bin/automake-* | sed 's:.*/automake-::' | sort -V | tail -1)
+            export AUTOCONF_VERSION AUTOMAKE_VERSION
+            echo "autoconf $AUTOCONF_VERSION, automake $AUTOMAKE_VERSION"
+            uname -a
+            tools/setup
+            ./configure --enable-libtap
+            gmake
+            cd lib && gmake test
+
+  netbsd:
+    name: Running build and unit tests on NetBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v7
+      - name: Build and test in a NetBSD VM
+        uses: vmactions/netbsd-vm@v1
+        with:
+          usesh: true
+          cache-after-prepare: true
+          prepare: |
+            /usr/sbin/pkg_add -u autoconf automake gmake perl
+          run: |
+            set -e
+            uname -a
+            tools/setup
+            ./configure --enable-libtap
+            gmake
+            cd lib && gmake test

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -27,4 +27,4 @@ libmonitoringplug_a_SOURCES += parse_ini.c extra_opts.c
 endif USE_PARSE_INI
 
 test test-debug:
-	cd tests && make $@
+	cd tests && $(MAKE) $@

--- a/plugins-root/check_icmp.d/config.h
+++ b/plugins-root/check_icmp.d/config.h
@@ -3,6 +3,7 @@
 #include "../../config.h"
 #include "../../lib/states.h"
 #include <stddef.h>
+#include <sys/time.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>


### PR DESCRIPTION
Refs #2160.

Adds `.github/workflows/test-unix.yml` with one job per platform. Each boots a
QEMU VM on the normal `ubuntu-latest` runner using the `vmactions` actions @sni
mentioned in the issue, then runs `tools/setup` -> `./configure --enable-libtap`
-> `make` -> the `lib/tests` unit tests.

Triggers are `push` and `pull_request` plus `workflow_dispatch`, the same as
`test.yml`.

### What it covers, and what it deliberately does not

The top level `make test` is **not** run in the VMs. It depends on the service
zoo that `.github/prepare_debian.sh` builds (apache, squid, slapd, mariadb,
postfix, snmpd, sshd), which is not reasonable to reproduce three more times.
What these jobs cover is the autotools bootstrap, the full C build of every
plugin, and the self-contained libtap unit tests under `lib/tests`.

### Verification

https://github.com/neilpang/monitoring-plugins/actions/runs/30911208131

| | FreeBSD 15.1-RELEASE-p1 | OpenBSD 7.9 | NetBSD 11.0 |
|---|---|---|---|
| `CC`/`CCLD` invocations | 196 | 201 | 211 |
| libtap | Files=10, Tests=265, PASS | same | same |

### The two fixes that come with it

**`check_icmp` does not build on NetBSD.**

```
check_icmp.d/./config.h:88:17: error: field 'stime' has incomplete type
   88 |  struct timeval stime;
```

`plugins-root/check_icmp.d/config.h` uses `struct timeval` without including
`<sys/time.h>`. Linux and FreeBSD pull it in transitively; NetBSD does not.

**`lib/Makefile.am` recursed with a bare `make`.**

It used `cd tests && make $@` where every other recursive rule in the tree uses
`$(MAKE)`, so the recursion swapped make implementation halfway through.

The committed `lib/tests/test_generic_output` binary and its missing
`.gitignore` entry were in an earlier version of this PR; #2305 handled both
upstream, so those hunks are gone and `test_generic_output` now builds and runs
on all three BSDs -- which is where the jump from 246 to 265 subtests comes
from.

### OpenBSD versions are resolved at run time

Per @oxzi: nothing is pinned. `pkg_add` installs the newest `autoconf` and
`automake` the mirror offers, and `AUTOCONF_VERSION`/`AUTOMAKE_VERSION` are read
back off the binaries it installed, which is what the `metaauto` wrappers
dispatch on. The run above resolved autoconf 2.72 and automake 1.18.

### Not covered

- **Solaris**: a separate PR, as agreed. The job is green on Solaris 11.4; it
  needed fixes in four files, two of which are not Solaris-specific --
  `lib/tests/test_cmd.c` never NULL-terminates its argv array and so reads
  uninitialised memory on every platform, and `check_swap`'s SVR4 branch calls
  `getSwapFromSwapctl_SRV4()` while the function is named
  `getSwapFromSwap_SRV4()`, so that path has never been compiled by anything.
- **`gnutls` instead of `openssl`, and no-TLS builds**: not attempted here.
