### PR TITLE
check_snmp: fix two build failures against net-snmp

### DIFF
--- a/plugins/check_snmp.d/check_snmp_helpers.c
+++ b/plugins/check_snmp.d/check_snmp_helpers.c
@@ -898,7 +898,7 @@ state_key np_enable_state(char *keyname, int expected_data_version, const char *
 char *_np_state_generate_key(int argc, char **argv) {
 	unsigned char result[256];
 
-#ifdef USE_OPENSSL
+#ifdef MOPL_USE_OPENSSL
 	/*
 	 * This code path is chosen if openssl is available (which should be the most common
 	 * scenario). Alternatively, the gnulib implementation/
@@ -922,7 +922,7 @@ char *_np_state_generate_key(int argc, char **argv) {
 	}
 
 	sha256_finish_ctx(&ctx, result);
-#endif // FOUNDOPENSSL
+#endif // MOPL_USE_OPENSSL
 
 	char keyname[41];
 	for (int i = 0; i < 20; ++i) {

--- a/plugins/check_snmp.d/check_snmp_helpers.c
+++ b/plugins/check_snmp.d/check_snmp_helpers.c
@@ -127,7 +127,7 @@ check_snmp_config check_snmp_config_init() {
 	snmp_sess_init(&tmp.snmp_params.snmp_session);
 
 	tmp.snmp_params.snmp_session.retries = DEFAULT_RETRIES;
-	tmp.snmp_params.snmp_session.version = DEFAULT_SNMP_VERSION;
+	tmp.snmp_params.snmp_session.version = SNMP_VERSION_3;
 	tmp.snmp_params.snmp_session.securityLevel = SNMP_SEC_LEVEL_NOAUTH;
 	tmp.snmp_params.snmp_session.community = (unsigned char *)"public";
 	tmp.snmp_params.snmp_session.community_len = strlen("public");


### PR DESCRIPTION
Two independent build failures in `check_snmp`, reproduced with net-snmp 5.9.5.2 on macOS.
Neither is platform specific. One commit each.

**1.** `_np_state_generate_key()` still tests `USE_OPENSSL`, which #2253 renamed to `MOPL_USE_OPENSSL`. `lib/utils_base.h` includes `sha256.h` only when `MOPL_USE_OPENSSL` is undefined, so an OpenSSL build compiles the gnulib branch without its declarations:

```
check_snmp_helpers.c:918:20: error: variable has incomplete type 'struct sha256_ctx'
check_snmp_helpers.c:921:3: error: use of undeclared identifier 'sha256_process_bytes'
```

**2.** `DEFAULT_SNMP_VERSION` is a legacy alias that net-snmp defines only when `NETSNMP_NO_LEGACY_DEFINITIONS` is unset:

```
check_snmp_helpers.c:130:41: error: use of undeclared identifier 'DEFAULT_SNMP_VERSION'
```

It also expands to the version number (1/2/3), not the `SNMP_VERSION_*` encoding the field expects. Compile-only change: the value is overwritten in every path, by `-P` or by the existing v2c fallback.