### PR TITLE
Remove CGIURL everywhere

### DIFF
--- a/README
+++ b/README
@@ -51,12 +51,10 @@ Installation Instructions
 2.  Run the configure script to initialize variables and create a Makefile,
     etc.
 
-    	./configure --prefix=BASEDIRECTORY --with-cgiurl=SOMEURL
+    	./configure --prefix=BASEDIRECTORY
 
     Replace `BASEDIRECTORY` with the path of the directory under which your
-    monitoring system is installed (default is `/usr/local`), and replace
-    `SOMEURL` with the path used to access the monitoring system CGIs with a
-    web browser (default is `/nagios/cgi-bin`).
+    monitoring system is installed (default is `/usr/local`).
 
 3.  Compile the plugins with the following command:
 

--- a/configure.ac
+++ b/configure.ac
@@ -64,15 +64,6 @@ AC_SUBST(WARRANTY)
 SUPPORT="Send email to help@monitoring-plugins.org if you have questions regarding use\nof this software. To submit patches or suggest improvements, send email to\ndevel@monitoring-plugins.org. Please include version information with all\ncorrespondence (when possible, use output from the --version option of the\nplugin itself).\n"
 AC_SUBST(SUPPORT)
 
-dnl CGIURL has changed for Nagios with 1.0 beta
-AC_ARG_WITH(cgiurl,
-	ACX_HELP_STRING([--with-cgiurl=DIR],
-		[sets URL for cgi programs]),
-	with_cgiurl=$withval,
-	with_cgiurl=/nagios/cgi-bin)
-CGIURL="$with_cgiurl"
-AC_DEFINE_UNQUOTED(CGIURL,"$CGIURL",[URL of CGI programs])
-
 AC_ARG_WITH(trusted_path,
 	ACX_HELP_STRING([--with-trusted-path=PATH],
 		[sets trusted path for executables called by scripts]),
@@ -1965,7 +1956,6 @@ ACX_FEATURE([with],[gnutls])
 ACX_FEATURE([enable],[extra-opts])
 ACX_FEATURE([with],[perl])
 ACX_FEATURE([enable],[perl-modules])
-ACX_FEATURE([with],[cgiurl])
 ACX_FEATURE([with],[trusted-path])
 ACX_FEATURE([enable],[libtap])
 ACX_FEATURE([with],[libcurl])

--- a/plugins/check_ping.c
+++ b/plugins/check_ping.c
@@ -148,9 +148,6 @@ int main(int argc, char **argv) {
 			die(STATE_OK, "%s is alive\n", config.addresses[i]);
 		}
 
-		if (config.display_html) {
-			printf("<A HREF='%s/traceroute.cgi?%s'>", CGIURL, config.addresses[i]);
-		}
 		if (pinged.packet_loss == 100) {
 			printf(_("PING %s - %sPacket loss = %d%%"), state_text(pinged.state), warn_text,
 				   pinged.packet_loss);


### PR DESCRIPTION
Recently renoticed that `CGIURL` thing again and since it is only ever used in `check_ping` and my best guess is, that nobody needs that "feature" anymore I am going to remove it and reduce our code size a bit.