### PR TITLE
check_icmp: Fix sockset.socket{4,6} detection and setsockopt(2) calls

### DIFF
--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -921,7 +921,7 @@ int main(int argc, char **argv) {
 	pledge("stdio inet", NULL);
 #endif // __OpenBSD__
 
-	if (sockset.socket4) {
+	if (sockset.socket4 != -1) {
 		int result = setsockopt(sockset.socket4, SOL_IP, IP_TTL, &config.ttl, sizeof(config.ttl));
 		if (debug) {
 			if (result == -1) {
@@ -932,7 +932,7 @@ int main(int argc, char **argv) {
 		}
 	}
 
-	if (sockset.socket6) {
+	if (sockset.socket6 != -1) {
 		int result = setsockopt(sockset.socket6, SOL_IP, IP_TTL, &config.ttl, sizeof(config.ttl));
 		if (debug) {
 			if (result == -1) {
@@ -1010,10 +1010,10 @@ int main(int argc, char **argv) {
 		   config.number_of_targets, &program_state, config.hosts, config.number_of_hosts,
 		   &overall);
 
-	if (sockset.socket4) {
+	if (sockset.socket4 != -1) {
 		close(sockset.socket4);
 	}
-	if (sockset.socket6) {
+	if (sockset.socket6 != -1) {
 		close(sockset.socket6);
 	}
 

--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -881,29 +881,40 @@ int main(int argc, char **argv) {
 		}
 
 #ifdef SO_TIMESTAMP
-		if (sockset.socket4 != -1) {
-			int on = 1;
-			if (setsockopt(sockset.socket4, SOL_SOCKET, SO_TIMESTAMP, &on, sizeof(on))) {
-				if (debug) {
-					printf("Warning: no SO_TIMESTAMP support\n");
-				}
-			}
-		}
-		if (sockset.socket6 != -1) {
-			int on = 1;
-			if (setsockopt(sockset.socket6, SOL_SOCKET, SO_TIMESTAMP, &on, sizeof(on))) {
-				if (debug) {
-					printf("Warning: no SO_TIMESTAMP support\n");
-				}
-			}
+		int on = 1;
+		if (setsockopt(sockset.socket4, SOL_SOCKET, SO_TIMESTAMP, &on, sizeof(on))) {
+			crash("setsockopt SO_TIMESTAMP");
+		} else if (debug) {
+			printf("enables reception of timestamp\n");
 		}
 #endif // SO_TIMESTAMP
+
+		if (setsockopt(sockset.socket4, IPPROTO_IP, IP_TTL, &config.ttl, sizeof(config.ttl))) {
+			crash("setsockopt IP_TTL");
+		} else if (debug) {
+			printf("ttl set to %d\n", config.ttl);
+		}
 	}
 
 	if (config.need_v6) {
 		sockset.socket6 = socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
 		if (sockset.socket6 == -1) {
 			crash("Failed to obtain ICMP v6 socket");
+		}
+
+#ifdef SO_TIMESTAMP
+		int on = 1;
+		if (setsockopt(sockset.socket6, SOL_SOCKET, SO_TIMESTAMP, &on, sizeof(on))) {
+			crash("setsockopt SO_TIMESTAMP");
+		} else if (debug) {
+			printf("enables reception of timestamp\n");
+		}
+#endif // SO_TIMESTAMP
+
+		if (setsockopt(sockset.socket6, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &config.ttl, sizeof(config.ttl))) {
+			crash("setsockopt IPV6_UNICAST_HOPS");
+		} else if (debug) {
+			printf("hop limit set to %d\n", config.ttl);
 		}
 	}
 
@@ -916,28 +927,6 @@ int main(int argc, char **argv) {
 #ifdef __OpenBSD__
 	pledge("stdio inet", NULL);
 #endif // __OpenBSD__
-
-	if (sockset.socket4 != -1) {
-		int result = setsockopt(sockset.socket4, IPPROTO_IP, IP_TTL, &config.ttl, sizeof(config.ttl));
-		if (debug) {
-			if (result == -1) {
-				printf("setsockopt failed\n");
-			} else {
-				printf("ttl set to %lu\n", config.ttl);
-			}
-		}
-	}
-
-	if (sockset.socket6 != -1) {
-		int result = setsockopt(sockset.socket6, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &config.ttl, sizeof(config.ttl));
-		if (debug) {
-			if (result == -1) {
-				printf("setsockopt failed\n");
-			} else {
-				printf("ttl set to %lu\n", config.ttl);
-			}
-		}
-	}
 
 	/* make sure we don't wait any longer than necessary */
 	struct timeval prog_start;

--- a/plugins-root/check_icmp.c
+++ b/plugins-root/check_icmp.c
@@ -90,10 +90,6 @@ const char *email = "devel@monitoring-plugins.org";
 #	define INADDR_NONE (in_addr_t)(-1)
 #endif
 
-#ifndef SOL_IP
-#	define SOL_IP 0
-#endif
-
 /* we bundle these in one #ifndef, since they're all from BSD
  * Put individual #ifndef's around those that bother you */
 #ifndef ICMP_UNREACH_NET_UNKNOWN
@@ -922,7 +918,7 @@ int main(int argc, char **argv) {
 #endif // __OpenBSD__
 
 	if (sockset.socket4 != -1) {
-		int result = setsockopt(sockset.socket4, SOL_IP, IP_TTL, &config.ttl, sizeof(config.ttl));
+		int result = setsockopt(sockset.socket4, IPPROTO_IP, IP_TTL, &config.ttl, sizeof(config.ttl));
 		if (debug) {
 			if (result == -1) {
 				printf("setsockopt failed\n");
@@ -933,7 +929,7 @@ int main(int argc, char **argv) {
 	}
 
 	if (sockset.socket6 != -1) {
-		int result = setsockopt(sockset.socket6, SOL_IP, IP_TTL, &config.ttl, sizeof(config.ttl));
+		int result = setsockopt(sockset.socket6, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &config.ttl, sizeof(config.ttl));
 		if (debug) {
 			if (result == -1) {
 				printf("setsockopt failed\n");

--- a/plugins-root/check_icmp.d/config.h
+++ b/plugins-root/check_icmp.d/config.h
@@ -59,7 +59,7 @@ typedef struct {
 	check_icmp_threshold crit;
 	check_icmp_threshold warn;
 
-	unsigned long ttl;
+	int ttl;
 	unsigned short icmp_data_size;
 	time_t target_interval;
 	unsigned short number_of_packets;


### PR DESCRIPTION
This PR addresses a few smaller issues in `check_icmp` all around the `setsockopt(2)` calls, which are resulting in program termination under the latest OpenBSD -current. Details are in the commit messages listed below.

I would kindly ask for a reviewer to try and verify these changes on another operating system, such as some Linux. Also consider inspecting the `setsockopt(2)` return values either via the `-v` flag or through `strace(1)`. Thanks :)

---

    check_icmp: Fix sockset.socket{4,6} detection
    
    The "check_icmp_socket_set sockset" is initialized with ".socket4" and
    ".socket6" both being set to -1. Later, these values are being
    overwritten with the result of socket(2) if "config.need_v{4,6}" is set.
    
    However, not every access guard checked the value correctly. Resulting
    in setsockopt(2) calls for -1, as ktrace(1)/kdump(1) demonstrates:
    
    > 18105 check_icmp CALL  setsockopt(-1,0<ip>,4,0x77553bf062f8,8)
    > 18105 check_icmp RET   setsockopt -1 errno 9 Bad file descriptor

---

    check_icmp: Fix setsockopt(2) calls for IPv6
    
    The same IP_TTL option was set for both IPv4 and IPv6 sockets in the
    setsockopt(2) call. While this is valid for IPv4, there is no TTL in
    IPv6, but a hop limit - which is also reflected in the options. So, this
    call has never worked.
    
    Because the error was hidden behind the debug log level, the failure was
    not detected so far. This has changed on OpenBSD -current, where a
    strict setsockopt(2) parameter check was added for programs under a
    pledge(2) promise[^0]. Now, check_icmp gets aborted.
    
    > $ /usr/local/libexec/nagios/check_icmp -6 -H localhost
    > check_icmp[10540]: pledge "inet", syscall 105
    > Abort trap
    
    Under ktrace(1)/kdump(1) inspection, the faulty setsockopt(2) system
    call is shown.
    
    > 47094 check_icmp CALL  setsockopt(3,0<ip>,4,0x7bacef492d88,8)
    > 47094 check_icmp PLDG  setsockopt, "inet", errno 1 Operation not permitted
    > 47094 check_icmp PSIG  SIGABRT SIG_DFL
    > 47094 check_icmp NAMI  "check_icmp.core"
    
    Furthermore, SOL_IP was exchanged by IPPROTO_IP and IPPROTO_IPV6. The
    SOL_* socket options are nonportable Linux-variables[^1].
    
    [^0]: https://cvsweb.openbsd.org/log/src/sys/kern/kern_pledge.c?sort=File#rev1.363
    [^1]: https://www.man7.org/linux/man-pages/man7/ipv6.7.html#NOTES

---

    check_icmp: Verify setsockopt(2) exit code and fix
    
    Start with actually verifying the setsockopt(2) exit code by crashing if
    the system call fails. When verbosity is enforced, log what was done.
    
    This unveiled an error with the IP_TTL/IPV6_UNICAST_HOPS call, which
    failed for both versions of the Internet Protocol. After some debugging,
    the type of the "ttl" parameter was too large - unsigned long instead of
    an int -, resulting in a system call failure. I haven't verified how
    this behaves on other platforms, but at least on OpenBSD this must have
    always failed.
    
    The SO_TIMESTAMP setsockopt(2) call for IPv6 was never performed, as the
    system call, wrapped in a "sockset.socket6" check, was performed before
    the socket was created. This was moved up.
    
    Through a bit of reordering, a few checks could have been skipped.