### PR TITLE
Fix check_smtp using the wrong port accidentaly if -D was used before -S

### DIFF
--- a/plugins/check_smtp.c
+++ b/plugins/check_smtp.c
@@ -660,7 +660,6 @@ check_smtp_config_wrapper process_arguments(int argc, char **argv) {
 
 	unsigned long command_size = 0;
 	unsigned long response_size = 0;
-	bool implicit_tls = false;
 	int server_port_option = 0;
 	while (true) {
 		int opt_index =
@@ -792,8 +791,7 @@ check_smtp_config_wrapper process_arguments(int argc, char **argv) {
 #else
 			usage(_("SSL support not available - install OpenSSL and recompile"));
 #endif
-			implicit_tls = true;
-			// fallthrough
+			break;
 		case 's':
 			/* ssl */
 			result.config.use_ssl = true;
@@ -864,11 +862,12 @@ check_smtp_config_wrapper process_arguments(int argc, char **argv) {
 	}
 
 	if (result.config.use_starttls && result.config.use_ssl) {
-		if (implicit_tls) {
-			result.config.use_ssl = false;
-		} else {
-			usage4(_("Set either -s/--ssl/--tls or -S/--starttls"));
-		}
+		usage4(_("Set either -s/--ssl/--tls or -S/--starttls"));
+	}
+
+	if (!result.config.use_starttls && !result.config.use_ssl &&
+		(result.config.days_till_exp_crit != 0 || result.config.days_till_exp_warn != 0)) {
+		usage4(_("Set either -s/--ssl/--tls or -S/--starttls"));
 	}
 
 	if (server_port_option != 0) {

--- a/plugins/check_smtp.d/config.h
+++ b/plugins/check_smtp.d/config.h
@@ -53,7 +53,7 @@ typedef struct {
 	mp_output_format output_format;
 } check_smtp_config;
 
-check_smtp_config check_smtp_config_init() {
+check_smtp_config check_smtp_config_init(void) {
 	check_smtp_config tmp = {
 		.server_port = SMTP_PORT,
 		.server_address = NULL,


### PR DESCRIPTION
If the parameters were in the wrong order (where order was not specified, nor should it have been), `check_smtp` chose the wrong port to connect to a server.
This fixes this behaviour and requires now explicit setting of either TLS or STARTTLS for the connection.

fixes #2301 