### PR TITLE
Homogenous DBG printing

### DIFF
--- a/plugins/check_ntp_peer.c
+++ b/plugins/check_ntp_peer.c
@@ -136,13 +136,6 @@ typedef struct {
 #define SIZEOF_NTPCM(m)                                                                            \
 	(12 + ntohs(m.count) + ((ntohs(m.count) % 4) ? 4 - (ntohs(m.count) % 4) : 0))
 
-/* finally, a little helper or two for debugging: */
-#define DBG(x)                                                                                     \
-	do {                                                                                           \
-		if (verbose > 1) {                                                                         \
-			x;                                                                                     \
-		}                                                                                          \
-	} while (0);
 #define PRINTSOCKADDR(x)                                                                           \
 	do {                                                                                           \
 		printf("%u.%u.%u.%u", (x >> 24) & 0xff, (x >> 16) & 0xff, (x >> 8) & 0xff, x & 0xff);      \
@@ -250,14 +243,14 @@ ntp_request_result ntp_request(const check_ntp_peer_config config) {
 	size_t npeers = 0;
 	do {
 		setup_control_request(&req, OP_READSTAT, 1);
-		DBG(printf("sending READSTAT request"));
+		DBG_PRINT_1("sending READSTAT request");
 		write(conn, &req, SIZEOF_NTPCM(req));
 		DBG(print_ntp_control_message(&req));
 
 		do {
 			/* Attempt to read the largest size packet possible */
 			req.count = htons(MAX_CM_SIZE);
-			DBG(printf("receiving READSTAT response"))
+			DBG_PRINT_1("receiving READSTAT response")
 			if (read(conn, &req, SIZEOF_NTPCM(req)) == -1) {
 				die(STATE_CRITICAL, "NTP CRITICAL: No response from NTP server\n");
 			}
@@ -303,24 +296,18 @@ ntp_request_result ntp_request(const check_ntp_peer_config config) {
 		}
 	}
 
-	if (verbose) {
-		printf("%d candidate peers available\n", num_candidates);
-		if (result.syncsource_found) {
-			printf("synchronization source found\n");
-		}
+	DBG_PRINT_1("%d candidate peers available\n", num_candidates);
+	if (result.syncsource_found) {
+		DBG_PRINT_1("synchronization source found\n");
 	}
 
 	if (!result.syncsource_found) {
 		result.state = STATE_WARNING;
-		if (verbose) {
-			printf("warning: no synchronization source found\n");
-		}
+		DBG_PRINT_1("warning: no synchronization source found\n");
 	}
 	if (result.li_alarm) {
 		result.state = STATE_WARNING;
-		if (verbose) {
-			printf("warning: LI_ALARM bit is set\n");
-		}
+		DBG_PRINT_1("warning: LI_ALARM bit is set\n");
 	}
 
 	const char *getvar = "stratum,offset,jitter";
@@ -329,9 +316,8 @@ ntp_request_result ntp_request(const check_ntp_peer_config config) {
 		/* Only query this server if it is the current sync source */
 		/* If there's no sync.peer, query all candidates and use the best one */
 		if (PEER_SEL(peers[i].status) >= min_peer_sel) {
-			if (verbose) {
-				printf("Getting offset, jitter and stratum for peer %.2x\n", ntohs(peers[i].assoc));
-			}
+			DBG_PRINT_1("Getting offset, jitter and stratum for peer %.2x\n",
+						ntohs(peers[i].assoc));
 			data = strdup("");
 			do {
 				setup_control_request(&req, OP_READVAR, 2);
@@ -345,13 +331,13 @@ ntp_request_result ntp_request(const check_ntp_peer_config config) {
 				 * error on the first pass we redo it with "dispersion" */
 				strncpy(req.data, getvar, MAX_CM_SIZE - 1);
 				req.count = htons(strlen(getvar));
-				DBG(printf("sending READVAR request...\n"));
+				DBG_PRINT_1("sending READVAR request...\n");
 				write(conn, &req, SIZEOF_NTPCM(req));
 				DBG(print_ntp_control_message(&req));
 
 				do {
 					req.count = htons(MAX_CM_SIZE);
-					DBG(printf("receiving READVAR response...\n"));
+					DBG_PRINT_1("receiving READVAR response...\n");
 					read(conn, &req, SIZEOF_NTPCM(req));
 					DBG(print_ntp_control_message(&req));
 				} while (!(req.op & OP_READVAR && ntohs(req.seq) == 2));
@@ -363,36 +349,30 @@ ntp_request_result ntp_request(const check_ntp_peer_config config) {
 
 			if (req.op & REM_ERROR) {
 				if (strstr(getvar, "jitter")) {
-					if (verbose) {
-						printf("The command failed. This is usually caused by servers refusing the "
-							   "'jitter'\nvariable. Restarting with "
-							   "'dispersion'...\n");
-					}
+					DBG_PRINT_1(
+						"The command failed. This is usually caused by servers refusing the "
+						"'jitter'\nvariable. Restarting with "
+						"'dispersion'...\n");
 					getvar = "stratum,offset,dispersion";
 					i--;
 					continue;
 				}
 				if (strlen(getvar)) {
-					if (verbose) {
-						printf("Server didn't like dispersion either; will retrieve everything\n");
-					}
+					DBG_PRINT_1("Server didn't like dispersion either; will retrieve everything\n");
 					getvar = "";
 					i--;
 					continue;
 				}
 			}
 
-			if (verbose > 1) {
-				printf("Server responded: >>>%s<<<\n", data);
-			}
+			DBG_PRINT_1("Server responded: >>>%s<<<\n", data);
 
 			double tmp_offset = 0;
 			char *value;
 			char *nptr;
 			/* get the offset */
-			if (verbose) {
-				printf("parsing offset from peer %.2x: ", ntohs(peers[i].assoc));
-			}
+
+			DBG_PRINT_1("parsing offset from peer %.2x: ", ntohs(peers[i].assoc));
 
 			value = np_extract_ntpvar(data, "offset");
 			nptr = NULL;
@@ -402,13 +382,9 @@ ntp_request_result ntp_request(const check_ntp_peer_config config) {
 			}
 			/* If value is null or no conversion was performed */
 			if (value == NULL || value == nptr) {
-				if (verbose) {
-					printf("error: unable to read server offset response.\n");
-				}
+				DBG_PRINT_1("error: unable to read server offset response.\n");
 			} else {
-				if (verbose) {
-					printf("%.10g\n", tmp_offset);
-				}
+				DBG_PRINT_1("%.10g\n", tmp_offset);
 				if (result.offset_result == STATE_UNKNOWN ||
 					fabs(tmp_offset) < fabs(result.offset)) {
 					result.offset = tmp_offset;
@@ -421,11 +397,9 @@ ntp_request_result ntp_request(const check_ntp_peer_config config) {
 
 			if (config.do_jitter) {
 				/* get the jitter */
-				if (verbose) {
-					printf("parsing %s from peer %.2x: ",
-						   strstr(getvar, "dispersion") != NULL ? "dispersion" : "jitter",
-						   ntohs(peers[i].assoc));
-				}
+				DBG_PRINT_1("parsing %s from peer %.2x: ",
+							strstr(getvar, "dispersion") != NULL ? "dispersion" : "jitter",
+							ntohs(peers[i].assoc));
 				value = np_extract_ntpvar(data, strstr(getvar, "dispersion") != NULL ? "dispersion"
 																					 : "jitter");
 				nptr = NULL;
@@ -435,20 +409,16 @@ ntp_request_result ntp_request(const check_ntp_peer_config config) {
 				}
 				/* If value is null or no conversion was performed */
 				if (value == NULL || value == nptr) {
-					if (verbose) {
-						printf("error: unable to read server jitter/dispersion response.\n");
-					}
+					DBG_PRINT_1("error: unable to read server jitter/dispersion response.\n");
 					result.jitter = -1;
-				} else if (verbose) {
-					printf("%.10g\n", result.jitter);
+				} else {
+					DBG_PRINT_1("%.10g\n", result.jitter);
 				}
 			}
 
 			if (config.do_stratum) {
 				/* get the stratum */
-				if (verbose) {
-					printf("parsing stratum from peer %.2x: ", ntohs(peers[i].assoc));
-				}
+				DBG_PRINT_1("parsing stratum from peer %.2x: ", ntohs(peers[i].assoc));
 				value = np_extract_ntpvar(data, "stratum");
 				nptr = NULL;
 				/* Convert the value if we have one */
@@ -456,14 +426,10 @@ ntp_request_result ntp_request(const check_ntp_peer_config config) {
 					result.stratum = strtol(value, &nptr, 10);
 				}
 				if (value == NULL || value == nptr) {
-					if (verbose) {
-						printf("error: unable to read server stratum response.\n");
-					}
+					DBG_PRINT_1("error: unable to read server stratum response.\n");
 					result.stratum = -1;
 				} else {
-					if (verbose) {
-						printf("%li\n", result.stratum);
-					}
+					DBG_PRINT_1("%li\n", result.stratum);
 				}
 			}
 		} /* if (PEER_SEL(peers[i].status) >= min_peer_sel) */

--- a/plugins/check_ntp_time.c
+++ b/plugins/check_ntp_time.c
@@ -202,13 +202,6 @@ static double TVasDOUBLE(struct timeval time) {
  */
 #define SIZEOF_NTPCM(m) (12 + ntohs(m.count) + ((m.count) ? 4 - (ntohs(m.count) % 4) : 0))
 
-/* finally, a little helper or two for debugging: */
-#define DBG(x)                                                                                     \
-	do {                                                                                           \
-		if (verbose > 1) {                                                                         \
-			x;                                                                                     \
-		}                                                                                          \
-	} while (0);
 #define PRINTSOCKADDR(x)                                                                           \
 	do {                                                                                           \
 		printf("%u.%u.%u.%u", (x >> 24) & 0xff, (x >> 16) & 0xff, (x >> 8) & 0xff, x & 0xff);      \
@@ -276,49 +269,45 @@ static int best_offset_server(const ntp_server_results *slist, int nservers) {
 		 * stratum 0 is for reference clocks so no NTP server should ever report
 		 * a stratum 0 */
 		if (slist[cserver].stratum == 0) {
-			if (verbose) {
-				printf("discarding peer %d: stratum=%d\n", cserver, slist[cserver].stratum);
-			}
+			DBG_PRINT_1("discarding peer %d: stratum=%d\n", cserver, slist[cserver].stratum);
 			continue;
 		}
 		/* Sort out servers with error flags */
 		if (LI(slist[cserver].flags) == LI_ALARM) {
-			if (verbose) {
-				printf("discarding peer %d: flags=%d\n", cserver, LI(slist[cserver].flags));
-			}
+			DBG_PRINT_1("discarding peer %d: flags=%d\n", cserver, LI(slist[cserver].flags));
 			continue;
 		}
 
 		/* If we don't have a server yet, use the first one */
 		if (best_server_index == -1) {
 			best_server_index = cserver;
-			DBG(printf("using peer %d as our first candidate\n", best_server_index));
+			DBG_PRINT_1("using peer %d as our first candidate\n", best_server_index);
 			continue;
 		}
 
 		/* compare the server to the best one we've seen so far */
 		/* does it have an equal or better stratum? */
-		DBG(printf("comparing peer %d with peer %d\n", cserver, best_server_index));
+		DBG_PRINT_1("comparing peer %d with peer %d\n", cserver, best_server_index);
 		if (slist[cserver].stratum <= slist[best_server_index].stratum) {
-			DBG(printf("stratum for peer %d <= peer %d\n", cserver, best_server_index));
+			DBG_PRINT_1("stratum for peer %d <= peer %d\n", cserver, best_server_index);
 			/* does it have an equal or better dispersion? */
 			if (slist[cserver].rtdisp <= slist[best_server_index].rtdisp) {
-				DBG(printf("dispersion for peer %d <= peer %d\n", cserver, best_server_index));
+				DBG_PRINT_1("dispersion for peer %d <= peer %d\n", cserver, best_server_index);
 				/* does it have a better rtdelay? */
 				if (slist[cserver].rtdelay < slist[best_server_index].rtdelay) {
-					DBG(printf("rtdelay for peer %d < peer %d\n", cserver, best_server_index));
+					DBG_PRINT_1("rtdelay for peer %d < peer %d\n", cserver, best_server_index);
 					best_server_index = cserver;
-					DBG(printf("peer %d is now our best candidate\n", best_server_index));
+					DBG_PRINT_1("peer %d is now our best candidate\n", best_server_index);
 				}
 			}
 		}
 	}
 
 	if (best_server_index >= 0) {
-		DBG(printf("best server selected: peer %d\n", best_server_index));
+		DBG_PRINT_1("best server selected: peer %d\n", best_server_index);
 		return best_server_index;
 	}
-	DBG(printf("no peers meeting synchronization criteria :(\n"));
+	DBG_PRINT_1("no peers meeting synchronization criteria :(\n");
 	return -1;
 }
 
@@ -382,13 +371,13 @@ static offset_request_wrapper offset_request(const char *host, const char *port,
 		die(STATE_UNKNOWN, "can not allocate server array");
 	}
 	memset(servers, 0, sizeof(ntp_server_results) * num_hosts);
-	DBG(printf("Found %zu peers to check\n", num_hosts));
+	DBG_PRINT_1("Found %zu peers to check\n", num_hosts);
 
 	/* setup each socket for writing, and the corresponding struct pollfd */
 	if (is_socket) {
 		socklist[0] = socket(AF_UNIX, SOCK_STREAM, 0);
 		if (socklist[0] == -1) {
-			DBG(printf("can't create socket: %s\n", strerror(errno)));
+			DBG_PRINT_1("can't create socket: %s\n", strerror(errno));
 			die(STATE_UNKNOWN, "can not create new socket\n");
 		}
 
@@ -406,7 +395,7 @@ static offset_request_wrapper offset_request(const char *host, const char *port,
 			   answering in time. This also would break for dual ipv4/6 stacked
 			   ntp servers when the client only supports on of them.
 			 */
-			DBG(printf("can't create socket connection on peer %i: %s\n", 0, strerror(errno)));
+			DBG_PRINT_1("can't create socket connection on peer %i: %s\n", 0, strerror(errno));
 		} else {
 			ufds[0].fd = socklist[0];
 			ufds[0].events = POLLIN;
@@ -425,7 +414,7 @@ static offset_request_wrapper offset_request(const char *host, const char *port,
 				   answering in time. This also would break for dual ipv4/6 stacked
 				   ntp servers when the client only supports on of them.
 				 */
-				DBG(printf("can't create socket connection on peer %i: %s\n", i, strerror(errno)));
+				DBG_PRINT_1("can't create socket connection on peer %i: %s\n", i, strerror(errno));
 			} else {
 				ufds[i].fd = socklist[i];
 				ufds[i].events = POLLIN;
@@ -451,12 +440,10 @@ static offset_request_wrapper offset_request(const char *host, const char *port,
 
 		for (size_t i = 0; i < num_hosts; i++) {
 			if (servers[i].waiting < now_time && servers[i].num_responses < AVG_NUM) {
-				if (verbose && servers[i].waiting != 0) {
-					printf("re-");
+				if (servers[i].waiting != 0) {
+					DBG_PRINT_1("re-");
 				}
-				if (verbose) {
-					printf("sending request to peer %zu\n", i);
-				}
+				DBG_PRINT_1("sending request to peer %zu\n", i);
 				setup_request(&req[i]);
 				write(socklist[i], &req[i], sizeof(ntp_message));
 				servers[i].waiting = now_time;
@@ -474,9 +461,7 @@ static offset_request_wrapper offset_request(const char *host, const char *port,
 		/* read from any sockets with pending data */
 		for (size_t i = 0; servers_readable && i < num_hosts; i++) {
 			if (ufds[i].revents & POLLIN && servers[i].num_responses < AVG_NUM) {
-				if (verbose) {
-					printf("response from peer %zu: ", i);
-				}
+				DBG_PRINT_1("response from peer %zu: ", i);
 
 				read(ufds[i].fd, &req[i], sizeof(ntp_message));
 
@@ -485,9 +470,9 @@ static offset_request_wrapper offset_request(const char *host, const char *port,
 				DBG(print_ntp_message(&req[i]));
 				int respnum = servers[i].num_responses++;
 				servers[i].offset[respnum] = calc_offset(&req[i], &recv_time) + time_offset;
-				if (verbose) {
-					printf("offset %.10g\n", servers[i].offset[respnum]);
-				}
+
+				DBG_PRINT_1("offset %.10g\n", servers[i].offset[respnum]);
+
 				servers[i].stratum = req[i].stratum;
 				servers[i].rtdisp = NTP32asDOUBLE(req[i].rtdisp);
 				servers[i].rtdelay = NTP32asDOUBLE(req[i].rtdelay);
@@ -536,9 +521,7 @@ static offset_request_wrapper offset_request(const char *host, const char *port,
 	free(req);
 	freeaddrinfo(addresses);
 
-	if (verbose) {
-		printf("overall average offset: %.10g\n", avg_offset);
-	}
+	DBG_PRINT_1("overall average offset: %.10g\n", avg_offset);
 
 	result.offset = avg_offset;
 	return result;

--- a/plugins/utils.h
+++ b/plugins/utils.h
@@ -207,4 +207,23 @@ For more information about these matters, see the file named COPYING.\n")
  --output-format=OUTPUT_FORMAT\n\
     Select output format. Valid values: \"multi-line\", \"mp-test-json\"\n")
 
+/* finally, a little helper or two for debugging: */
+#define DBG(x)                                                                                     \
+	do {                                                                                           \
+		if (verbose > 1) {                                                                         \
+			x;                                                                                     \
+		}                                                                                          \
+	} while (0);
+
+#define DBG_PRINT(x, ...)                                                                          \
+	do {                                                                                           \
+		if (verbose > x) {                                                                         \
+			printf(0 __VA_OPT__(, ) __VA_ARGS__);                                                  \
+		}                                                                                          \
+	} while (0);
+
+#define DBG_PRINT_1(...) DBG_PRINT(1, 0 __VA_OPT__(, ) __VA_ARGS__);
+#define DBG_PRINT_2(...) DBG_PRINT(2, 0 __VA_OPT__(, ) __VA_ARGS__);
+#define DBG_PRINT_3(...) DBG_PRINT(3, 0 __VA_OPT__(, ) __VA_ARGS__);
+
 #endif /* NP_UTILS_H */


### PR DESCRIPTION
Adapts the debugging macros from `check_ntp_time` into the general part and uses them in `check_ntp_peer`, too.
I did not integrate it in the other plugins, this can be done step by step.

The change saves a few lines everywhere by remove the `if (verbose) { ... }` stuff.
Centralised debug printing might also later be used to redirect it or something.