### PR TITLE
Replace last remaining USE_OPENSSL

### DIFF
--- a/plugins/check_curl.d/check_curl_helpers.h
+++ b/plugins/check_curl.d/check_curl_helpers.h
@@ -3,7 +3,7 @@
 #include "../picohttpparser/picohttpparser.h"
 #include "output.h"
 
-#if defined(HAVE_SSL) && defined(USE_OPENSSL)
+#if defined(HAVE_SSL) && defined(MOPL_USE_OPENSSL)
 #	include <openssl/opensslv.h>
 #endif
 


### PR DESCRIPTION
Replace the last occurence of `USE_OPENSSL` with our `MOPL_USE_OPENSSL`.