### PR TITLE
check_snmp: detect missing OIDs

### DIFF
--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -399,7 +399,8 @@ static process_arguments_wrapper process_arguments(int argc, char **argv) {
 		connection_prefix_index,
 		output_format_index,
 		calculate_rate,
-		rate_multiplier
+		rate_multiplier,
+		missing_oid,
 	};
 
 	static struct option longopts[] = {
@@ -409,6 +410,7 @@ static process_arguments_wrapper process_arguments(int argc, char **argv) {
 		{"object", required_argument, 0, 'o'},
 		{"delimiter", required_argument, 0, 'd'},
 		{"nulloid", required_argument, 0, 'z'},
+		{"missing-oid", required_argument, 0, missing_oid},
 		{"output-delimiter", required_argument, 0, 'D'},
 		{"string", required_argument, 0, 's'},
 		{"timeout", required_argument, 0, 't'},
@@ -717,7 +719,16 @@ static process_arguments_wrapper process_arguments(int argc, char **argv) {
 			if (!is_integer(optarg)) {
 				usage2(_("Exit status must be a positive integer"), optarg);
 			} else {
+				// TODO: do real parsing here
 				config.evaluation_params.nulloid_result = atoi(optarg);
+			}
+			break;
+		case missing_oid: // What to do when an OID is missing in response
+			if (!is_integer(optarg)) {
+				usage2(_("Exit status must be a positive integer"), optarg);
+			} else {
+				// TODO: do real parsing here
+				config.evaluation_params.missing_oid_result = atoi(optarg);
 			}
 			break;
 		case 's': /* string or substring */

--- a/plugins/check_snmp.c
+++ b/plugins/check_snmp.c
@@ -1107,6 +1107,14 @@ void print_help(void) {
 	printf("    %s\n", _("1 = WARNING"));
 	printf("    %s\n", _("2 = CRITICAL"));
 	printf("    %s\n", _("3 = UNKNOWN"));
+	printf(" %s\n", "--missing-oid=#");
+	printf("    %s\n", _("If a query for an OID returns nothing (OID missing on the target)"));
+	printf("    %s\n", _("this option allows you to choose what status you want for this specific OID"));
+	printf("    %s\n", _("Excluding this option renders the default exit of 2 (CRITICAL)"));
+	printf("    %s\n", _("0 = OK"));
+	printf("    %s\n", _("1 = WARNING"));
+	printf("    %s\n", _("2 = CRITICAL"));
+	printf("    %s\n", _("3 = UNKNOWN"));
 
 	/* Tests Against Integers */
 	printf(" %s\n", "-w, --warning=THRESHOLD(s)");

--- a/plugins/check_snmp.d/check_snmp_helpers.c
+++ b/plugins/check_snmp.d/check_snmp_helpers.c
@@ -107,6 +107,7 @@ check_snmp_config check_snmp_config_init() {
 		.evaluation_params =
 			{
 				.nulloid_result = STATE_UNKNOWN, // state to return if no result for query
+				.missing_oid_result = STATE_CRITICAL,
 
 				.invert_search = true,
 				.regex_cmp_value = {},
@@ -290,7 +291,7 @@ snmp_responces do_snmp_query(check_snmp_config_snmp_parameters parameters) {
 			if (verbose) {
 				printf("Debug: Got a unmatched result type: %hhu\n", vars->type);
 			}
-			// TODO: Error here?
+			result.response_values[result.number_of_results].type = vars->type;
 			break;
 		}
 	}
@@ -540,6 +541,19 @@ check_snmp_evaluation evaluate_single_unit(response_value response,
 	case ASN_IPADDRESS:
 		// TODO
 		break;
+	default: {
+		// no known type
+		xasprintf(&sc_oid_test.output, "%s: no valid response", oid_string);
+		sc_oid_test = mp_set_subcheck_default_state(sc_oid_test, eval_params.missing_oid_result);
+		check_snmp_evaluation result = {
+			.sc = sc_oid_test,
+			.state = result_state,
+		};
+
+		return result;
+
+		break;
+	}
 	}
 
 	if (got_a_numerical_value) {

--- a/plugins/check_snmp.d/config.h
+++ b/plugins/check_snmp.d/config.h
@@ -51,6 +51,9 @@ typedef struct {
 	// State if an empty value is encountered
 	mp_state_enum nulloid_result;
 
+	// State if an OID is not available
+	mp_state_enum missing_oid_result;
+
 	// String evaluation stuff
 	bool invert_search;
 	regex_t regex_cmp_value; // regex to match query results against


### PR DESCRIPTION
This PR changes the behaviour of `check_snmp` when it encounters empty responses (= likely the OID does not exist on the agent).

A new parameter `--missing-oid` with the typical four states as argument allows setting the result state for this encounter to either ignore or alarm on such a condition. The default is CRITICAL.

fixes #1702 which was not true after 3.0.0, but the problem persisted in other ways after that.