### PR TITLE
check_mailq: Add support for opensmtp

### DIFF
--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -741,7 +741,7 @@ sub print_help () {
     print "-W (--warning-domain)  = Min. number of messages for same domain in queue to generate warning\n";
     print "-C (--critical-domain) = Min. number of messages for same domain in queue to generate critical alert ( W < C )\n";
     print "-t (--timeout)   = Plugin timeout in seconds (default = $utils::TIMEOUT)\n";
-    print "-M (--mailserver) = [ sendmail | qmail | postfix | exim | nullmailer ] (default = autodetect)\n";
+    print "-M (--mailserver) = [ sendmail | qmail | postfix | exim | nullmailer | opensmtp ] (default = autodetect)\n";
     print "-s (--sudo)      = DEPRECATED, ignored. Grant queue access via your MTA instead:\n";
     print "                   Postfix: authorized_mailq_users in main.cf (see postconf(5))\n";
     print "                   Exim: queue_list_requires_admin = false\n";

--- a/plugins-scripts/check_mailq.pl
+++ b/plugins-scripts/check_mailq.pl
@@ -574,6 +574,38 @@ elsif ( $mailq eq "nullmailer" ) {
     }
 } # end of ($mailq eq "nullmailer")
 
+elsif ( $mailq eq "opensmtp" ) {
+       ## open mailq
+       if ( defined $utils::PATH_TO_MAILQ && -x $utils::PATH_TO_MAILQ ) {
+               if (! open (MAILQ, "$utils::PATH_TO_MAILQ | " ) ) {
+                       print "ERROR: could not open $utils::PATH_TO_MAILQ \n";
+                       exit $ERRORS{'UNKNOWN'};
+               }
+       }elsif( defined $utils::PATH_TO_MAILQ){
+               unless (-x $utils::PATH_TO_MAILQ) {
+                       print "ERROR: $utils::PATH_TO_MAILQ is not executable by (uid $>:gid($)))\n";
+                       exit $ERRORS{'UNKNOWN'};
+               }
+       } else {
+               print "ERROR: \$utils::PATH_TO_MAILQ is not defined\n";
+               exit $ERRORS{'UNKNOWN'};
+       }
+
+       $msg_q++ while (<MAILQ>);
+
+       close(MAILQ) ;
+       if ($msg_q < $opt_w) {
+               $msg = "OK: $mailq mailq ($msg_q) is below threshold ($opt_w/$opt_c)";
+               $state = $ERRORS{'OK'};
+       }elsif ($msg_q >= $opt_w  && $msg_q < $opt_c) {
+               $msg = "WARNING: $mailq mailq is $msg_q (threshold w = $opt_w)";
+               $state = $ERRORS{'WARNING'};
+       }else {
+               $msg = "CRITICAL: $mailq mailq is $msg_q (threshold c = $opt_c)";
+               $state = $ERRORS{'CRITICAL'};
+       }
+} # end of ($mailq eq "opensmtp")
+
 # Perfdata support
 print "$msg|unsent=$msg_q;$opt_w;$opt_c;0\n";
 exit $state;
@@ -654,7 +686,7 @@ sub process_arguments(){
     }
 
     if (defined $opt_M) {
-        if ($opt_M =~ /^(sendmail|qmail|postfix|exim|nullmailer)$/) {
+        if ($opt_M =~ /^(sendmail|qmail|postfix|exim|nullmailer|opensmtp)$/) {
             $mailq = $opt_M ;
         }elsif( $opt_M eq ''){
             $mailq = 'sendmail';


### PR DESCRIPTION
This adds a OpenBSD patch to check_mailq directly here. The patch contains added support for the opensmtpd MRA server.

superceeds #1495
superceeds #1753
fixes #2328

All of this was just lying around since Perl is not my strong forte, but if it works on OpenBSD it is probably good enough
